### PR TITLE
- bugfix - fix #282 - fail to warn trailing semicolon in `export default Object.freeze({})`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - none
 
 ## v2021.5.28-beta
+- bugfix - fix #282 - fail to warn trailing semicolon in `export default Object.freeze({})`.
 - ci - auto-update changelog in README.md from CHANGELOG.md.
 - ci - auto-update version numbers in README.md and jslint.js from CHANGELOG.md.
 - website - replace links `branch.xxx` with `branch-xxx`.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ right so that you can focus your creative energy where it is most needed.
 - none
 
 ## v2021.5.28-beta
+- bugfix - fix #282 - fail to warn trailing semicolon in `export default Object.freeze({})`.
 - ci - auto-update changelog in README.md from CHANGELOG.md.
 - ci - auto-update version numbers in README.md and jslint.js from CHANGELOG.md.
 - website - replace links `branch.xxx` with `branch-xxx`.

--- a/jslint.js
+++ b/jslint.js
@@ -3824,8 +3824,10 @@ stmt("export", function () {
 // cause: "export default {}"
 
             warn("freeze_exports", the_thing);
-        }
-        if (next_token.id === ";") {
+        } else {
+
+// cause: "export default Object.freeze({})"
+
             semicolon();
         }
         exports.default = the_thing;

--- a/test.js
+++ b/test.js
@@ -328,6 +328,7 @@ function noop() {
             + "|no_space_only"
             + "|one_space_only"
             + "|one_space"
+            + "|semicolon"
             + "|stop"
             + "|stop_at"
             + "|warn"
@@ -350,6 +351,9 @@ function noop() {
             case "one_space":
             case "one_space_only":
                 expectedWarningCode = "expected_space_a_b";
+                break;
+            case "semicolon":
+                expectedWarningCode = "expected_a_b";
                 break;
             }
         }


### PR DESCRIPTION
fixes #282.