### PR TITLE
remove obsolete ie-era warning about duplicate names for caught-exceptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 - jslint - add new warning if const/let/var statements are not declared at top of function-scope.
 - jslint - add new warning if const/let/var statements are not sorted.
 - jslint - migrate code away from recursive-loops to for/while loops.
-- jslint - remove obsolete ie-warning about duplicate names for caught-errors.
 - node - after node-v12 is deprecated, change `require("fs").promises` to `require("fs/promises")`.
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - website - replace current-editor with CodeMirror-editor and change programming-font-faminly from `Programma` to `Consolas, Menlo, monospace`.
@@ -21,6 +20,7 @@
 - breaking-change - remove little-used-feature allowing jslint to accept array-of-strings as source b/c internal lines-object has been changed from array-of-strings to array-of-objects.
 - jslint - add eslint-like ignore-directives `/*jslint-disable*/`, `/*jslint-enable*/`, `//jslint-quiet`.
 - jslint - add new warning `Unclosed directive /*jslint-disable*/.`.
+- jslint - remove obsolete ie-era warning about duplicate names for caught-errors.
 
 ## v2021.5.30
 - bugfix - fix issue #282 - fail to warn trailing semicolon in `export default Object.freeze({})`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 - breaking-change - hardcode `const fudge = 1`
 - breaking-change - remove little-used-feature allowing jslint to accept array-of-strings as source b/c internal lines-object has been changed from array-of-strings to array-of-objects.
 - jslint - add eslint-like ignore-directives `/*jslint-disable*/`, `/*jslint-enable*/`, `//jslint-quiet`.
-- jslint - add new warning `Unclosed directive /*jslint-disable*/.`.
+- jslint - add new warning `Directive /*jslint-disable*/ was not closed with /*jslint-enable*/.`.
+- jslint - add new warning `Directive /*jslint-enable*/ was not opened with /*jslint-disable*/.`.
 - jslint - remove obsolete ie-era warning about duplicate names for caught-errors.
 
 ## v2021.5.30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - jslint - migrate code away from recursive-loops to for/while loops.
 - node - after node-v12 is deprecated, change `require("fs").promises` to `require("fs/promises")`.
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
-- website - replace current-editor with CodeMirror-editor and change programming-font-faminly from `Programma` to `Consolas, Menlo, monospace`.
+- website - replace current-editor with CodeMirror-editor and change programming-font-family from `Programma` to `Consolas, Menlo, monospace`.
 
 ## v2021.6.1-beta
 - breaking-change - hardcode `const fudge = 1`

--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ right so that you can focus your creative energy where it is most needed.
 - jslint - add new warning if const/let/var statements are not declared at top of function-scope.
 - jslint - add new warning if const/let/var statements are not sorted.
 - jslint - migrate code away from recursive-loops to for/while loops.
-- jslint - remove obsolete ie-warning about duplicate names for caught-errors.
 - node - after node-v12 is deprecated, change `require("fs").promises` to `require("fs/promises")`.
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - website - replace current-editor with CodeMirror-editor and change programming-font-faminly from `Programma` to `Consolas, Menlo, monospace`.
@@ -107,6 +106,7 @@ right so that you can focus your creative energy where it is most needed.
 - breaking-change - remove little-used-feature allowing jslint to accept array-of-strings as source b/c internal lines-object has been changed from array-of-strings to array-of-objects.
 - jslint - add eslint-like ignore-directives `/*jslint-disable*/`, `/*jslint-enable*/`, `//jslint-quiet`.
 - jslint - add new warning `Unclosed directive /*jslint-disable*/.`.
+- jslint - remove obsolete ie-era warning about duplicate names for caught-errors.
 
 ## v2021.5.30
 - bugfix - fix issue #282 - fail to warn trailing semicolon in `export default Object.freeze({})`.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ right so that you can focus your creative energy where it is most needed.
 - jslint - migrate code away from recursive-loops to for/while loops.
 - node - after node-v12 is deprecated, change `require("fs").promises` to `require("fs/promises")`.
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
-- website - replace current-editor with CodeMirror-editor and change programming-font-faminly from `Programma` to `Consolas, Menlo, monospace`.
+- website - replace current-editor with CodeMirror-editor and change programming-font-family from `Programma` to `Consolas, Menlo, monospace`.
 
 ## v2021.6.1-beta
 - breaking-change - hardcode `const fudge = 1`

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ right so that you can focus your creative energy where it is most needed.
 - breaking-change - hardcode `const fudge = 1`
 - breaking-change - remove little-used-feature allowing jslint to accept array-of-strings as source b/c internal lines-object has been changed from array-of-strings to array-of-objects.
 - jslint - add eslint-like ignore-directives `/*jslint-disable*/`, `/*jslint-enable*/`, `//jslint-quiet`.
-- jslint - add new warning `Unclosed directive /*jslint-disable*/.`.
+- jslint - add new warning `Directive /*jslint-disable*/ was not closed with /*jslint-enable*/.`.
+- jslint - add new warning `Directive /*jslint-enable*/ was not opened with /*jslint-disable*/.`.
 - jslint - remove obsolete ie-era warning about duplicate names for caught-errors.
 
 ## v2021.5.30

--- a/browser.js
+++ b/browser.js
@@ -380,7 +380,9 @@ import https from "https";
 console.log('hello world');
 /*jslint-enable*/
 
-eval("console.log('hello world');"); //jslint-quiet
+eval( //jslint-quiet
+    "console.log('hello world');"
+);
 
 (async function () {
     let result;

--- a/ci.sh
+++ b/ci.sh
@@ -4,6 +4,7 @@
 #
 # git branch -d -r origin/aa
 # git fetch origin alpha beta master && git fetch upstream alpha beta master
+# git fetch upstream "refs/tags/*:refs/tags/*"
 # head CHANGELOG.md -n50
 # sh ci.sh shCiBranchPromote origin alpha beta
 
@@ -530,8 +531,7 @@ if (!globalThis.debugInline) {
         function stringHtmlSafe(str) {
         /*
          * this function will make <str> html-safe
-         * https://stackoverflow.com/questions/7381974/
-         * which-characters-need-to-be-escaped-on-html
+         * https://stackoverflow.com/questions/7381974/which-characters-need-to-be-escaped-on-html //jslint-quiet
          */
             return str.replace((
                 /&/gu

--- a/jslint.js
+++ b/jslint.js
@@ -6169,7 +6169,13 @@ function jslint(
                 }
             }
         });
+
+// 1. Tokenize source into ast.
+
         tokenize(source);
+
+// 2. Walk ast.
+
         advance();
         if (json_mode) {
             tree = json_value();
@@ -6198,6 +6204,9 @@ function jslint(
             advance("(end)");
             functionage = global;
             walk_statement(tree);
+
+// 3. Re-walk ast validating whitespace.
+
             if (warnings.length === 0) {
                 uninitialized_and_unused();
                 if (!option.white) {

--- a/jslint.js
+++ b/jslint.js
@@ -88,7 +88,8 @@
 /*jslint node*/
 
 /*property
-    directive_quiet, endsWith, source_line, unclosed_disable, unordered,
+    directive_quiet, endsWith, source_line, unclosed_disable, unopened_enable,
+    unordered,
     JSLINT_CLI, a, all, and, argv, arity, assign, b, bad_assignment_a,
     bad_directive_a, bad_get, bad_module_name_a, bad_option_a, bad_property_a,
     bad_set, bitwise, block, body, browser, c, calls, catch, cli_mode, closer,
@@ -328,7 +329,10 @@ const bundle = {
     too_long: "Line is longer than 80 characters.",
     too_many_digits: "Too many digits.",
     unclosed_comment: "Unclosed comment.",
-    unclosed_disable: "Unclosed directive /*jslint-disable*/.",
+    unclosed_disable: (
+        "Directive '/*jslint-disable*/' was not closed "
+        + "with '/*jslint-enable*/'."
+    ),
     unclosed_mega: "Unclosed mega literal.",
     unclosed_string: "Unclosed string.",
     undeclared_a: "Undeclared '{a}'.",
@@ -353,6 +357,10 @@ const bundle = {
         "Unexpected 'typeof'. Use '===' to compare directly with {a}."
     ),
     uninitialized_a: "Uninitialized '{a}'.",
+    unopened_enable: (
+        "Directive '/*jslint-enable*/' was not opened "
+        + "with '/*jslint-disable*/'."
+    ),
     unordered_a_b: "{a} '{b}' not listed in alphabetical order.",
     unreachable_a: "Unreachable '{a}'.",
     unregistered_property_a: "Unregistered property name '{a}'.",
@@ -710,9 +718,12 @@ function tokenize(source) {
 
             disable_line = line;
         } else if (source_line === "/*jslint-enable*/") {
+            if (disable_line === undefined) {
 
 // cause: "/*jslint-enable*/"
 
+                stop_at("unopened_enable", line);
+            }
             disable_line = undefined;
         } else if (source_line.endsWith(" //jslint-quiet")) {
 

--- a/test.js
+++ b/test.js
@@ -156,6 +156,20 @@ function noop() {
             "let aa = (\n    aa()\n    ? 0\n    : 1\n) "
             + "&& (\n    aa()\n    ? 0\n    : 1\n);"
         ],
+        try_catch: [
+            "let aa = 0;\n"
+            + "try {\n"
+            + "    aa();\n"
+            + "} catch (err) {\n"
+            + "    aa = err;\n"
+            + "}\n"
+            + "try {\n"
+            + "    aa();\n"
+            + "} catch (err) {\n"
+            + "    aa = err;\n"
+            + "}\n"
+            + "aa();\n"
+        ],
         var: [
             "let [...aa] = [...aa];",
             "let [\n    aa, bb = 0\n] = 0;",


### PR DESCRIPTION
this pr feels cheesy/hacky but seems to get the job done and passes tests (it creates a new function-scope for each catch-block).  if someone has time to review it and come up with more elegant solution would be nice ; )

motivation:
due to buggy internet-explorer lacking scope for catch-blocks, jslint warned against the following code:

```javascript
/*jslint devel*/
let aa = 0;

try {
    aa();
} catch (err) {
    console.error(err);
}

try {
    aa();
// warning
// Redefinition of 'err' from line 6.
} catch (err) {
    console.error(err);
}
```

modern engines don't have this bug plus its PITA maintaining unique exception-name for each catch-block, when typing out a buncha successive try...catch sequences.  as bonus, jslint will now properly warn exception-names are out-of-scope when used outside of catch-blocks.

web-demo of this pr available @ https://kaizhu256.github.io/jslint/branch-alpha/index.html

![image](https://user-images.githubusercontent.com/280571/120278379-d200d280-c27a-11eb-95dd-df8c5c585503.png)
