### PR TITLE
v2021.5.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - none
 
 ## v2021.5.27-beta
+- website - add hotkey ctrl-enter to run jslint.
+- jslint - add directive unordered to tolerate unordered properties and params.
+- jslint - add directive test_internal_error.
 - deadcode - replace with assertion-check in function are_similar() - "if (a === b) { return true }".
 - deadcode - replace with assertion-check in function are_similar() superseded by id-check - "if (Array.isArray(b)) { return false; }".
 - deadcode - replace with assertion-check in function are_similar() superseded by is_weird() check - "if (a.arity === "function" && a.arity ===...c".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,17 @@
 - node - after node-v14 is deprecated, remove shell-code export "NODE_OPTIONS=--unhandled-rejections=strict".
 - none
 
-## v2021.5.27-beta
-- website - add hotkey ctrl-enter to run jslint.
-- jslint - add directive unordered to tolerate unordered properties and params.
-- jslint - add directive test_internal_error.
+## v2021.5.27
+- ci - fix expectedWarningCode not being validated.
+- ci - in windows, disable git-autocrlf.
 - deadcode - replace with assertion-check in function are_similar() - "if (a === b) { return true }".
 - deadcode - replace with assertion-check in function are_similar() superseded by id-check - "if (Array.isArray(b)) { return false; }".
 - deadcode - replace with assertion-check in function are_similar() superseded by is_weird() check - "if (a.arity === "function" && a.arity ===...c".
-- ci - fix expectedWarningCode not being validated
-- ci - in windows, disable git-autocrlf
+- jslint - add directive `test_internal_error`.
+- jslint - add directive `unordered` to tolerate unordered properties and params.
 - jslint - inline-document each warning with cause that can reproduce it - part 1.
-- style - refactor code moving infix-operators from post-position to pre-position in multiline statements
+- style - refactor code moving infix-operators from post-position to pre-position in multiline statements.
+- website - add hotkey ctrl-enter to run jslint.
 - none
 
 ## v2021.5.26

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Douglas Crockford
 douglas@crockford.com
 
 ## Status
-| Branch | [master<br>(v2021.5.26)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(testing)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(development)](https://github.com/jslint-org/jslint/tree/alpha) |
+| Branch | [master<br>(v2021.5.27)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(testing)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(development)](https://github.com/jslint-org/jslint/tree/alpha) |
 |--:|:--:|:--:|:--:|
 | CI | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jslint-org/jslint/actions?query=branch%3Amaster) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/jslint-org/jslint/actions?query=branch%3Abeta) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/jslint-org/jslint/actions?query=branch%3Aalpha) |
 | Coverage | [![coverage](https://jslint-org.github.io/jslint/branch.master/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch.master/.build/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch.beta/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch.beta/.build/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch.alpha/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch.alpha/.build/coverage/index.html) |

--- a/browser.js
+++ b/browser.js
@@ -7,6 +7,7 @@
 */
 
 /*property
+    addEventListener, ctrlKey, key,
     checked, closure, column, context, create, disable, display, edition,
     exports, filter, focus, forEach, froms, fudge, functions, getElementById,
     global, id, innerHTML, isArray, join, json, keys, length, level, line,
@@ -352,6 +353,12 @@ elem_source.onscroll = function () {
         elem_number.scrollTop = ss;
     }
 };
+
+document.addEventListener("keydown", function (evt) {
+    if (evt.ctrlKey && evt.key === "Enter") {
+        call_jslint();
+    }
+});
 
 document.querySelectorAll("[name='JSLint']").forEach(function (node) {
     node.onclick = call_jslint;

--- a/help.html
+++ b/help.html
@@ -463,6 +463,11 @@ a:active {
             <td><code>true</code> if <code>this</code> should be allowed. </td>
         </tr>
         <tr>
+            <td id="unordered">Tolerate unordered properties and params.</td>
+            <td><code>unordered</code></td>
+            <td><code>true</code> if objects and functions are allowed to declare properties and params in non-alphabetical order.</td>
+        </tr>
+        <tr>
             <td id="white">Tolerate whitespace mess</td>
             <td><code>white</code></td>
             <td><code>true</code> if the whitespace rules should be ignored.</td>

--- a/index.html
+++ b/index.html
@@ -463,6 +463,7 @@ style="
       <div><label><input title=long type=checkbox>long lines</label></div>
       <div><label><input title=single type=checkbox>single quote strings</label></div>
       <div><label><input title=this type=checkbox>this</label></div>
+      <div><label><input title=unordered type=checkbox>unordered properties and params</label></div>
       <div><label><input title=white type=checkbox>whitespace mess</label></div>
     </div>
     <div>Global variables...

--- a/jslint.js
+++ b/jslint.js
@@ -129,7 +129,7 @@
     wrapped, writable, y
 */
 
-const edition = "v2021.5.27-beta";
+const edition = "v2021.5.27";
 
 function assert_or_throw(passed, message) {
 

--- a/test.js
+++ b/test.js
@@ -78,7 +78,7 @@ function noop() {
         white: true
     }).warnings.length === 0);
     assertOrThrow(jslint("", {
-        test_uncaught_error: true
+        test_internal_error: true
     }).warnings.length === 1);
 }());
 


### PR DESCRIPTION
- ci - fix expectedWarningCode not being validated.
- ci - in windows, disable git-autocrlf.
- deadcode - replace with assertion-check in function are_similar() - "if (a === b) { return true }".
- deadcode - replace with assertion-check in function are_similar() superseded by id-check - "if (Array.isArray(b)) { return false; }".
- deadcode - replace with assertion-check in function are_similar() superseded by is_weird() check - "if (a.arity === "function" && a.arity ===...c".
- jslint - add directive `test_internal_error`.
- jslint - add directive `unordered` to tolerate unordered properties and params.
- jslint - inline-document each warning with cause that can reproduce it - part 1.
- style - refactor code moving infix-operators from post-position to pre-position in multiline statements.
- website - add hotkey ctrl-enter to run jslint.
