### PR TITLE
allow async/await - as devops/data-sci, i would like to jslint my google-puppeteer code

### DIFF
--- a/jslint.js
+++ b/jslint.js
@@ -1591,7 +1591,7 @@ function dispense() {
     const next_cadet_id = (tokens[token_nr + 1] || { id: "" }).id;
     if (
         (cadet.id === "async" && next_cadet_id === "function")
-        || (cadet.id === "await" && next_cadet_id.match(/[a-zA-Z_$]/))
+        || (cadet.id === "await" && next_cadet_id[0].match(/[a-zA-Z_$]/))
     ) {
         cadet.id = next_cadet_id;
         token_nr += 1;

--- a/jslint.js
+++ b/jslint.js
@@ -1587,6 +1587,15 @@ function dispense() {
 // Deliver the next token, skipping the comments.
 
     const cadet = tokens[token_nr];
+    // hack-jslint - advance token async/await to next_token based on context
+    const next_cadet_id = (tokens[token_nr + 1] || { id: "" }).id;
+    if (
+        (cadet.id === "async" && next_cadet_id === "function")
+        || (cadet.id === "await" && next_cadet_id.match(/[a-zA-Z_$]/))
+    ) {
+        cadet.id = next_cadet_id;
+        token_nr += 1;
+    }
     token_nr += 1;
     if (cadet.id === "(comment)") {
         if (json_mode) {


### PR DESCRIPTION
google-puppeteer's api-documentation[1] is writtenly entirely using async/await syntax.  trying to untangle/refactor them into preES8-syntax is a bit troublesome/bug-prone.

this pull-request would make it easier for users to use jslint with google-puppeteer.

working-demo of patched-jslint available @ https://kaizhu256.github.io/JSLint/branch.async_await/index.html

![image](https://user-images.githubusercontent.com/280571/63235379-bee45600-c1fe-11e9-8fdb-342e488a095c.png)


[1] google-puppeteer documentation
https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md