### PR TITLE
- jslint - add eslint-like ignore-directives `/*jslint-disable*/`, `/*jslint-enable*/`, `//jslint-quiet`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,19 @@
 - doc - add svg package-listing.
 - doc - document cli-feature to jslint entire directory.
 - jslint - add `for...of` syntax support.
-- jslint - add eslint-like disable-macros `/*jslint-disable*/`, `/*jslint-enable*/`, `//jslint-disable-line`.
 - jslint - add html and css linting back into jslint.
 - jslint - add new warning if case-statements are not sorted.
 - jslint - add new warning if const/let/var statements are not declared at top of function-scope.
 - jslint - add new warning if const/let/var statements are not sorted.
 - jslint - migrate code away from recursive-loops to for/while loops.
+- jslint - remove obsolete ie-warning about duplicate names for caught-errors.
 - node - after node-v12 is deprecated, change `require("fs").promises` to `require("fs/promises")`.
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
+
+## v2021.6.1-beta
+- breaking-change - hardcode `const fudge = 1`
+- breaking-change - remove little-used-feature allowing jslint to accept array-of-strings as source b/c internal lines-object has been changed from array-of-strings to array-of-objects.
+- jslint - add ignore-directives `/*jslint_disable_parse*/`, `/*jslint_enable_parse*/`, `//jslint_ignore_warning`.
 
 ## v2021.5.30
 - bugfix - fix issue #282 - fail to warn trailing semicolon in `export default Object.freeze({})`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 ## v2021.6.1-beta
 - breaking-change - hardcode `const fudge = 1`
 - breaking-change - remove little-used-feature allowing jslint to accept array-of-strings as source b/c internal lines-object has been changed from array-of-strings to array-of-objects.
-- jslint - add eslint-like ignore-directives `/*jslint-disable*/`, `/*jslint-enable*/`, `//jslint_ignore_warning`.
+- jslint - add eslint-like ignore-directives `/*jslint-disable*/`, `/*jslint-enable*/`, `//jslint-quiet`.
+- jslint - add new warning `Unclosed directive /*jslint-disable*/.`.
 
 ## v2021.5.30
 - bugfix - fix issue #282 - fail to warn trailing semicolon in `export default Object.freeze({})`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 ## v2021.6.1-beta
 - breaking-change - hardcode `const fudge = 1`
 - breaking-change - remove little-used-feature allowing jslint to accept array-of-strings as source b/c internal lines-object has been changed from array-of-strings to array-of-objects.
-- jslint - add ignore-directives `/*jslint_disable_parse*/`, `/*jslint_enable_parse*/`, `//jslint_ignore_warning`.
+- jslint - add eslint-like ignore-directives `/*jslint-disable*/`, `/*jslint-enable*/`, `//jslint_ignore_warning`.
 
 ## v2021.5.30
 - bugfix - fix issue #282 - fail to warn trailing semicolon in `export default Object.freeze({})`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - jslint - remove obsolete ie-warning about duplicate names for caught-errors.
 - node - after node-v12 is deprecated, change `require("fs").promises` to `require("fs/promises")`.
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
+- website - replace current-editor with CodeMirror-editor and change programming-font-faminly from `Programma` to `Consolas, Menlo, monospace`.
 
 ## v2021.6.1-beta
 - breaking-change - hardcode `const fudge = 1`

--- a/README.md
+++ b/README.md
@@ -93,13 +93,18 @@ right so that you can focus your creative energy where it is most needed.
 - doc - document cli-feature to jslint entire directory.
 - jslint - add `for...of` syntax support.
 - jslint - add html and css linting back into jslint.
-- jslint - add eslint-like disable-macros `/*jslint-disable*/`, `/*jslint-enable*/`, `//jslint-disable-line`.
 - jslint - add new warning if case-statements are not sorted.
 - jslint - add new warning if const/let/var statements are not declared at top of function-scope.
 - jslint - add new warning if const/let/var statements are not sorted.
 - jslint - migrate code away from recursive-loops to for/while loops.
+- jslint - remove obsolete ie-warning about duplicate names for caught-errors.
 - node - after node-v12 is deprecated, change `require("fs").promises` to `require("fs/promises")`.
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
+
+## v2021.6.1-beta
+- breaking-change - hardcode `const fudge = 1`
+- breaking-change - remove little-used-feature allowing jslint to accept array-of-strings as source b/c internal lines-object has been changed from array-of-strings to array-of-objects.
+- jslint - add ignore-directives `/*jslint_disable_parse*/`, `/*jslint_enable_parse*/`, `//jslint_ignore_warning`.
 
 ## v2021.5.30
 - bugfix - fix issue #282 - fail to warn trailing semicolon in `export default Object.freeze({})`.
@@ -119,17 +124,5 @@ right so that you can focus your creative energy where it is most needed.
 - tests - inline remaining causal-regressions from test.js into jslint.js
 - tests - validate inline-multi-causes are sorted.
 - website - replace links `branch.xxx` with `branch-xxx`.
-
-## v2021.5.27
-- ci - fix expectedWarningCode not being validated.
-- ci - in windows, disable git-autocrlf.
-- deadcode - replace with assertion-check in function are_similar() - "if (a === b) { return true }".
-- deadcode - replace with assertion-check in function are_similar() superseded by id-check - "if (Array.isArray(b)) { return false; }".
-- deadcode - replace with assertion-check in function are_similar() superseded by is_weird() check - "if (a.arity === "function" && a.arity ===...c".
-- jslint - add directive `test_internal_error`.
-- jslint - add directive `unordered` to tolerate unordered properties and params.
-- jslint - inline-document each warning with cause that can reproduce it - part 1.
-- style - refactor code moving infix-operators from post-position to pre-position in multiline statements.
-- website - add hotkey ctrl-enter to run jslint.
 
 # End

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ right so that you can focus your creative energy where it is most needed.
 - jslint - remove obsolete ie-warning about duplicate names for caught-errors.
 - node - after node-v12 is deprecated, change `require("fs").promises` to `require("fs/promises")`.
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
+- website - replace current-editor with CodeMirror-editor and change programming-font-faminly from `Programma` to `Consolas, Menlo, monospace`.
 
 ## v2021.6.1-beta
 - breaking-change - hardcode `const fudge = 1`

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ right so that you can focus your creative energy where it is most needed.
 ## v2021.6.1-beta
 - breaking-change - hardcode `const fudge = 1`
 - breaking-change - remove little-used-feature allowing jslint to accept array-of-strings as source b/c internal lines-object has been changed from array-of-strings to array-of-objects.
-- jslint - add eslint-like ignore-directives `/*jslint-disable*/`, `/*jslint-enable*/`, `//jslint_ignore_warning`.
+- jslint - add eslint-like ignore-directives `/*jslint-disable*/`, `/*jslint-enable*/`, `//jslint-quiet`.
+- jslint - add new warning `Unclosed directive /*jslint-disable*/.`.
 
 ## v2021.5.30
 - bugfix - fix issue #282 - fail to warn trailing semicolon in `export default Object.freeze({})`.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ right so that you can focus your creative energy where it is most needed.
 ## v2021.6.1-beta
 - breaking-change - hardcode `const fudge = 1`
 - breaking-change - remove little-used-feature allowing jslint to accept array-of-strings as source b/c internal lines-object has been changed from array-of-strings to array-of-objects.
-- jslint - add ignore-directives `/*jslint_disable_parse*/`, `/*jslint_enable_parse*/`, `//jslint_ignore_warning`.
+- jslint - add eslint-like ignore-directives `/*jslint-disable*/`, `/*jslint-enable*/`, `//jslint_ignore_warning`.
 
 ## v2021.5.30
 - bugfix - fix issue #282 - fail to warn trailing semicolon in `export default Object.freeze({})`.

--- a/browser.js
+++ b/browser.js
@@ -7,9 +7,9 @@
 */
 
 /*property
-    addEventListener, ctrlKey, key,
+    addEventListener, ctrlKey, key, source_line, stack_trace,
     checked, closure, column, context, create, disable, display, edition,
-    exports, filter, focus, forEach, froms, fudge, functions, getElementById,
+    exports, filter, focus, forEach, froms, functions, getElementById,
     global, id, innerHTML, isArray, join, json, keys, length, level, line,
     lines, map, message, module, name, names, onchange, onclick, onscroll,
     option, parameters, parent, property, push, querySelectorAll, replace, role,
@@ -22,14 +22,8 @@ import jslint from "./jslint.js";
 // This is the web script companion file for JSLint. It includes code for
 // interacting with the browser and displaying the reports.
 
-let rx_crlf = /\n|\r\n?/;
-let rx_separator = /[\s,;'"]+/;
-
-let fudge_unit = 0;
-
 const elem_aux = document.getElementById("JSLINT_AUX");
 const elem_boxes = document.querySelectorAll("[type=checkbox]");
-const elem_fudge = document.getElementById("JSLINT_FUDGE");
 const elem_global = document.getElementById("JSLINT_GLOBAL");
 const elem_number = document.getElementById("JSLINT_NUMBER");
 const elem_property = document.getElementById("JSLINT_PROPERTY");
@@ -71,21 +65,26 @@ function error_report(data) {
 // <cite><address>LINE_NUMBER</address>MESSAGE</cite>
 // <samp>EVIDENCE</samp>
 
-    let fudge = Number(Boolean(data.option.fudge));
     let output = [];
     if (data.stop) {
         output.push("<center>JSLint was unable to finish.</center>");
     }
-    data.warnings.forEach(function (warning) {
+    data.warnings.forEach(function ({
+        column,
+        line,
+        message,
+        source_line,
+        stack_trace = ""
+    }) {
         output.push(
             "<cite><address>",
-            entityify(warning.line + fudge),
+            entityify(line),
             ".",
-            entityify(warning.column + fudge),
+            entityify(column),
             "</address>",
-            entityify(warning.message),
+            entityify(message),
             "</cite><samp>",
-            entityify(data.lines[warning.line] || ""),
+            entityify(source_line + "\n" + stack_trace),
             "</samp>"
         );
     });
@@ -100,7 +99,6 @@ function function_report(data) {
 //     <dt>DETAIL</dt><dd>NAMES</dd>
 // </dl>
 
-    let fudge = Number(Boolean(data.option.fudge));
     let mode = (
         data.module
         ? "module"
@@ -150,7 +148,7 @@ function function_report(data) {
                 "<dl class=level",
                 entityify(the_function.level),
                 "><address>",
-                entityify(the_function.line + fudge),
+                entityify(the_function.line),
                 "</address><dfn>",
                 (
                     the_function.name === "=>"
@@ -250,11 +248,13 @@ function property_directive(data) {
 }
 
 function show_numbers() {
-    elem_number.value = elem_source.value.split(rx_crlf).map(function (
+    elem_number.value = elem_source.value.split(
+        /\n|\r\n?/
+    ).map(function (
         ignore,
         index
     ) {
-        return index + fudge_unit;
+        return index + 1;
     }).join("\n");
 }
 
@@ -271,16 +271,10 @@ function clear() {
     elem_warnings_list.innerHTML = "";
 }
 
-function fudge_change() {
-    fudge_unit = Number(elem_fudge.checked);
-    show_numbers();
-}
-
 function clear_options() {
     elem_boxes.forEach(function (node) {
         node.checked = false;
     });
-    fudge_change();
     elem_global.innerHTML = "";
 }
 
@@ -304,7 +298,9 @@ function call_jslint() {
         (
             global_string === ""
             ? undefined
-            : global_string.split(rx_separator)
+            : global_string.split(
+                /[\s,;'"]+/
+            )
         )
     );
 
@@ -337,8 +333,6 @@ function call_jslint() {
     elem_aux.style.display = "block";
     elem_source.select();
 }
-
-elem_fudge.onchange = fudge_change;
 
 elem_source.onchange = function (ignore) {
     show_numbers();
@@ -374,7 +368,6 @@ document.getElementById("JSLINT_SELECT").onclick = function () {
 };
 document.getElementById("JSLINT_CLEAR_OPTIONS").onclick = clear_options;
 
-fudge_change();
 elem_source.select();
 elem_source.focus();
 elem_source.value = String(`

--- a/browser.js
+++ b/browser.js
@@ -370,11 +370,18 @@ document.getElementById("JSLINT_CLEAR_OPTIONS").onclick = clear_options;
 
 elem_source.select();
 elem_source.focus();
-elem_source.value = String(`
-#!/usr/bin/env node
-/*jslint devel*/
-import jslint from "./jslint.js";
+elem_source.value = `#!/usr/bin/env node
+/*jslint node*/
+import jslint from "./jslint.mjs";
 import https from "https";
+
+/*jslint_disable_parse*/
+// Todo: jslint this code-block in the future.
+console.log('hello world');
+/*jslint_enable_parse*/
+
+eval("console.log('hello world');"); //jslint_ignore_warning
+
 (async function () {
     let result;
     result = await new Promise(function (resolve) {
@@ -391,9 +398,10 @@ import https from "https";
     result.warnings.forEach(function ({
         formatted_message
     }) {
-        console.error(formatted_message);
+
+        console.error(formatted_message); //jslint_ignore_warning
+
     });
-}());
-`).trim();
+}());`;
 elem_source.onchange();
 call_jslint();

--- a/browser.js
+++ b/browser.js
@@ -376,11 +376,11 @@ import jslint from "./jslint.mjs";
 import https from "https";
 
 /*jslint-disable*/
-// Todo: jslint this code-block in the future.
+// TODO: jslint this code-block in the future.
 console.log('hello world');
 /*jslint-enable*/
 
-eval("console.log('hello world');"); //jslint_ignore_warning
+eval("console.log('hello world');"); //jslint-quiet
 
 (async function () {
     let result;
@@ -398,9 +398,7 @@ eval("console.log('hello world');"); //jslint_ignore_warning
     result.warnings.forEach(function ({
         formatted_message
     }) {
-
-        console.error(formatted_message); //jslint_ignore_warning
-
+        console.error(formatted_message);
     });
 }());`;
 elem_source.onchange();

--- a/browser.js
+++ b/browser.js
@@ -375,10 +375,10 @@ elem_source.value = `#!/usr/bin/env node
 import jslint from "./jslint.mjs";
 import https from "https";
 
-/*jslint_disable_parse*/
+/*jslint-disable*/
 // Todo: jslint this code-block in the future.
 console.log('hello world');
-/*jslint_enable_parse*/
+/*jslint-enable*/
 
 eval("console.log('hello world');"); //jslint_ignore_warning
 

--- a/ci.sh
+++ b/ci.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 
 # sh one-liner
-# head CHANGELOG.md -n20
+#
+# git branch -d -r origin/aa
 # git fetch origin alpha beta master && git fetch upstream alpha beta master
+# head CHANGELOG.md -n50
 # sh ci.sh shCiBranchPromote origin alpha beta
 
 shBrowserScreenshot() {(set -e

--- a/help.html
+++ b/help.html
@@ -418,17 +418,7 @@ a:active {
                 instead.</td>
         </tr>
         <tr>
-            <td id="fudge">Fudge the line and column numbers</td>
-            <td><code>fudge</code></td>
-            <td><code>true</code> if the origin of a text file is line 1 column
-                1. Programmers know that number systems start at zero.
-                Unfortunately, most text editors start numbering lines and
-                columns at one. JSLint will by default start
-                numbering at zero. Use this option to start the numbering at one
-                in its reports.</td>
-        </tr>
-        <tr>
-            <td id="fudge">Tolerate <code>get</code> and <code>set</code></td>
+            <td id="getsest">Tolerate <code>get</code> and <code>set</code></td>
             <td><code>getset</code></td>
             <td><code>true</code> if accessor properties are allowed in object literals.</td>
         </tr>

--- a/index.html
+++ b/index.html
@@ -451,8 +451,6 @@ style="
       <div><label><input title=browser type=checkbox>a browser</label></div>
       <div><label><input title=couch type=checkbox>CouchDB</label></div>
       <div><label><input title=node type=checkbox>Node.js</label></div>
-    <br>Fudge...
-      <div><label><input id="JSLINT_FUDGE" title=fudge type=checkbox>First line number is 1</label></div>
     </div>
     <div>Tolerate...
       <div><label><input title=bitwise type=checkbox>bitwise operators</label></div>

--- a/jslint.js
+++ b/jslint.js
@@ -698,18 +698,18 @@ function tokenize(source) {
         whole_line = source_line;
 
 // Scan each line for following ignore-directives:
-// "/*jslint_disable_parse*/"
-// "/*jslint_enable_parse*/"
+// "/*jslint-disable*/"
+// "/*jslint-enable*/"
 // "//jslint_ignore_warning
 
-        if (source_line === "/*jslint_disable_parse*/") {
+        if (source_line === "/*jslint-disable*/") {
 
-// cause: "/*jslint_disable_parse*/"
+// cause: "/*jslint-disable*/"
 
             disable_parse = true;
-        } else if (source_line === "/*jslint_enable_parse*/") {
+        } else if (source_line === "/*jslint-enable*/") {
 
-// cause: "/*jslint_enable_parse*/"
+// cause: "/*jslint-enable*/"
 
             disable_parse = false;
         } else if (source_line.endsWith(" //jslint_ignore_warning")) {
@@ -720,7 +720,7 @@ function tokenize(source) {
         }
         if (disable_parse) {
 
-// cause: "/*jslint_disable_parse*/\n0"
+// cause: "/*jslint-disable*/\n0"
 
             source_line = "";
         }

--- a/jslint.js
+++ b/jslint.js
@@ -538,7 +538,7 @@ function warn_at(code, line, column, a, b, c, d) {
         b,
         c,
         code,
-        column,
+        column: column || fudge,
         d,
         line,
         name: "JSLintError",
@@ -595,6 +595,9 @@ function warn(code, the_token, a, b, c, d) {
         the_token.warning = warn_at(
             code,
             the_token.line,
+
+// Fudge column numbers in warning message.
+
             the_token.from + fudge,
             a || artifact(the_token),
             b,
@@ -673,6 +676,7 @@ function tokenize(source) {
         if (
             !option.long
             && whole_line.length > 80
+            && !disable_parse
             && !json_mode
             && first
             && !regexp_seen
@@ -5584,10 +5588,10 @@ function whitage() {
             "expected_a_at_b_c",
             right,
             artifact(right),
+
+// Fudge column numbers in warning message.
+
             at + fudge,
-
-// Return the fudged column number of an artifact.
-
             right.from + fudge
         );
     }

--- a/test.js
+++ b/test.js
@@ -60,7 +60,7 @@ function noop() {
 /*
  * this function will test jslint's option handling-behavior
  */
-    assertOrThrow(jslint([""], {
+    assertOrThrow(jslint("", {
         bitwise: true,
         browser: true,
         convert: true,
@@ -69,7 +69,6 @@ function noop() {
         devel: true,
         eval: true,
         for: true,
-        fudge: true,
         getset: true,
         long: true,
         node: true,
@@ -114,6 +113,12 @@ function noop() {
         ],
         fart: [
             "function aa() {\n    return () => 0;\n}"
+        ],
+        jslint_disable_parse: [
+            "/*jslint_disable_parse*/\n0\n/*jslint_enable_parse*/"
+        ],
+        jslint_ignore_warning: [
+            "0 //jslint_ignore_warning"
         ],
         json: [
             "{\"aa\":[[],-0,null]}"

--- a/test.js
+++ b/test.js
@@ -117,8 +117,8 @@ function noop() {
         jslint_disable: [
             "/*jslint-disable*/\n0\n/*jslint-enable*/"
         ],
-        jslint_ignore_warning: [
-            "0 //jslint_ignore_warning"
+        jslint_quiet: [
+            "0 //jslint-quiet"
         ],
         json: [
             "{\"aa\":[[],-0,null]}"
@@ -192,7 +192,7 @@ function noop() {
         let expectedWarningCode;
         let fnc;
         // debug match0
-        console.error(match0.trim().replace((/\n\n/g), "\n"));
+        // console.error(match0.trim().replace((/\n\n/g), "\n"));
         assertOrThrow(
             match0.indexOf("\n\n" + causeList + "\n    ") === 0,
             JSON.stringify([

--- a/test.js
+++ b/test.js
@@ -114,8 +114,8 @@ function noop() {
         fart: [
             "function aa() {\n    return () => 0;\n}"
         ],
-        jslint_disable_parse: [
-            "/*jslint_disable_parse*/\n0\n/*jslint_enable_parse*/"
+        jslint_disable: [
+            "/*jslint-disable*/\n0\n/*jslint-enable*/"
         ],
         jslint_ignore_warning: [
             "0 //jslint_ignore_warning"


### PR DESCRIPTION
fixes #304, #281

- breaking-change - hardcode `const fudge = 1`
- breaking-change - remove little-used-feature allowing jslint to accept array-of-strings as source b/c internal lines-object has been changed from array-of-strings to array-of-objects.
- jslint - add eslint-like ignore-directives `/*jslint-disable*/`, `/*jslint-enable*/`, `//jslint-quiet`.
- jslint - add new warning `Unclosed directive /*jslint-disable*/.`.


2nd attempt to add ignore-directives because:
- make it easier for newcomers to onboard jslint by allowing them to selectively disable warnings for project-files they don't have time yet to fix.
- allow jslinting of rollup files that contain machine-generated-code.
- eventually get rid of "hammer" directives `/*jslint devel*/` and `/*jslint eval*/`, replacing them with line-specific directive `eval(...) //jslint_ignore_warning`.


demo of this pr available @ https://www.jslint.com/branch-alpha/

![image](https://user-images.githubusercontent.com/280571/120257110-36a93680-c255-11eb-8bc9-5e12de9e57ef.png)