### PR TITLE
- jslint rewrite part1 - make "stateful" variables scoped outside of jslint() "stateless" by moving them into jslint().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,22 @@
 - jslint - add `for...of` syntax support.
 - jslint - add html and css linting back into jslint.
 - jslint - add new warning if case-statements are not sorted.
-- jslint - add new warning if const/let/var statements are not declared at top of function-scope.
+- jslint - add new warning if const/let/var statements are not declared
+  at top of function-scope.
 - jslint - add new warning if const/let/var statements are not sorted.
-- jslint - migrate code away from recursive-loops to for/while loops.
-- node - after node-v12 is deprecated, change `require("fs").promises` to `require("fs/promises")`.
-- node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
-- tests - update function warn_at() with assertion-check matching column with artifact.
-- website - replace current-editor with CodeMirror-editor and change programming-font-family from `Programma` to `Consolas, Menlo, monospace`.
+- jslint rewrite part2 - migrate recursive-loops to for/while loops.
+- node - after node-v12 is deprecated, change `require("fs").promises`
+  to `require("fs/promises")`.
+- node - after node-v14 is deprecated, remove shell-code
+  `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
+- tests - update function warn_at() with assertion-check matching
+  column with artifact.
+- website - replace current-editor with CodeMirror-editor and change
+  programming-font-family from `Programma` to `Consolas, Menlo, monospace`.
+
+## v2021.6.4-beta
+- jslint rewrite part1 - make "stateful" variables scoped outside of
+  jslint() "stateless" by moving them into jslint().
 
 ## v2021.6.3
 - breaking-change - hardcode `const fudge = 1`
@@ -106,6 +115,9 @@
 
 ## v2017.11.6
 - last jslint version written in es5.
+
+## v2014.7.8
+- last jslint version before 2 year hiatus.
 
 ## v2013.3.13
 - last jslint version that can lint .html and .css files.

--- a/jslint.js
+++ b/jslint.js
@@ -22,11 +22,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// jslint(source, option_object, global_array) is a function that takes 3
+// jslint(source, option, global_array) is a function that takes 3
 // arguments. The second two arguments are optional.
 
 //      source          A text to analyze, a string or an array of strings.
-//      option_object   An object whose keys correspond to option names.
+//      option          An object whose keys correspond to option names.
 //      global_array    An array of strings containing global variables that
 //                      the file is allowed readonly access.
 
@@ -131,7 +131,7 @@
     wrapped, writable, y
 */
 
-const edition = "v2021.6.3";
+const edition = "v2021.6.4-beta";
 
 function assert_or_throw(passed, message) {
 
@@ -166,105 +166,115 @@ function populate(array, object = empty(), value = true) {
     return object;
 }
 
-const allowed_option = {
+function jslint(
+    source = "",
+    option = empty(),
+    global_array = []
+) {
+
+    const allowed_option = {
 
 // These are the options that are recognized in the option object or that may
 // appear in a /*jslint*/ directive. Most options will have a boolean value,
 // usually true. Some options will also predefine some number of global
 // variables.
 
-    bitwise: true,
-    browser: [
-        "caches", "CharacterData", "clearInterval", "clearTimeout", "document",
-        "DocumentType", "DOMException", "Element", "Event", "event", "fetch",
-        "FileReader", "FontFace", "FormData", "history", "IntersectionObserver",
-        "localStorage", "location", "MutationObserver", "name", "navigator",
-        "screen", "sessionStorage", "setInterval", "setTimeout", "Storage",
-        "TextDecoder", "TextEncoder", "URL", "window", "Worker",
-        "XMLHttpRequest"
-    ],
-    convert: true,
-    couch: [
-        "emit", "getRow", "isArray", "log", "provides", "registerType",
-        "require", "send", "start", "sum", "toJSON"
-    ],
-    debug: true,
-    devel: [
-        "alert", "confirm", "console", "prompt"
-    ],
-    eval: true,
-    for: true,
-    getset: true,
-    long: true,
-    node: [
-        "Buffer", "clearImmediate", "clearInterval", "clearTimeout",
-        "console", "exports", "module", "process", "require",
-        "setImmediate", "setInterval", "setTimeout", "TextDecoder",
-        "TextEncoder", "URL", "URLSearchParams", "__dirname", "__filename"
-    ],
-    single: true,
-    test_internal_error: true,
-    this: true,
-    unordered: true,
-    white: true
-};
+        bitwise: true,
+        browser: [
+            "caches", "CharacterData", "clearInterval", "clearTimeout",
+            "document",
+            "DocumentType", "DOMException", "Element", "Event", "event",
+            "fetch",
+            "FileReader", "FontFace", "FormData", "history",
+            "IntersectionObserver",
+            "localStorage", "location", "MutationObserver", "name", "navigator",
+            "screen", "sessionStorage", "setInterval", "setTimeout", "Storage",
+            "TextDecoder", "TextEncoder", "URL", "window", "Worker",
+            "XMLHttpRequest"
+        ],
+        convert: true,
+        couch: [
+            "emit", "getRow", "isArray", "log", "provides", "registerType",
+            "require", "send", "start", "sum", "toJSON"
+        ],
+        debug: true,
+        devel: [
+            "alert", "confirm", "console", "prompt"
+        ],
+        eval: true,
+        for: true,
+        getset: true,
+        long: true,
+        node: [
+            "Buffer", "clearImmediate", "clearInterval", "clearTimeout",
+            "console", "exports", "module", "process", "require",
+            "setImmediate", "setInterval", "setTimeout", "TextDecoder",
+            "TextEncoder", "URL", "URLSearchParams", "__dirname", "__filename"
+        ],
+        single: true,
+        test_internal_error: true,
+        this: true,
+        unordered: true,
+        white: true
+    };
 
-const anticondition = populate([
-    "?", "~", "&", "|", "^", "<<", ">>", ">>>", "+", "-", "*", "/", "%",
-    "typeof", "(number)", "(string)"
-]);
+    const anticondition = populate([
+        "?", "~", "&", "|", "^", "<<", ">>", ">>>", "+", "-", "*", "/", "%",
+        "typeof", "(number)", "(string)"
+    ]);
 
 // These are the bitwise operators.
 
-const bitwiseop = populate([
-    "~", "^", "^=", "&", "&=", "|", "|=", "<<", "<<=", ">>", ">>=",
-    ">>>", ">>>="
-]);
+    const bitwiseop = populate([
+        "~", "^", "^=", "&", "&=", "|", "|=", "<<", "<<=", ">>", ">>=",
+        ">>>", ">>>="
+    ]);
 
-const escapeable = populate([
-    "\\", "/", "`", "b", "f", "n", "r", "t"
-]);
+    const escapeable = populate([
+        "\\", "/", "`", "b", "f", "n", "r", "t"
+    ]);
 
-const opener = {
+    const opener = {
 
 // The open and close pairs.
 
-    "${": "}",      // mega
-    "(": ")",       // paren
-    "[": "]",       // bracket
-    "{": "}"        // brace
-};
+        "${": "}",      // mega
+        "(": ")",       // paren
+        "[": "]",       // bracket
+        "{": "}"        // brace
+    };
 
 // The relational operators.
 
-const relationop = populate([
-    "!=", "!==", "==", "===", "<", "<=", ">", ">="
-]);
+    const relationop = populate([
+        "!=", "!==", "==", "===", "<", "<=", ">", ">="
+    ]);
 
 // This is the set of infix operators that require a space on each side.
 
-const spaceop = populate([
-    "!=", "!==", "%", "%=", "&", "&=", "&&", "*", "*=", "+=", "-=", "/",
-    "/=", "<", "<=", "<<", "<<=", "=", "==", "===", "=>", ">", ">=",
-    ">>", ">>=", ">>>", ">>>=", "^", "^=", "|", "|=", "||"
-]);
+    const spaceop = populate([
+        "!=", "!==", "%", "%=", "&", "&=", "&&", "*", "*=", "+=", "-=", "/",
+        "/=", "<", "<=", "<<", "<<=", "=", "==", "===", "=>", ">", ">=",
+        ">>", ">>=", ">>>", ">>>=", "^", "^=", "|", "|=", "||"
+    ]);
 
-const standard = [
+    const standard = [
 
 // These are the globals that are provided by the language standard.
 
-    "Array", "ArrayBuffer", "Boolean", "DataView", "Date", "Error", "EvalError",
-    "Float32Array", "Float64Array", "Generator", "GeneratorFunction",
-    "Int16Array", "Int32Array", "Int8Array", "Intl", "JSON", "Map", "Math",
-    "Number", "Object", "Promise", "Proxy", "RangeError", "ReferenceError",
-    "Reflect", "RegExp", "Set", "String", "Symbol", "SyntaxError", "System",
-    "TypeError", "URIError", "Uint16Array", "Uint32Array", "Uint8Array",
-    "Uint8ClampedArray", "WeakMap", "WeakSet", "decodeURI",
-    "decodeURIComponent", "encodeURI", "encodeURIComponent", "globalThis",
-    "import", "parseFloat", "parseInt"
-];
+        "Array", "ArrayBuffer", "Boolean", "DataView", "Date", "Error",
+        "EvalError",
+        "Float32Array", "Float64Array", "Generator", "GeneratorFunction",
+        "Int16Array", "Int32Array", "Int8Array", "Intl", "JSON", "Map", "Math",
+        "Number", "Object", "Promise", "Proxy", "RangeError", "ReferenceError",
+        "Reflect", "RegExp", "Set", "String", "Symbol", "SyntaxError", "System",
+        "TypeError", "URIError", "Uint16Array", "Uint32Array", "Uint8Array",
+        "Uint8ClampedArray", "WeakMap", "WeakSet", "decodeURI",
+        "decodeURIComponent", "encodeURI", "encodeURIComponent", "globalThis",
+        "import", "parseFloat", "parseInt"
+    ];
 
-const bundle = {
+    const bundle = {
 
 // The bundle contains the raw text messages that are generated by jslint. It
 // seems that they are all error messages and warnings. There are no "Atta
@@ -273,408 +283,4760 @@ const bundle = {
 // wound the inner child. But if you accept it as sound advice rather than as
 // personal criticism, it can make your programs better.
 
-    and: "The '&&' subexpression should be wrapped in parens.",
-    bad_assignment_a: "Bad assignment to '{a}'.",
-    bad_directive_a: "Bad directive '{a}'.",
-    bad_get: "A get function takes no parameters.",
-    bad_module_name_a: "Bad module name '{a}'.",
-    bad_option_a: "Bad option '{a}'.",
-    bad_property_a: "Bad property name '{a}'.",
-    bad_set: "A set function takes one parameter.",
-    duplicate_a: "Duplicate '{a}'.",
-    empty_block: "Empty block.",
-    expected_a: "Expected '{a}'.",
-    expected_a_at_b_c: "Expected '{a}' at column {b}, not column {c}.",
-    expected_a_b: "Expected '{a}' and instead saw '{b}'.",
-    expected_a_b_from_c_d: (
-        "Expected '{a}' to match '{b}' from line {c} and instead saw '{d}'."
-    ),
-    expected_a_before_b: "Expected '{a}' before '{b}'.",
-    expected_digits_after_a: "Expected digits after '{a}'.",
-    expected_four_digits: "Expected four digits after '\\u'.",
-    expected_identifier_a: "Expected an identifier and instead saw '{a}'.",
-    expected_line_break_a_b: "Expected a line break between '{a}' and '{b}'.",
-    expected_regexp_factor_a: "Expected a regexp factor and instead saw '{a}'.",
-    expected_space_a_b: "Expected one space between '{a}' and '{b}'.",
-    expected_statements_a: "Expected statements before '{a}'.",
-    expected_string_a: "Expected a string and instead saw '{a}'.",
-    expected_type_string_a: "Expected a type string and instead saw '{a}'.",
-    freeze_exports: (
-        "Expected 'Object.freeze('. All export values should be frozen."
-    ),
-    function_in_loop: "Don't make functions within a loop.",
-    infix_in: (
-        "Unexpected 'in'. Compare with undefined, "
-        + "or use the hasOwnProperty method instead."
-    ),
-    label_a: "'{a}' is a statement label.",
-    misplaced_a: "Place '{a}' at the outermost level.",
-    misplaced_directive_a: (
-        "Place the '/*{a}*/' directive before the first statement."
-    ),
-    missing_await_statement: "Expected await statement in async function.",
-    missing_browser: "/*global*/ requires the Assume a browser option.",
-    missing_m: "Expected 'm' flag on a multiline regular expression.",
-    naked_block: "Naked block.",
-    nested_comment: "Nested comment.",
-    not_label_a: "'{a}' is not a label.",
-    number_isNaN: "Use Number.isNaN function to compare with NaN.",
-    out_of_scope_a: "'{a}' is out of scope.",
-    redefinition_a_b: "Redefinition of '{a}' from line {b}.",
-    required_a_optional_b: (
-        "Required parameter '{a}' after optional parameter '{b}'."
-    ),
-    reserved_a: "Reserved name '{a}'.",
-    subscript_a: "['{a}'] is better written in dot notation.",
-    todo_comment: "Unexpected TODO comment.",
-    too_long: "Line is longer than 80 characters.",
-    too_many_digits: "Too many digits.",
-    unclosed_comment: "Unclosed comment.",
-    unclosed_disable: (
-        "Directive '/*jslint-disable*/' was not closed "
-        + "with '/*jslint-enable*/'."
-    ),
-    unclosed_mega: "Unclosed mega literal.",
-    unclosed_string: "Unclosed string.",
-    undeclared_a: "Undeclared '{a}'.",
-    unexpected_a: "Unexpected '{a}'.",
-    unexpected_a_after_b: "Unexpected '{a}' after '{b}'.",
-    unexpected_a_before_b: "Unexpected '{a}' before '{b}'.",
-    unexpected_at_top_level_a: "Expected '{a}' to be in a function.",
-    unexpected_char_a: "Unexpected character '{a}'.",
-    unexpected_comment: "Unexpected comment.",
-    unexpected_directive_a: "When using modules, don't use directive '/*{a}'.",
-    unexpected_expression_a: (
-        "Unexpected expression '{a}' in statement position."
-    ),
-    unexpected_label_a: "Unexpected label '{a}'.",
-    unexpected_parens: "Don't wrap function literals in parens.",
-    unexpected_space_a_b: "Unexpected space between '{a}' and '{b}'.",
-    unexpected_statement_a: (
-        "Unexpected statement '{a}' in expression position."
-    ),
-    unexpected_trailing_space: "Unexpected trailing space.",
-    unexpected_typeof_a: (
-        "Unexpected 'typeof'. Use '===' to compare directly with {a}."
-    ),
-    uninitialized_a: "Uninitialized '{a}'.",
-    unopened_enable: (
-        "Directive '/*jslint-enable*/' was not opened "
-        + "with '/*jslint-disable*/'."
-    ),
-    unordered_a_b: "{a} '{b}' not listed in alphabetical order.",
-    unreachable_a: "Unreachable '{a}'.",
-    unregistered_property_a: "Unregistered property name '{a}'.",
-    unused_a: "Unused '{a}'.",
-    use_double: "Use double quotes, not single quotes.",
-    use_open: (
-        "Wrap a ternary expression in parens, "
-        + "with a line break after the left paren."
-    ),
-    use_spaces: "Use spaces, not tabs.",
-    var_loop: "Don't declare variables in a loop.",
-    var_switch: "Don't declare variables in a switch.",
-    weird_condition_a: "Weird condition '{a}'.",
-    weird_expression_a: "Weird expression '{a}'.",
-    weird_loop: "Weird loop.",
-    weird_relation_a: "Weird relation '{a}'.",
-    wrap_condition: "Wrap the condition in parens.",
-    wrap_immediate: (
-        "Wrap an immediate function invocation in parentheses to assist "
-        + "the reader in understanding that the expression is the result "
-        + "of a function, and not the function itself."
-    ),
-    wrap_parameter: "Wrap the parameter in parens.",
-    wrap_regexp: "Wrap this regexp in parens to avoid confusion.",
-    wrap_unary: "Wrap the unary expression in parens."
-};
+        and: "The '&&' subexpression should be wrapped in parens.",
+        bad_assignment_a: "Bad assignment to '{a}'.",
+        bad_directive_a: "Bad directive '{a}'.",
+        bad_get: "A get function takes no parameters.",
+        bad_module_name_a: "Bad module name '{a}'.",
+        bad_option_a: "Bad option '{a}'.",
+        bad_property_a: "Bad property name '{a}'.",
+        bad_set: "A set function takes one parameter.",
+        duplicate_a: "Duplicate '{a}'.",
+        empty_block: "Empty block.",
+        expected_a: "Expected '{a}'.",
+        expected_a_at_b_c: "Expected '{a}' at column {b}, not column {c}.",
+        expected_a_b: "Expected '{a}' and instead saw '{b}'.",
+        expected_a_b_from_c_d: (
+            "Expected '{a}' to match '{b}' from line {c} and instead saw '{d}'."
+        ),
+        expected_a_before_b: "Expected '{a}' before '{b}'.",
+        expected_digits_after_a: "Expected digits after '{a}'.",
+        expected_four_digits: "Expected four digits after '\\u'.",
+        expected_identifier_a: "Expected an identifier and instead saw '{a}'.",
+        expected_line_break_a_b: (
+            "Expected a line break between '{a}' and '{b}'."
+        ),
+        expected_regexp_factor_a: (
+            "Expected a regexp factor and instead saw '{a}'."
+        ),
+        expected_space_a_b: "Expected one space between '{a}' and '{b}'.",
+        expected_statements_a: "Expected statements before '{a}'.",
+        expected_string_a: "Expected a string and instead saw '{a}'.",
+        expected_type_string_a: "Expected a type string and instead saw '{a}'.",
+        freeze_exports: (
+            "Expected 'Object.freeze('. All export values should be frozen."
+        ),
+        function_in_loop: "Don't make functions within a loop.",
+        infix_in: (
+            "Unexpected 'in'. Compare with undefined, "
+            + "or use the hasOwnProperty method instead."
+        ),
+        label_a: "'{a}' is a statement label.",
+        misplaced_a: "Place '{a}' at the outermost level.",
+        misplaced_directive_a: (
+            "Place the '/*{a}*/' directive before the first statement."
+        ),
+        missing_await_statement: "Expected await statement in async function.",
+        missing_browser: "/*global*/ requires the Assume a browser option.",
+        missing_m: "Expected 'm' flag on a multiline regular expression.",
+        naked_block: "Naked block.",
+        nested_comment: "Nested comment.",
+        not_label_a: "'{a}' is not a label.",
+        number_isNaN: "Use Number.isNaN function to compare with NaN.",
+        out_of_scope_a: "'{a}' is out of scope.",
+        redefinition_a_b: "Redefinition of '{a}' from line {b}.",
+        required_a_optional_b: (
+            "Required parameter '{a}' after optional parameter '{b}'."
+        ),
+        reserved_a: "Reserved name '{a}'.",
+        subscript_a: "['{a}'] is better written in dot notation.",
+        todo_comment: "Unexpected TODO comment.",
+        too_long: "Line is longer than 80 characters.",
+        too_many_digits: "Too many digits.",
+        unclosed_comment: "Unclosed comment.",
+        unclosed_disable: (
+            "Directive '/*jslint-disable*/' was not closed "
+            + "with '/*jslint-enable*/'."
+        ),
+        unclosed_mega: "Unclosed mega literal.",
+        unclosed_string: "Unclosed string.",
+        undeclared_a: "Undeclared '{a}'.",
+        unexpected_a: "Unexpected '{a}'.",
+        unexpected_a_after_b: "Unexpected '{a}' after '{b}'.",
+        unexpected_a_before_b: "Unexpected '{a}' before '{b}'.",
+        unexpected_at_top_level_a: "Expected '{a}' to be in a function.",
+        unexpected_char_a: "Unexpected character '{a}'.",
+        unexpected_comment: "Unexpected comment.",
+        unexpected_directive_a: (
+            "When using modules, don't use directive '/*{a}'."
+        ),
+        unexpected_expression_a: (
+            "Unexpected expression '{a}' in statement position."
+        ),
+        unexpected_label_a: "Unexpected label '{a}'.",
+        unexpected_parens: "Don't wrap function literals in parens.",
+        unexpected_space_a_b: "Unexpected space between '{a}' and '{b}'.",
+        unexpected_statement_a: (
+            "Unexpected statement '{a}' in expression position."
+        ),
+        unexpected_trailing_space: "Unexpected trailing space.",
+        unexpected_typeof_a: (
+            "Unexpected 'typeof'. Use '===' to compare directly with {a}."
+        ),
+        uninitialized_a: "Uninitialized '{a}'.",
+        unopened_enable: (
+            "Directive '/*jslint-enable*/' was not opened "
+            + "with '/*jslint-disable*/'."
+        ),
+        unordered_a_b: "{a} '{b}' not listed in alphabetical order.",
+        unreachable_a: "Unreachable '{a}'.",
+        unregistered_property_a: "Unregistered property name '{a}'.",
+        unused_a: "Unused '{a}'.",
+        use_double: "Use double quotes, not single quotes.",
+        use_open: (
+            "Wrap a ternary expression in parens, "
+            + "with a line break after the left paren."
+        ),
+        use_spaces: "Use spaces, not tabs.",
+        var_loop: "Don't declare variables in a loop.",
+        var_switch: "Don't declare variables in a switch.",
+        weird_condition_a: "Weird condition '{a}'.",
+        weird_expression_a: "Weird expression '{a}'.",
+        weird_loop: "Weird loop.",
+        weird_relation_a: "Weird relation '{a}'.",
+        wrap_condition: "Wrap the condition in parens.",
+        wrap_immediate: (
+            "Wrap an immediate function invocation in parentheses to assist "
+            + "the reader in understanding that the expression is the result "
+            + "of a function, and not the function itself."
+        ),
+        wrap_parameter: "Wrap the parameter in parens.",
+        wrap_regexp: "Wrap this regexp in parens to avoid confusion.",
+        wrap_unary: "Wrap the unary expression in parens."
+    };
 
 // Regular expression literals:
 
-function tag_regexp(strings) {
-    return new RegExp(strings.raw[0].replace(/\s/g, ""));
-}
+    function tag_regexp(strings) {
+        return new RegExp(strings.raw[0].replace(/\s/g, ""));
+    }
 
 // supplant {variables}
-const rx_supplant = /\{([^{}]*)\}/g;
+    const rx_supplant = /\{([^{}]*)\}/g;
 // identifier
-const rx_identifier = tag_regexp ` ^(
-    [ a-z A-Z _ $ ]
-    [ a-z A-Z 0-9 _ $ ]*
-)$`;
-const rx_module = tag_regexp ` ^ [ a-z A-Z 0-9 _ $ : . @ \- \/ ]+ $ `;
-const rx_bad_property = tag_regexp `
-    ^_
-  | \$
-  | Sync $
-  | _ $
-`;
+    const rx_identifier = tag_regexp ` ^(
+        [ a-z A-Z _ $ ]
+        [ a-z A-Z 0-9 _ $ ]*
+    )$`;
+    const rx_module = tag_regexp ` ^ [ a-z A-Z 0-9 _ $ : . @ \- \/ ]+ $ `;
+    const rx_bad_property = tag_regexp `
+        ^_
+      | \$
+      | Sync $
+      | _ $
+    `;
 // star slash
-const rx_star_slash = tag_regexp ` \* \/ `;
+    const rx_star_slash = tag_regexp ` \* \/ `;
 // slash star
-const rx_slash_star = tag_regexp ` \/ \* `;
+    const rx_slash_star = tag_regexp ` \/ \* `;
 // slash star or ending slash
-const rx_slash_star_or_slash = tag_regexp ` \/ \* | \/ $ `;
+    const rx_slash_star_or_slash = tag_regexp ` \/ \* | \/ $ `;
 // uncompleted work comment
-const rx_todo = tag_regexp ` \b (?:
-    todo
-  | TO \s? DO
-  | HACK
-) \b `;
+    const rx_todo = tag_regexp ` \b (?:
+        todo
+      | TO \s? DO
+      | HACK
+    ) \b `;
 // tab
-const rx_tab = /\t/g;
+    const rx_tab = /\t/g;
 // directive
-const rx_directive = tag_regexp ` ^ (
-    jslint
-  | property
-  | global
-) \s+ ( .* ) $ `;
-const rx_directive_part = tag_regexp ` ^ (
-    [ a-z A-Z $ _ ] [ a-z A-Z 0-9 $ _ ]*
-) (?:
-    : \s* ( true | false )
-)? ,? \s* ( .* ) $ `;
+    const rx_directive = tag_regexp ` ^ (
+        jslint
+      | property
+      | global
+    ) \s+ ( .* ) $ `;
+    const rx_directive_part = tag_regexp ` ^ (
+        [ a-z A-Z $ _ ] [ a-z A-Z 0-9 $ _ ]*
+    ) (?:
+        : \s* ( true | false )
+    )? ,? \s* ( .* ) $ `;
 // token
-const rx_token = tag_regexp ` ^ (
-    (\s+)
-  | (
-      [ a-z A-Z _ $ ]
-      [ a-z A-Z 0-9 _ $ ]*
-    )
-  | [
-      ( ) { } \[ \] , : ; ' " ~ \`
-  ]
-  | \? [ ? . ]?
-  | = (?:
-        = =?
-      | >
-    )?
-  | \.+
-  | \* [ * \/ = ]?
-  | \/ [ * \/ ]?
-  | \+ [ = + ]?
-  | - [ = \- ]?
-  | [ \^ % ] =?
-  | & [ & = ]?
-  | \| [ | = ]?
-  | >{1,3} =?
-  | < <? =?
-  | ! (?:
-        !
-      | = =?
-    )?
-  | (
-        0
-      | [ 1-9 ] [ 0-9 ]*
-    )
-) ( .* ) $ `;
-const rx_digits = /^[0-9]*/;
-const rx_hexs = /^[0-9A-F]*/i;
-const rx_octals = /^[0-7]*/;
-const rx_bits = /^[01]*/;
+    const rx_token = tag_regexp ` ^ (
+        (\s+)
+      | (
+          [ a-z A-Z _ $ ]
+          [ a-z A-Z 0-9 _ $ ]*
+        )
+      | [
+          ( ) { } \[ \] , : ; ' " ~ \`
+      ]
+      | \? [ ? . ]?
+      | = (?:
+            = =?
+          | >
+        )?
+      | \.+
+      | \* [ * \/ = ]?
+      | \/ [ * \/ ]?
+      | \+ [ = + ]?
+      | - [ = \- ]?
+      | [ \^ % ] =?
+      | & [ & = ]?
+      | \| [ | = ]?
+      | >{1,3} =?
+      | < <? =?
+      | ! (?:
+            !
+          | = =?
+        )?
+      | (
+            0
+          | [ 1-9 ] [ 0-9 ]*
+        )
+    ) ( .* ) $ `;
+    const rx_digits = /^[0-9]*/;
+    const rx_hexs = /^[0-9A-F]*/i;
+    const rx_octals = /^[0-7]*/;
+    const rx_bits = /^[01]*/;
 // mega
-const rx_mega = /[`\\]|\$\{/;
+    const rx_mega = /[`\\]|\$\{/;
 // JSON number
-const rx_JSON_number = tag_regexp ` ^
-    -?
-    (?: 0 | [ 1-9 ] \d* )
-    (?: \. \d* )?
-    (?: [ e E ] [ \- + ]? \d+ )?
-$ `;
+    const rx_JSON_number = tag_regexp ` ^
+        -?
+        (?: 0 | [ 1-9 ] \d* )
+        (?: \. \d* )?
+        (?: [ e E ] [ \- + ]? \d+ )?
+    $ `;
 // initial cap
-const rx_cap = /^[A-Z]/;
+    const rx_cap = /^[A-Z]/;
 
-function is_letter(string) {
-    return (
-        (string >= "a" && string <= "z\uffff")
-        || (string >= "A" && string <= "Z\uffff")
-    );
-}
+    function is_letter(string) {
+        return (
+            (string >= "a" && string <= "z\uffff")
+            || (string >= "A" && string <= "Z\uffff")
+        );
+    }
 
-const fudge = 1;        // Fudge starting line and starting column to 1.
-let anon;               // The guessed name for anonymous functions.
-let block_stack;        // The stack of blocks.
-let blockage;           // The current block.
-let declared_globals;   // The object containing the global declarations.
-let directive_mode;     // true if directives are still allowed.
-let directives;         // The directive comments.
-let early_stop;         // true if JSLint cannot finish.
-let exports;            // The exported names and values.
-let froms;              // The array collecting all import-from strings.
-let functionage;        // The current function.
-let functions;          // The array containing all of the functions.
-let global;             // The global object; the outermost context.
-let json_mode;          // true if parsing JSON.
-let lines;              // The array containing source lines.
-let mega_mode;          // true if currently parsing a megastring literal.
-let module_mode;        // true if import or export was used.
-let next_token;         // The next token to be examined in the parse.
-let option;             // The options parameter.
-let property;           // The object containing the tallied property names.
-let shebang;            // true if a #! was seen on the first line.
-let stack;              // The stack of functions.
-let syntax;             // The object containing the parser.
-let tenure;             // The predefined property registry.
-let token;              // The current token being examined in the parse.
-let token_nr;           // The number of the next token.
-let tokens;             // The array of tokens.
-let tree;               // The abstract parse tree.
-let var_mode;           // "var" if using var; "let" if using let.
-let warnings;           // The array collecting all generated warnings.
+    const fudge = 1;        // Fudge starting line and starting column to 1.
+    let anon;               // The guessed name for anonymous functions.
+    let block_stack;        // The stack of blocks.
+    let blockage;           // The current block.
+    let char;               // A popular character.
+    let column = 0;         // The column number of the next character.
+    let declared_globals;   // The object containing the global declarations.
+    let directive_mode;     // true if directives are still allowed.
+    let directives;         // The directive comments.
+    let disable_line;       // The starting line of "/*jslint-disable*/".
+    let early_stop;         // true if JSLint cannot finish.
+    let exports;            // The exported names and values.
+    let from;               // The starting column number of the token.
+    let froms;              // The array collecting all import-from strings.
+    let functionage;        // The current function.
+    let functions;          // The array containing all of the functions.
+    const global = {        // The global object; the outermost context.
+        body: true,
+        context: empty(),
+        finally: 0,
+        from: 0,
+        id: "(global)",
+        level: 0,
+        line: fudge,
+        live: [],
+        loop: 0,
+        switch: 0,
+        thru: 0,
+        try: 0
+    };
+    let json_mode;          // true if parsing JSON.
+    let line = 0;           // The line number of the next character.
+    let lines;              // The array containing source lines.
+    let mega_from;          // The starting column of megastring.
+    let mega_line;          // The starting line of megastring.
+    let mega_mode;          // true if currently parsing a megastring literal.
+    let module_mode;        // true if import or export was used.
+    let nr = 0;             // The next token number.
+    let prior = global;     // The previous token excluding comments.
+    let property;           // The object containing the tallied property names.
+    let regexp_seen;        // Regular expression literal seen on this line.
+    let shebang;            // true if a #! was seen on the first line.
+    let snippet = "";       // A piece of string.
+    let source_line = "";   // The remaining line source string.
+    let stack;              // The stack of functions.
+    let syntax;             // The object containing the parser.
+    let tenure;             // The predefined property registry.
+    let token_curr;         // The current token being examined in the parse.
+    let token_frst;         // The first token.
+    let token_next;         // The next token to be examined in the parse.
+    let token_nr;           // The number of the next token.
+    let token_prev = global;// The previous token including comments.
+    let tokens;             // The array of tokens.
+    let tree;               // The abstract parse tree.
+    let var_mode;           // "var" if using var; "let" if using let.
+    let warnings;           // The array collecting all generated warnings.
+    let whole_line = "";    // The whole line source string.
 
 // Error reportage functions:
 
-function artifact(the_token) {
+    function artifact(the_token) {
 
 // Return a string representing an artifact.
 
-    if (the_token === undefined) {
-        the_token = next_token;
+        if (the_token === undefined) {
+            the_token = token_next;
+        }
+        return (
+            (the_token.id === "(string)" || the_token.id === "(number)")
+            ? String(the_token.value)
+            : the_token.id
+        );
     }
-    return (
-        (the_token.id === "(string)" || the_token.id === "(number)")
-        ? String(the_token.value)
-        : the_token.id
-    );
-}
 
-function warn_at(code, line, column, a, b, c, d) {
+    function warn_at(code, line, column, a, b, c, d) {
 
 // Report an error at some line and column of the program. The warning object
 // resembles an exception.
 
-    const warning = Object.assign({
-        a,
-        b,
-        c,
-        code,
+        const warning = Object.assign({
+            a,
+            b,
+            c,
+            code,
 
 // Fudge column numbers in warning message.
 
-        column: column || fudge,
-        d,
-        line,
-        name: "JSLintError",
-        source_line: ""
-    }, lines[line]);
-    warning.message = bundle[code].replace(rx_supplant, function (
-        ignore,
-        filling
-    ) {
-        assert_or_throw(
-            warning[filling] !== undefined,
-            "Expected warning[filling] !== undefined."
-        );
+            column: column || fudge,
+            d,
+            line,
+            name: "JSLintError",
+            source_line: ""
+        }, lines[line]);
+        warning.message = bundle[code].replace(rx_supplant, function (
+            ignore,
+            filling
+        ) {
+            assert_or_throw(
+                warning[filling] !== undefined,
+                "Expected warning[filling] !== undefined."
+            );
 //      Probably deadcode.
 //      return (
 //          replacement !== undefined
 //          ? replacement
 //          : found
 //      );
-        return warning[filling];
-    });
+            return warning[filling];
+        });
 
 // Include stack_trace for jslint to debug itself for errors.
 
-    if (option.debug) {
-        warning.stack_trace = new Error().stack;
-    }
-    if (warning.directive_quiet) {
+        if (option.debug) {
+            warning.stack_trace = new Error().stack;
+        }
+        if (warning.directive_quiet) {
 
 // cause: "0 //jslint-quiet"
 
+            return warning;
+        }
+        warnings.push(warning);
         return warning;
     }
-    warnings.push(warning);
-    return warning;
-}
 
-function stop_at(code, line, column, a, b, c, d) {
+    function stop_at(code, line, column, a, b, c, d) {
 
 // Same as warn_at, except that it stops the analysis.
 
-    throw warn_at(code, line, column, a, b, c, d);
-}
+        throw warn_at(code, line, column, a, b, c, d);
+    }
 
-function warn(code, the_token, a, b, c, d) {
+    function warn(code, the_token, a, b, c, d) {
 
 // Same as warn_at, except the warning will be associated with a specific token.
 // If there is already a warning on this token, suppress the new one. It is
 // likely that the first warning will be the most meaningful.
 
-    if (the_token === undefined) {
-        the_token = next_token;
+        if (the_token === undefined) {
+            the_token = token_next;
+        }
+        if (the_token.warning === undefined) {
+            the_token.warning = warn_at(
+                code,
+                the_token.line,
+                (the_token.from || 0) + fudge,
+                a || artifact(the_token),
+                b,
+                c,
+                d
+            );
+            return the_token.warning;
+        }
     }
-    if (the_token.warning === undefined) {
-        the_token.warning = warn_at(
-            code,
-            the_token.line,
-            (the_token.from || 0) + fudge,
-            a || artifact(the_token),
-            b,
-            c,
-            d
-        );
-        return the_token.warning;
-    }
-}
 
-function stop(code, the_token, a, b, c, d) {
+    function stop(code, the_token, a, b, c, d) {
 
 // Similar to warn and stop_at. If the token already had a warning, that
 // warning will be replaced with this new one. It is likely that the stopping
 // warning will be the more meaningful.
 
-    if (the_token === undefined) {
-        the_token = next_token;
+        if (the_token === undefined) {
+            the_token = token_next;
+        }
+        delete the_token.warning;
+        throw warn(code, the_token, a, b, c, d);
     }
-    delete the_token.warning;
-    throw warn(code, the_token, a, b, c, d);
-}
 
-// Tokenize:
+//!! // Tokenize:
 
-function tokenize(source) {
+    //!! function tokenize(source) {
+    //!! }
 
-// tokenize takes a source and produces from it an array of token objects.
-// JavaScript is notoriously difficult to tokenize because of the horrible
-// interactions between automatic semicolon insertion, regular expression
-// literals, and now megastring literals. JSLint benefits from eliminating
-// automatic semicolon insertion and nested megastring literals, which allows
-// full tokenization to precede parsing.
+// Parsing:
 
-    let char;                   // a popular character
-    let column = 0;             // the column number of the next character
-    let disable_line;           // the starting line of /*jslint-disable*/
-    let first;                  // the first token
-    let from;                   // the starting column number of the token
-    let line = 0;               // the line number of the next character
-    let mega_from;              // the starting column of megastring
-    let mega_line;              // the starting line of megastring
-    let nr = 0;                 // the next token number
-    let previous = global;      // the previous token including comments
-    let prior = global;         // the previous token excluding comments
-    let regexp_seen;            // regular expression literal seen on this line
-    let snippet = "";           // a piece of string
-    let source_line = "";       // the remaining line source string
-    let whole_line = "";        // the whole line source string
+// Parsing weaves the tokens into an abstract syntax tree. During that process,
+// a token may be given any of these properties:
 
-// Split source into lines at the carriage return/linefeed.
+//      arity       string
+//      label       identifier
+//      name        identifier
+//      expression  expressions
+//      block       statements
+//      else        statements (else, default, catch)
 
-    lines = String("\n" + source).split(
-        /\n|\r\n?/
-    ).map(function (source_line) {
-        return {
-            source_line
+// Specialized tokens may have additional properties.
+
+    function survey(name) {
+        let id = name.id;
+
+// Tally the property name. If it is a string, only tally strings that conform
+// to the identifier rules.
+
+        if (id === "(string)") {
+            id = name.value;
+            if (!rx_identifier.test(id)) {
+                return id;
+            }
+        } else if (id === "`") {
+            if (name.value.length === 1) {
+                id = name.value[0].value;
+                if (!rx_identifier.test(id)) {
+                    return id;
+                }
+            }
+        } else if (!name.identifier) {
+
+// cause: "let aa={0:0}"
+
+            return stop("expected_identifier_a", name);
+        }
+
+// If we have seen this name before, increment its count.
+
+        if (typeof property[id] === "number") {
+            property[id] += 1;
+
+// If this is the first time seeing this property name, and if there is a
+// tenure list, then it must be on the list. Otherwise, it must conform to
+// the rules for good property names.
+
+        } else {
+            if (tenure !== undefined) {
+                if (tenure[id] !== true) {
+
+// cause: "/*property aa*/\naa.bb"
+
+                    warn("unregistered_property_a", name);
+                }
+            } else {
+                if (name.identifier && rx_bad_property.test(id)) {
+
+// cause: "aa._"
+
+                    warn("bad_property_a", name);
+                }
+            }
+            property[id] = 1;
+        }
+        return id;
+    }
+
+    function dispense() {
+
+// Deliver the next token, skipping the comments.
+
+        const cadet = tokens[token_nr];
+        token_nr += 1;
+        if (cadet.id === "(comment)") {
+            if (json_mode) {
+
+// cause: "[//]"
+
+                warn("unexpected_a", cadet);
+            }
+            return dispense();
+        } else {
+            return cadet;
+        }
+    }
+
+    function lookahead() {
+
+// Look ahead one token without advancing.
+
+        const old_token_nr = token_nr;
+        const cadet = dispense(true);
+        token_nr = old_token_nr;
+        return cadet;
+    }
+
+    function advance(id, match) {
+
+// Produce the next token.
+
+// Attempt to give helpful names to anonymous functions.
+
+        if (token_curr.identifier && token_curr.id !== "function") {
+            anon = token_curr.id;
+        } else if (
+            token_curr.id === "(string)"
+            && rx_identifier.test(token_curr.value)
+        ) {
+            anon = token_curr.value;
+        }
+
+// Attempt to match token_next with an expected id.
+
+        if (id !== undefined && token_next.id !== id) {
+            return (
+                match === undefined
+
+// cause: "()"
+
+                ? stop("expected_a_b", token_next, id, artifact())
+
+// cause: "{\"aa\":0"
+
+                : stop(
+                    "expected_a_b_from_c_d",
+                    token_next,
+                    id,
+                    artifact(match),
+                    match.line,
+                    artifact(token_next)
+                )
+            );
+        }
+
+// Promote the tokens, skipping comments.
+
+        token_curr = token_next;
+        token_next = dispense();
+        if (token_next.id === "(end)") {
+            token_nr -= 1;
+        }
+    }
+
+// Parsing of JSON is simple:
+
+    function json_value() {
+        let negative;
+        if (token_next.id === "{") {
+            return (function json_object() {
+                const brace = token_next;
+                const object = empty();
+                const properties = [];
+                brace.expression = properties;
+                advance("{");
+                if (token_next.id !== "}") {
+                    (function next() {
+                        let name;
+                        let value;
+                        if (token_next.quote !== "\"") {
+                            warn(
+                                "unexpected_a",
+                                token_next,
+                                token_next.quote
+                            );
+                        }
+                        name = token_next;
+                        advance("(string)");
+                        if (object[token_curr.value] !== undefined) {
+
+// cause: "{\"aa\":0,\"aa\":0}"
+
+                            warn("duplicate_a", token_curr);
+                        } else if (token_curr.value === "__proto__") {
+
+// cause: "{\"__proto__\":0}"
+
+                            warn("bad_property_a", token_curr);
+                        } else {
+                            object[token_curr.value] = token_curr;
+                        }
+                        advance(":");
+                        value = json_value();
+                        value.label = name;
+                        properties.push(value);
+                        if (token_next.id === ",") {
+                            advance(",");
+                            return next();
+                        }
+                    }());
+                }
+                advance("}", brace);
+                return brace;
+            }());
+        }
+        if (token_next.id === "[") {
+            return (function json_array() {
+                const bracket = token_next;
+                const elements = [];
+                bracket.expression = elements;
+                advance("[");
+                if (token_next.id !== "]") {
+                    (function next() {
+                        elements.push(json_value());
+                        if (token_next.id === ",") {
+                            advance(",");
+                            return next();
+                        }
+                    }());
+                }
+                advance("]", bracket);
+                return bracket;
+            }());
+        }
+        if (
+            token_next.id === "true"
+            || token_next.id === "false"
+            || token_next.id === "null"
+        ) {
+            advance();
+            return token_curr;
+        }
+        if (token_next.id === "(number)") {
+
+// cause: "[0x0]"
+
+            if (!rx_JSON_number.test(token_next.value)) {
+                warn("unexpected_a");
+            }
+            advance();
+            return token_curr;
+        }
+        if (token_next.id === "(string)") {
+
+// cause: "['']"
+
+            if (token_next.quote !== "\"") {
+                warn("unexpected_a", token_next, token_next.quote);
+            }
+            advance();
+            return token_curr;
+        }
+        if (token_next.id === "-") {
+            negative = token_next;
+            negative.arity = "unary";
+            advance("-");
+            advance("(number)");
+            if (!rx_JSON_number.test(token_curr.value)) {
+
+// cause: "[-0x0]"
+
+                warn("unexpected_a", token_curr);
+            }
+            negative.expression = token_curr;
+            return negative;
+        }
+        stop("unexpected_a");
+    }
+
+// Now we parse JavaScript.
+
+    function enroll(name, role, readonly) {
+
+// Enroll a name into the current function context. The role can be exception,
+// function, label, parameter, or variable. We look for variable redefinition
+// because it causes confusion.
+
+        const id = name.id;
+
+// Reserved words may not be enrolled.
+
+        if (syntax[id] !== undefined && id !== "ignore") {
+
+// cause: "let undefined"
+
+            warn("reserved_a", name);
+        } else {
+
+// Has the name been enrolled in this context?
+
+            let earlier = functionage.context[id];
+            if (earlier) {
+
+// cause: "let aa;let aa"
+
+                warn(
+                    "redefinition_a_b",
+                    name,
+                    name.id,
+                    earlier.line
+                );
+
+// Has the name been enrolled in an outer context?
+
+            } else {
+                stack.forEach(function (value) {
+                    const item = value.context[id];
+                    if (item !== undefined) {
+                        earlier = item;
+                    }
+                });
+                if (earlier) {
+                    if (id === "ignore") {
+                        if (earlier.role === "variable") {
+
+// cause: "let ignore;function aa(ignore){}"
+
+                            warn("unexpected_a", name);
+                        }
+                    } else {
+                        if (
+                            (
+                                role !== "exception"
+                                || earlier.role !== "exception"
+                            )
+                            && role !== "parameter"
+                            && role !== "function"
+                        ) {
+
+// cause: "function aa(){try{aa();}catch(aa){aa();}}"
+// cause: "function aa(){var aa;}"
+
+                            warn(
+                                "redefinition_a_b",
+                                name,
+                                name.id,
+                                earlier.line
+                            );
+                        }
+                    }
+                }
+
+// Enroll it.
+
+                functionage.context[id] = name;
+                name.dead = true;
+                name.parent = functionage;
+                name.init = false;
+                name.role = role;
+                name.used = 0;
+                name.writable = !readonly;
+            }
+        }
+    }
+
+    function expression(rbp, initial) {
+
+// This is the heart of the Pratt parser. I retained Pratt's nomenclature.
+// They are elements of the parsing method called Top Down Operator Precedence.
+
+// nud     Null denotation
+// led     Left denotation
+// lbp     Left binding power
+// rbp     Right binding power
+
+// It processes a nud (variable, constant, prefix operator). It will then
+// process leds (infix operators) until the bind powers cause it to stop. It
+// returns the expression's parse tree.
+
+        let left;
+        let the_symbol;
+
+// Statements will have already advanced, so advance now only if the token is
+// not the first of a statement,
+
+        if (!initial) {
+            advance();
+        }
+        the_symbol = syntax[token_curr.id];
+        if (the_symbol !== undefined && the_symbol.nud !== undefined) {
+
+// cause: "0"
+
+            left = the_symbol.nud();
+        } else if (token_curr.identifier) {
+
+// cause: "aa"
+
+            left = token_curr;
+            left.arity = "variable";
+        } else {
+
+// cause: "!"
+
+            return stop("unexpected_a", token_curr);
+        }
+        (function right() {
+            the_symbol = syntax[token_next.id];
+            if (
+                the_symbol !== undefined
+                && the_symbol.led !== undefined
+                && rbp < the_symbol.lbp
+            ) {
+                advance();
+                left = the_symbol.led(left);
+                return right();
+            }
+        }());
+        return left;
+    }
+
+    function condition() {
+
+// Parse the condition part of a do, if, while.
+
+        const the_paren = token_next;
+        let the_value;
+
+// cause: "do{}while()"
+// cause: "if(){}"
+// cause: "while(){}"
+
+        the_paren.free = true;
+        advance("(");
+        the_value = expression(0);
+        advance(")");
+        if (the_value.wrapped === true) {
+
+// cause: "while((0)){}"
+
+            warn("unexpected_a", the_paren);
+        }
+        if (anticondition[the_value.id] === true) {
+
+// cause: "while(~0){}"
+
+            warn("unexpected_a", the_value);
+        }
+        return the_value;
+    }
+
+    function is_weird(thing) {
+        return (
+            thing.id === "(regexp)"
+            || thing.id === "{"
+            || thing.id === "=>"
+            || thing.id === "function"
+            || (thing.id === "[" && thing.arity === "unary")
+        );
+    }
+
+    function are_similar(a, b) {
+
+// cause: "0&&0"
+
+        assert_or_throw(!(a === b), `Expected !(a === b).`);
+//  Probably deadcode.
+//  if (a === b) {
+//      return true;
+//  }
+        if (Array.isArray(a)) {
+            return (
+                Array.isArray(b)
+                && a.length === b.length
+                && a.every(function (value, index) {
+
+// cause: "`${0}`&&`${0}`"
+
+                    return are_similar(value, b[index]);
+                })
+            );
+        }
+        assert_or_throw(!Array.isArray(b), `Expected !Array.isArray(b).`);
+//  Probably deadcode.
+//  if (Array.isArray(b)) {
+//      return false;
+//  }
+        if (a.id === "(number)" && b.id === "(number)") {
+            return a.value === b.value;
+        }
+        let a_string;
+        let b_string;
+        if (a.id === "(string)") {
+            a_string = a.value;
+        } else if (a.id === "`" && a.constant) {
+            a_string = a.value[0];
+        }
+        if (b.id === "(string)") {
+            b_string = b.value;
+        } else if (b.id === "`" && b.constant) {
+            b_string = b.value[0];
+        }
+        if (typeof a_string === "string") {
+            return a_string === b_string;
+        }
+        if (is_weird(a) || is_weird(b)) {
+            return false;
+        }
+        if (a.arity === b.arity && a.id === b.id) {
+
+// cause: "aa.bb&&aa.bb"
+
+            if (a.id === ".") {
+                return (
+                    are_similar(a.expression, b.expression)
+                    && are_similar(a.name, b.name)
+                );
+            }
+
+// cause: "+0&&+0"
+
+            if (a.arity === "unary") {
+                return are_similar(a.expression, b.expression);
+            }
+            if (a.arity === "binary") {
+
+// cause: "aa[0]&&aa[0]"
+
+                return (
+                    a.id !== "("
+                    && are_similar(a.expression[0], b.expression[0])
+                    && are_similar(a.expression[1], b.expression[1])
+                );
+            }
+            if (a.arity === "ternary") {
+
+// cause: "aa=(``?``:``)&&(``?``:``)"
+
+                return (
+                    are_similar(a.expression[0], b.expression[0])
+                    && are_similar(a.expression[1], b.expression[1])
+                    && are_similar(a.expression[2], b.expression[2])
+                );
+            }
+            assert_or_throw(
+                !(a.arity === "function" || a.arity === "regexp"),
+                `Expected !(a.arity === "function" || a.arity === "regexp").`
+            );
+//      Probably deadcode.
+//      if (a.arity === "function" || a.arity === "regexp") {
+//          return false;
+//      }
+
+// cause: "undefined&&undefined"
+
+            return true;
+        }
+
+// cause: "null&&undefined"
+
+        return false;
+    }
+
+    function semicolon() {
+
+// Try to match a semicolon.
+
+        if (token_next.id === ";") {
+            advance(";");
+        } else {
+
+// cause: "0"
+
+            warn_at(
+                "expected_a_b",
+                token_curr.line,
+                token_curr.thru,
+                ";",
+                artifact(token_next)
+            );
+        }
+        anon = "anonymous";
+    }
+
+    function statement() {
+
+// Parse a statement. Any statement may have a label, but only four statements
+// have use for one. A statement can be one of the standard statements, or
+// an assignment expression, or an invocation expression.
+
+        let first;
+        let the_label;
+        let the_statement;
+        let the_symbol;
+        advance();
+        if (token_curr.identifier && token_next.id === ":") {
+            the_label = token_curr;
+            if (the_label.id === "ignore") {
+
+// cause: "ignore:"
+
+                warn("unexpected_a", the_label);
+            }
+            advance(":");
+            if (
+                token_next.id === "do"
+                || token_next.id === "for"
+                || token_next.id === "switch"
+                || token_next.id === "while"
+            ) {
+                enroll(the_label, "label", true);
+                the_label.init = true;
+                the_label.dead = false;
+                the_statement = statement();
+                the_statement.label = the_label;
+                the_statement.statement = true;
+                return the_statement;
+            }
+            advance();
+
+// cause: "aa:"
+
+            warn("unexpected_label_a", the_label);
+        }
+
+// Parse the statement.
+
+        first = token_curr;
+        first.statement = true;
+        the_symbol = syntax[first.id];
+        if (the_symbol !== undefined && the_symbol.fud !== undefined) {
+            the_symbol.disrupt = false;
+            the_symbol.statement = true;
+            the_statement = the_symbol.fud();
+        } else {
+
+// It is an expression statement.
+
+            the_statement = expression(0, true);
+            if (the_statement.wrapped && the_statement.id !== "(") {
+
+// cause: "(0)"
+
+                warn("unexpected_a", first);
+            }
+            semicolon();
+        }
+        if (the_label !== undefined) {
+            the_label.dead = true;
+        }
+        return the_statement;
+    }
+
+    function statements() {
+
+// Parse a list of statements. Give a warning if an unreachable statement
+// follows a disruptive statement.
+
+        const array = [];
+        (function next(disrupt) {
+            if (
+                token_next.id !== "}"
+                && token_next.id !== "case"
+                && token_next.id !== "default"
+                && token_next.id !== "else"
+                && token_next.id !== "(end)"
+            ) {
+                let a_statement = statement();
+                array.push(a_statement);
+                if (disrupt) {
+
+// cause: "while(0){break;0;}"
+
+                    warn("unreachable_a", a_statement);
+                }
+                return next(a_statement.disrupt);
+            }
+        }(false));
+        return array;
+    }
+
+    function not_top_level(thing) {
+
+// Some features should not be at the outermost level.
+
+        if (functionage === global) {
+
+// cause: "while(0){}"
+
+            warn("unexpected_at_top_level_a", thing);
+        }
+    }
+
+    function top_level_only(the_thing) {
+
+// Some features must be at the most outermost level.
+
+        if (blockage !== global) {
+
+// cause: "if(0){import aa from \"aa\";}"
+
+            warn("misplaced_a", the_thing);
+        }
+    }
+
+    function block(special) {
+
+// Parse a block, a sequence of statements wrapped in braces.
+//  special "body"      The block is a function body.
+//          "ignore"    No warning on an empty block.
+//          "naked"     No advance.
+//          undefined   An ordinary block.
+
+        let stmts;
+        let the_block;
+        if (special !== "naked") {
+            advance("{");
+        }
+        the_block = token_curr;
+        the_block.arity = "statement";
+        the_block.body = special === "body";
+
+// Top level function bodies may include the "use strict" pragma.
+
+        if (
+            special === "body"
+            && stack.length === 1
+            && token_next.value === "use strict"
+        ) {
+            token_next.statement = true;
+            advance("(string)");
+            advance(";");
+        }
+        stmts = statements();
+        the_block.block = stmts;
+        if (stmts.length === 0) {
+            if (!option.devel && special !== "ignore") {
+
+// cause: "function aa(){}"
+
+                warn("empty_block", the_block);
+            }
+            the_block.disrupt = false;
+        } else {
+            the_block.disrupt = stmts[stmts.length - 1].disrupt;
+        }
+        advance("}");
+        return the_block;
+    }
+
+    function mutation_check(the_thing) {
+
+// The only expressions that may be assigned to are
+//      e.b
+//      e[b]
+//      v
+//      [destructure]
+//      {destructure}
+
+        if (
+            the_thing.arity !== "variable"
+            && the_thing.id !== "."
+            && the_thing.id !== "["
+            && the_thing.id !== "{"
+        ) {
+
+// cause: "0=0"
+
+            warn("bad_assignment_a", the_thing);
+            return false;
+        }
+        return true;
+    }
+
+    function left_check(left, right) {
+
+// Warn if the left is not one of these:
+//      ?.
+//      ?:
+//      e()
+//      e.b
+//      e[b]
+//      identifier
+
+        const id = left.id;
+        if (
+            !left.identifier
+            && (
+                left.arity !== "ternary"
+                || (
+                    !left_check(left.expression[1])
+                    && !left_check(left.expression[2])
+                )
+            )
+            && (
+                left.arity !== "binary"
+                || (id !== "." && id !== "?." && id !== "(" && id !== "[")
+            )
+        ) {
+            warn("unexpected_a", right);
+            return false;
+        }
+        return true;
+    }
+
+// These functions are used to specify the grammar of our language:
+
+    function symbol(id, bp) {
+
+// Make a symbol if it does not already exist in the language's syntax.
+
+        let the_symbol = syntax[id];
+        if (the_symbol === undefined) {
+            the_symbol = empty();
+            the_symbol.id = id;
+            the_symbol.lbp = bp || 0;
+            syntax[id] = the_symbol;
+        }
+        return the_symbol;
+    }
+
+    function assignment(id) {
+
+// Make an assignment operator. The one true assignment is different because
+// its left side, when it is a variable, is not treated as an expression.
+// That case is special because that is when a variable gets initialized. The
+// other assignment operators can modify, but they cannot initialize.
+
+        const the_symbol = symbol(id, 20);
+        the_symbol.led = function (left) {
+            const the_token = token_curr;
+            let right;
+            the_token.arity = "assignment";
+            right = expression(20 - 1);
+            if (id === "=" && left.arity === "variable") {
+                the_token.names = left;
+                the_token.expression = right;
+            } else {
+                the_token.expression = [left, right];
+            }
+            if (
+                right.arity === "assignment"
+                || right.arity === "pre"
+                || right.arity === "post"
+            ) {
+                warn("unexpected_a", right);
+            }
+            mutation_check(left);
+            return the_token;
         };
+        return the_symbol;
+    }
+
+    function constant(id, type, value) {
+
+// Make a constant symbol.
+
+        const the_symbol = symbol(id);
+        the_symbol.constant = true;
+        the_symbol.nud = (
+            typeof value === "function"
+            ? value
+            : function () {
+                token_curr.constant = true;
+                if (value !== undefined) {
+                    token_curr.value = value;
+                }
+                return token_curr;
+            }
+        );
+        the_symbol.type = type;
+        the_symbol.value = value;
+        return the_symbol;
+    }
+
+    function infix(id, bp, f) {
+
+// Make an infix operator.
+
+        const the_symbol = symbol(id, bp);
+        the_symbol.led = function (left) {
+            const the_token = token_curr;
+            the_token.arity = "binary";
+            if (f !== undefined) {
+                return f(left);
+            }
+            the_token.expression = [left, expression(bp)];
+            return the_token;
+        };
+        return the_symbol;
+    }
+
+    function infixr(id, bp) {
+
+// Make a right associative infix operator.
+
+        const the_symbol = symbol(id, bp);
+        the_symbol.led = function (left) {
+
+// cause: "0**0"
+
+            const the_token = token_curr;
+            the_token.arity = "binary";
+            the_token.expression = [left, expression(bp - 1)];
+            return the_token;
+        };
+        return the_symbol;
+    }
+
+    function post(id) {
+
+// Make one of the post operators.
+
+        const the_symbol = symbol(id, 150);
+        the_symbol.led = function (left) {
+            token_curr.expression = left;
+            token_curr.arity = "post";
+            mutation_check(token_curr.expression);
+            return token_curr;
+        };
+        return the_symbol;
+    }
+
+    function pre(id) {
+
+// Make one of the pre operators.
+
+        const the_symbol = symbol(id);
+        the_symbol.nud = function () {
+            const the_token = token_curr;
+            the_token.arity = "pre";
+            the_token.expression = expression(150);
+            mutation_check(the_token.expression);
+            return the_token;
+        };
+        return the_symbol;
+    }
+
+    function prefix(id, f) {
+
+// Make a prefix operator.
+
+        const the_symbol = symbol(id);
+        the_symbol.nud = function () {
+            const the_token = token_curr;
+            the_token.arity = "unary";
+            if (typeof f === "function") {
+                return f();
+            }
+            the_token.expression = expression(150);
+            return the_token;
+        };
+        return the_symbol;
+    }
+
+    function stmt(id, f) {
+
+// Make a statement.
+
+        const the_symbol = symbol(id);
+        the_symbol.fud = function () {
+            token_curr.arity = "statement";
+            return f();
+        };
+        return the_symbol;
+    }
+
+    function ternary(id1, id2) {
+
+// Make a ternary operator.
+
+        const the_symbol = symbol(id1, 30);
+        the_symbol.led = function (left) {
+            const the_token = token_curr;
+            const second = expression(20);
+            advance(id2);
+            token_curr.arity = "ternary";
+            the_token.arity = "ternary";
+            the_token.expression = [left, second, expression(10)];
+            if (token_next.id !== ")") {
+
+// cause: "0?0:0"
+
+                warn("use_open", the_token);
+            }
+            return the_token;
+        };
+        return the_symbol;
+    }
+
+// Begin defining the language.
+
+    syntax = empty();
+
+    symbol("}");
+    symbol(")");
+    symbol("]");
+    symbol(",");
+    symbol(";");
+    symbol(":");
+    symbol("*/");
+    symbol("async");
+    symbol("await");
+    symbol("case");
+    symbol("catch");
+    symbol("class");
+    symbol("default");
+    symbol("else");
+    symbol("enum");
+    symbol("finally");
+    symbol("implements");
+    symbol("interface");
+    symbol("package");
+    symbol("private");
+    symbol("protected");
+    symbol("public");
+    symbol("static");
+    symbol("super");
+    symbol("void");
+    symbol("yield");
+
+    constant("(number)", "number");
+    constant("(regexp)", "regexp");
+    constant("(string)", "string");
+    constant("arguments", "object", function () {
+
+// cause: "arguments"
+
+        warn("unexpected_a", token_curr);
+        return token_curr;
     });
-    tokens = [];
+    constant("eval", "function", function () {
+        if (!option.eval) {
 
-// Scan first line for "#!" and ignore it.
+// cause: "eval"
 
-    if (lines[fudge].source_line.startsWith("#!")) {
-        line += 1;
-        shebang = true;
+            warn("unexpected_a", token_curr);
+        } else if (token_next.id !== "(") {
+
+// cause: "/*jslint eval*/\neval"
+
+            warn("expected_a_before_b", token_next, "(", artifact());
+        }
+        return token_curr;
+    });
+    constant("false", "boolean", false);
+    constant("Function", "function", function () {
+        if (!option.eval) {
+
+// cause: "Function()"
+
+            warn("unexpected_a", token_curr);
+        } else if (token_next.id !== "(") {
+
+// cause: "/*jslint eval*/\nFunction"
+
+            warn("expected_a_before_b", token_next, "(", artifact());
+        }
+        return token_curr;
+    });
+    constant("ignore", "undefined", function () {
+
+// cause: "ignore"
+
+        warn("unexpected_a", token_curr);
+        return token_curr;
+    });
+    constant("Infinity", "number", Infinity);
+    constant("isFinite", "function", function () {
+
+// cause: "isFinite"
+
+        warn("expected_a_b", token_curr, "Number.isFinite", "isFinite");
+        return token_curr;
+    });
+    constant("isNaN", "function", function () {
+
+// cause: "isNaN(0)"
+
+        warn("number_isNaN", token_curr);
+        return token_curr;
+    });
+    constant("NaN", "number", NaN);
+    constant("null", "null", null);
+    constant("this", "object", function () {
+        if (!option.this) {
+
+// cause: "this"
+
+            warn("unexpected_a", token_curr);
+        }
+        return token_curr;
+    });
+    constant("true", "boolean", true);
+    constant("undefined", "undefined");
+
+    assignment("=");
+    assignment("+=");
+    assignment("-=");
+    assignment("*=");
+    assignment("/=");
+    assignment("%=");
+    assignment("&=");
+    assignment("|=");
+    assignment("^=");
+    assignment("<<=");
+    assignment(">>=");
+    assignment(">>>=");
+
+    infix("??", 35);
+    infix("||", 40);
+    infix("&&", 50);
+    infix("|", 70);
+    infix("^", 80);
+    infix("&", 90);
+    infix("==", 100);
+    infix("===", 100);
+    infix("!=", 100);
+    infix("!==", 100);
+    infix("<", 110);
+    infix(">", 110);
+    infix("<=", 110);
+    infix(">=", 110);
+    infix("in", 110);
+    infix("instanceof", 110);
+    infix("<<", 120);
+    infix(">>", 120);
+    infix(">>>", 120);
+    infix("+", 130);
+    infix("-", 130);
+    infix("*", 140);
+    infix("/", 140);
+    infix("%", 140);
+    infixr("**", 150);
+    infix("(", 160, function (left) {
+        const the_paren = token_curr;
+        let the_argument;
+        if (left.id !== "function") {
+
+// cause: "(0?0:0)()"
+// cause: "0()"
+
+            left_check(left, the_paren);
+        }
+        if (functionage.arity === "statement" && left.identifier) {
+            functionage.name.calls[left.id] = left;
+        }
+        the_paren.expression = [left];
+        if (token_next.id !== ")") {
+            (function next() {
+                let ellipsis;
+                if (token_next.id === "...") {
+                    ellipsis = true;
+                    advance("...");
+                }
+                the_argument = expression(10);
+                if (ellipsis) {
+                    the_argument.ellipsis = true;
+                }
+                the_paren.expression.push(the_argument);
+                if (token_next.id === ",") {
+                    advance(",");
+                    return next();
+                }
+            }());
+        }
+        advance(")", the_paren);
+        if (the_paren.expression.length === 2) {
+
+// cause: "aa(0)"
+
+            the_paren.free = true;
+            if (the_argument.wrapped === true) {
+
+// cause: "aa((0))"
+
+                warn("unexpected_a", the_paren);
+            }
+            if (the_argument.id === "(") {
+                the_argument.wrapped = true;
+            }
+        } else {
+
+// cause: "aa()"
+// cause: "aa(0,0)"
+
+            the_paren.free = false;
+        }
+        return the_paren;
+    });
+    infix(".", 170, function (left) {
+        const the_token = token_curr;
+        const name = token_next;
+        if (
+            (
+                left.id !== "(string)"
+                || (name.id !== "indexOf" && name.id !== "repeat")
+            )
+            && (
+                left.id !== "["
+                || (
+                    name.id !== "concat"
+                    && name.id !== "forEach"
+                    && name.id !== "join"
+                    && name.id !== "map"
+                )
+            )
+            && (left.id !== "+" || name.id !== "slice")
+            && (
+                left.id !== "(regexp)"
+                || (name.id !== "exec" && name.id !== "test")
+            )
+        ) {
+
+// cause: "\"\".aa"
+
+            left_check(left, the_token);
+        }
+        if (!name.identifier) {
+
+// cause: "aa.0"
+
+            stop("expected_identifier_a");
+        }
+        advance();
+        survey(name);
+
+// The property name is not an expression.
+
+        the_token.name = name;
+        the_token.expression = left;
+        return the_token;
+    });
+    infix("?.", 170, function (left) {
+        const the_token = token_curr;
+        const name = token_next;
+        if (
+            (
+                left.id !== "(string)"
+                || (name.id !== "indexOf" && name.id !== "repeat")
+            )
+            && (
+                left.id !== "["
+                || (
+                    name.id !== "concat"
+                    && name.id !== "forEach"
+                    && name.id !== "join"
+                    && name.id !== "map"
+                )
+            )
+
+// cause: "(0+0)?.0"
+
+            && (left.id !== "+" || name.id !== "slice")
+            && (
+                left.id !== "(regexp)"
+                || (name.id !== "exec" && name.id !== "test")
+            )
+        ) {
+
+// cause: "\"aa\"?.0"
+// cause: "(/./)?.0"
+// cause: "aa=[]?.aa"
+
+            left_check(left, the_token);
+        }
+        if (!name.identifier) {
+
+// cause: "aa?.0"
+
+            stop("expected_identifier_a");
+        }
+        advance();
+        survey(name);
+
+// The property name is not an expression.
+
+        the_token.name = name;
+        the_token.expression = left;
+        return the_token;
+    });
+    infix("[", 170, function (left) {
+        const the_token = token_curr;
+        const the_subscript = expression(0);
+        if (the_subscript.id === "(string)" || the_subscript.id === "`") {
+            const name = survey(the_subscript);
+            if (rx_identifier.test(name)) {
+
+// cause: "aa[`aa`]"
+
+                warn("subscript_a", the_subscript, name);
+            }
+        }
+
+// cause: "0[0]"
+
+        left_check(left, the_token);
+        the_token.expression = [left, the_subscript];
+        advance("]");
+        return the_token;
+    });
+    infix("=>", 170, function (left) {
+
+// cause: "aa=>0"
+
+        return stop("wrap_parameter", left);
+    });
+
+    function do_tick() {
+        const the_tick = token_curr;
+        the_tick.value = [];
+        the_tick.expression = [];
+        if (token_next.id !== "`") {
+            (function part() {
+                advance("(string)");
+                the_tick.value.push(token_curr);
+                if (token_next.id === "${") {
+                    advance("${");
+                    the_tick.expression.push(expression(0));
+                    advance("}");
+                    return part();
+                }
+            }());
+        }
+        advance("`");
+        return the_tick;
+    }
+
+    infix("`", 160, function (left) {
+        const the_tick = do_tick();
+
+// cause: "0``"
+
+        left_check(left, the_tick);
+        the_tick.expression = [left].concat(the_tick.expression);
+        return the_tick;
+    });
+
+    post("++");
+    post("--");
+    pre("++");
+    pre("--");
+
+    prefix("+");
+    prefix("-");
+    prefix("~");
+    prefix("!");
+    prefix("!!");
+    prefix("[", function () {
+        const the_token = token_curr;
+        the_token.expression = [];
+        if (token_next.id !== "]") {
+            (function next() {
+                let element;
+                let ellipsis = false;
+                if (token_next.id === "...") {
+                    ellipsis = true;
+                    advance("...");
+                }
+                element = expression(10);
+                if (ellipsis) {
+                    element.ellipsis = true;
+                }
+                the_token.expression.push(element);
+                if (token_next.id === ",") {
+                    advance(",");
+                    return next();
+                }
+            }());
+        }
+        advance("]");
+        return the_token;
+    });
+    prefix("/=", function () {
+
+// cause: "/="
+
+        stop("expected_a_b", token_curr, "/\\=", "/=");
+    });
+    prefix("=>", function () {
+
+// cause: "=>0"
+
+        return stop("expected_a_before_b", token_curr, "()", "=>");
+    });
+    prefix("new", function () {
+        const the_new = token_curr;
+        const right = expression(160);
+        if (token_next.id !== "(") {
+
+// cause: "new aa"
+
+            warn("expected_a_before_b", token_next, "()", artifact(token_next));
+        }
+        the_new.expression = right;
+        return the_new;
+    });
+    prefix("typeof");
+    prefix("void", function () {
+        const the_void = token_curr;
+
+// cause: "void"
+// cause: "void 0"
+
+        warn("unexpected_a", the_void);
+        the_void.expression = expression(0);
+        return the_void;
+    });
+
+    function parameter_list() {
+        const list = [];
+        let optional;
+        const signature = ["("];
+        if (token_next.id !== ")" && token_next.id !== "(end)") {
+            (function parameter() {
+                let ellipsis = false;
+                let param;
+                if (token_next.id === "{") {
+                    let a;
+                    let b = "";
+                    if (optional !== undefined) {
+
+// cause: "function aa(aa=0,{}){}"
+
+                        warn(
+                            "required_a_optional_b",
+                            token_next,
+                            token_next.id,
+                            optional.id
+                        );
+                    }
+                    param = token_next;
+                    param.names = [];
+                    advance("{");
+                    signature.push("{");
+                    (function subparameter() {
+                        let subparam = token_next;
+                        if (!subparam.identifier) {
+
+// cause: "function aa(aa=0,{}){}"
+// cause: "function aa({0}){}"
+
+                            return stop("expected_identifier_a");
+                        }
+                        survey(subparam);
+                        a = b;
+                        b = String(subparam.value || subparam.id);
+                        if (!option.unordered && a > b) {
+
+// cause: "function aa({bb,aa}){}"
+
+                            warn(
+                                "unordered_a_b",
+                                subparam,
+                                "Parameter",
+                                artifact(subparam)
+                            );
+                        }
+                        advance();
+                        signature.push(subparam.id);
+                        if (token_next.id === ":") {
+                            advance(":");
+                            advance();
+                            token_curr.label = subparam;
+                            subparam = token_curr;
+                            if (!subparam.identifier) {
+
+// cause: "function aa({aa:0}){}"
+
+                                return stop("expected_identifier_a");
+                            }
+                        }
+
+// cause: "function aa({aa=aa},aa){}"
+
+                        if (token_next.id === "=") {
+                            advance("=");
+                            subparam.expression = expression();
+                            param.open = true;
+                        }
+                        param.names.push(subparam);
+                        if (token_next.id === ",") {
+                            advance(",");
+                            signature.push(", ");
+                            return subparameter();
+                        }
+                    }());
+                    list.push(param);
+                    advance("}");
+                    signature.push("}");
+                    if (token_next.id === ",") {
+                        advance(",");
+                        signature.push(", ");
+                        return parameter();
+                    }
+                } else if (token_next.id === "[") {
+                    if (optional !== undefined) {
+
+// cause: "function aa(aa=0,[]){}"
+
+                        warn(
+                            "required_a_optional_b",
+                            token_next,
+                            token_next.id,
+                            optional.id
+                        );
+                    }
+                    param = token_next;
+                    param.names = [];
+                    advance("[");
+                    signature.push("[]");
+                    (function subparameter() {
+                        const subparam = token_next;
+                        if (!subparam.identifier) {
+
+// cause: "function aa(aa=0,[]){}"
+
+                            return stop("expected_identifier_a");
+                        }
+                        advance();
+                        param.names.push(subparam);
+
+// cause: "function aa([aa=aa],aa){}"
+
+                        if (token_next.id === "=") {
+                            advance("=");
+                            subparam.expression = expression();
+                            param.open = true;
+                        }
+                        if (token_next.id === ",") {
+                            advance(",");
+                            return subparameter();
+                        }
+                    }());
+                    list.push(param);
+                    advance("]");
+                    if (token_next.id === ",") {
+                        advance(",");
+                        signature.push(", ");
+                        return parameter();
+                    }
+                } else {
+                    if (token_next.id === "...") {
+                        ellipsis = true;
+                        signature.push("...");
+                        advance("...");
+                        if (optional !== undefined) {
+
+// cause: "function aa(aa=0,...){}"
+
+                            warn(
+                                "required_a_optional_b",
+                                token_next,
+                                token_next.id,
+                                optional.id
+                            );
+                        }
+                    }
+                    if (!token_next.identifier) {
+
+// cause: "function aa(0){}"
+
+                        return stop("expected_identifier_a");
+                    }
+                    param = token_next;
+                    list.push(param);
+                    advance();
+                    signature.push(param.id);
+                    if (ellipsis) {
+                        param.ellipsis = true;
+                    } else {
+                        if (token_next.id === "=") {
+                            optional = param;
+                            advance("=");
+                            param.expression = expression(0);
+                        } else {
+                            if (optional !== undefined) {
+
+// cause: "function aa(aa=0,bb){}"
+
+                                warn(
+                                    "required_a_optional_b",
+                                    param,
+                                    param.id,
+                                    optional.id
+                                );
+                            }
+                        }
+                        if (token_next.id === ",") {
+                            advance(",");
+                            signature.push(", ");
+                            return parameter();
+                        }
+                    }
+                }
+            }());
+        }
+        advance(")");
+        signature.push(")");
+        return [list, signature.join("")];
+    }
+
+    function do_function(the_function) {
+        let name;
+        if (the_function === undefined) {
+            the_function = token_curr;
+
+// A function statement must have a name that will be in the parent's scope.
+
+            if (the_function.arity === "statement") {
+                if (!token_next.identifier) {
+
+// cause: "function(){}"
+// cause: "function*aa(){}"
+
+                    return stop("expected_identifier_a", token_next);
+                }
+                name = token_next;
+                enroll(name, "variable", true);
+                the_function.name = name;
+                name.init = true;
+                name.calls = empty();
+                advance();
+            } else if (name === undefined) {
+
+// A function expression may have an optional name.
+
+                if (token_next.identifier) {
+                    name = token_next;
+                    the_function.name = name;
+                    advance();
+                } else {
+                    the_function.name = anon;
+                }
+            }
+        } else {
+            name = the_function.name;
+        }
+        the_function.level = functionage.level + 1;
+        assert_or_throw(!mega_mode, `Expected !mega_mode.`);
+//  Probably deadcode.
+//  if (mega_mode) {
+//      warn("unexpected_a", the_function);
+//  }
+
+// Don't make functions in loops. It is inefficient, and it can lead to scoping
+// errors.
+
+        if (functionage.loop > 0) {
+
+// cause: "while(0){aa.map(function(){});}"
+
+            warn("function_in_loop", the_function);
+        }
+
+// Give the function properties for storing its names and for observing the
+// depth of loops and switches.
+
+        the_function.context = empty();
+        the_function.finally = 0;
+        the_function.loop = 0;
+        the_function.switch = 0;
+        the_function.try = 0;
+
+// Push the current function context and establish a new one.
+
+        stack.push(functionage);
+        functions.push(the_function);
+        functionage = the_function;
+        if (the_function.arity !== "statement" && typeof name === "object") {
+
+// cause: "let aa=function bb(){return;};"
+
+            enroll(name, "function", true);
+            name.dead = false;
+            name.init = true;
+            name.used = 1;
+        }
+
+// Parse the parameter list.
+
+        advance("(");
+
+// cause: "function(){}"
+
+        token_curr.free = false;
+        token_curr.arity = "function";
+        [functionage.parameters, functionage.signature] = parameter_list();
+        functionage.parameters.forEach(function enroll_parameter(name) {
+            if (name.identifier) {
+                enroll(name, "parameter", false);
+            } else {
+                name.names.forEach(enroll_parameter);
+            }
+        });
+
+// The function's body is a block.
+
+        the_function.block = block("body");
+        if (
+            the_function.arity === "statement"
+            && token_next.line === token_curr.line
+        ) {
+
+// cause: "function aa(){}0"
+
+            return stop("unexpected_a", token_next);
+        }
+        if (
+            token_next.id === "."
+            || token_next.id === "?."
+            || token_next.id === "["
+        ) {
+
+// cause: "function aa(){}\n[]"
+
+            warn("unexpected_a");
+        }
+
+// Restore the previous context.
+
+        functionage = stack.pop();
+        return the_function;
+    }
+
+    function do_async() {
+        let the_async;
+        let the_function;
+        the_async = token_curr;
+        advance("function");
+        the_function = token_curr;
+        the_function.is_async = true;
+        the_function.arity = the_async.arity;
+        do_function();
+        if (!the_function.has_await) {
+
+// cause: "async function aa(){}"
+
+            warn("missing_await_statement", the_function);
+        }
+        return the_function;
+    }
+
+    prefix("async", do_async);
+    prefix("function", do_function);
+    prefix("await", function () {
+        let the_await;
+        the_await = token_curr;
+        if (!functionage.is_async) {
+
+// cause: "await"
+// cause: "function aa(){await 0;}"
+
+            return stop("unexpected_a", the_await);
+        }
+        functionage.has_await = true;
+        the_await.expression = expression(150);
+        return the_await;
+    });
+
+    function fart(pl) {
+        advance("=>");
+        const the_fart = token_curr;
+        the_fart.arity = "binary";
+        the_fart.name = "=>";
+        the_fart.level = functionage.level + 1;
+        functions.push(the_fart);
+        if (functionage.loop > 0) {
+
+// cause: "while(0){aa.map(()=>0);}"
+
+            warn("function_in_loop", the_fart);
+        }
+
+// Give the function properties storing its names and for observing the depth
+// of loops and switches.
+
+        the_fart.context = empty();
+        the_fart.finally = 0;
+        the_fart.loop = 0;
+        the_fart.switch = 0;
+        the_fart.try = 0;
+
+// Push the current function context and establish a new one.
+
+        stack.push(functionage);
+        functionage = the_fart;
+        the_fart.parameters = pl[0];
+        the_fart.signature = pl[1];
+        the_fart.parameters.forEach(function (name) {
+
+// cause: "(aa)=>{}"
+
+            enroll(name, "parameter", true);
+        });
+        if (token_next.id === "{") {
+
+// cause: "()=>{}"
+
+            warn("expected_a_b", the_fart, "function", "=>");
+            the_fart.block = block("body");
+        } else {
+            the_fart.expression = expression(0);
+        }
+        functionage = stack.pop();
+        return the_fart;
+    }
+
+    prefix("(", function () {
+        const the_paren = token_curr;
+        let the_value;
+        const cadet = lookahead().id;
+
+// We can distinguish between a parameter list for => and a wrapped expression
+// with one token of lookahead.
+
+        if (
+            token_next.id === ")"
+            || token_next.id === "..."
+            || (token_next.identifier && (cadet === "," || cadet === "="))
+        ) {
+
+// cause: "()=>0"
+
+            the_paren.free = false;
+            return fart(parameter_list());
+        }
+
+// cause: "(0)"
+
+        the_paren.free = true;
+        the_value = expression(0);
+        if (the_value.wrapped === true) {
+
+// cause: "((0))"
+
+            warn("unexpected_a", the_paren);
+        }
+        the_value.wrapped = true;
+        advance(")", the_paren);
+        if (token_next.id === "=>") {
+            if (the_value.arity !== "variable") {
+                if (the_value.id === "{" || the_value.id === "[") {
+
+// cause: "([])=>0"
+// cause: "({})=>0"
+
+                    warn("expected_a_before_b", the_paren, "function", "(");
+
+// cause: "([])=>0"
+// cause: "({})=>0"
+
+                    return stop("expected_a_b", token_next, "{", "=>");
+                }
+
+// cause: "(0)=>0"
+
+                return stop("expected_identifier_a", the_value);
+            }
+            the_paren.expression = [the_value];
+            return fart([the_paren.expression, "(" + the_value.id + ")"]);
+        }
+        return the_value;
+    });
+    prefix("`", do_tick);
+    prefix("{", function () {
+        const the_brace = token_curr;
+        const seen = empty();
+        the_brace.expression = [];
+        if (token_next.id !== "}") {
+            let a;
+            let b = "";
+            (function member() {
+                let extra;
+                let full;
+                let id;
+                let name = token_next;
+                let value;
+                advance();
+                a = b;
+                b = String(name.value || name.id);
+                if (!option.unordered && a > b) {
+
+// cause: "aa={bb,aa}"
+
+                    warn("unordered_a_b", name, "Property", artifact(name));
+                }
+                if (
+                    (name.id === "get" || name.id === "set")
+                    && token_next.identifier
+                ) {
+                    if (!option.getset) {
+
+// cause: "aa={get aa(){}}"
+
+                        warn("unexpected_a", name);
+                    }
+                    extra = name.id;
+                    full = extra + " " + token_next.id;
+                    name = token_next;
+                    advance();
+                    id = survey(name);
+                    if (seen[full] === true || seen[id] === true) {
+
+// cause: "aa={get aa(){},get aa(){}}"
+
+                        warn("duplicate_a", name);
+                    }
+                    seen[id] = false;
+                    seen[full] = true;
+                } else {
+                    id = survey(name);
+                    if (typeof seen[id] === "boolean") {
+
+// cause: "aa={aa,aa}"
+
+                        warn("duplicate_a", name);
+                    }
+                    seen[id] = true;
+                }
+                if (name.identifier) {
+                    if (token_next.id === "}" || token_next.id === ",") {
+                        if (typeof extra === "string") {
+
+// cause: "aa={get aa}"
+
+                            advance("(");
+                        }
+                        value = expression(Infinity, true);
+                    } else if (token_next.id === "(") {
+                        value = do_function({
+                            arity: "unary",
+                            from: name.from,
+                            id: "function",
+                            line: name.line,
+                            name: (
+                                typeof extra === "string"
+
+// cause: "aa={get aa(){}}"
+
+                                ? extra
+
+// cause: "aa={aa()}"
+
+                                : id
+                            ),
+                            thru: name.from
+                        });
+                    } else {
+                        if (typeof extra === "string") {
+
+// cause: "aa={get aa.aa}"
+
+                            advance("(");
+                        }
+                        let the_colon = token_next;
+                        advance(":");
+                        value = expression(0);
+                        if (value.id === name.id && value.id !== "function") {
+
+// cause: "aa={aa:aa}"
+
+                            warn("unexpected_a", the_colon, ": " + name.id);
+                        }
+                    }
+                    value.label = name;
+                    if (typeof extra === "string") {
+                        value.extra = extra;
+                    }
+                    the_brace.expression.push(value);
+                } else {
+                    advance(":");
+                    value = expression(0);
+                    value.label = name;
+                    the_brace.expression.push(value);
+                }
+                if (token_next.id === ",") {
+                    advance(",");
+                    return member();
+                }
+            }());
+        }
+        advance("}");
+        return the_brace;
+    });
+
+    stmt(";", function () {
+
+// cause: ";"
+
+        warn("unexpected_a", token_curr);
+        return token_curr;
+    });
+    stmt("{", function () {
+
+// cause: ";{}"
+// cause: "class aa{}"
+
+        warn("naked_block", token_curr);
+        return block("naked");
+    });
+    stmt("async", do_async);
+    stmt("break", function () {
+        const the_break = token_curr;
+        let the_label;
+        if (
+            (functionage.loop < 1 && functionage.switch < 1)
+            || functionage.finally > 0
+        ) {
+
+// cause: "break"
+
+            warn("unexpected_a", the_break);
+        }
+        the_break.disrupt = true;
+        if (token_next.identifier && token_curr.line === token_next.line) {
+            the_label = functionage.context[token_next.id];
+            if (
+                the_label === undefined
+                || the_label.role !== "label"
+                || the_label.dead
+            ) {
+                if (the_label !== undefined && the_label.dead) {
+
+// cause: "aa:{function aa(aa){break aa;}}"
+
+                    warn("out_of_scope_a");
+                } else {
+
+// cause: "aa:{break aa;}"
+
+                    warn("not_label_a");
+                }
+            } else {
+                the_label.used += 1;
+            }
+            the_break.label = token_next;
+            advance();
+        }
+        advance(";");
+        return the_break;
+    });
+
+    function do_var() {
+        const the_statement = token_curr;
+        const is_const = the_statement.id === "const";
+        the_statement.names = [];
+
+// A program may use var or let, but not both.
+
+        if (!is_const) {
+            if (var_mode === undefined) {
+                var_mode = the_statement.id;
+            } else if (the_statement.id !== var_mode) {
+
+// cause: "let aa;var aa"
+
+                warn(
+                    "expected_a_b",
+                    the_statement,
+                    var_mode,
+                    the_statement.id
+                );
+            }
+        }
+
+// We don't expect to see variables created in switch statements.
+
+        if (functionage.switch > 0) {
+
+// cause: "switch(0){case 0:var aa}"
+
+            warn("var_switch", the_statement);
+        }
+        if (functionage.loop > 0 && the_statement.id === "var") {
+
+// cause: "while(0){var aa;}"
+
+            warn("var_loop", the_statement);
+        }
+        (function next() {
+            if (token_next.id === "{" && the_statement.id !== "var") {
+                let a;
+                let b = "";
+                const the_brace = token_next;
+                advance("{");
+                (function pair() {
+                    if (!token_next.identifier) {
+
+// cause: "let {0}"
+
+                        return stop("expected_identifier_a", token_next);
+                    }
+                    const name = token_next;
+                    survey(name);
+                    a = b;
+                    b = String(name.value || name.id);
+                    if (!option.unordered && a > b) {
+
+// cause: "let{bb,aa}"
+
+                        warn(
+                            "unordered_a_b",
+                            name,
+                            "Parameter",
+                            artifact(name)
+                        );
+                    }
+                    advance();
+                    if (token_next.id === ":") {
+                        advance(":");
+                        if (!token_next.identifier) {
+
+// cause: "let {aa:0}"
+// cause: "let {aa:{aa}}"
+
+                            return stop("expected_identifier_a", token_next);
+                        }
+                        token_next.label = name;
+                        the_statement.names.push(token_next);
+                        enroll(token_next, "variable", is_const);
+                        advance();
+                        the_brace.open = true;
+                    } else {
+                        the_statement.names.push(name);
+                        enroll(name, "variable", is_const);
+                    }
+                    name.dead = false;
+                    name.init = true;
+                    if (token_next.id === "=") {
+
+// cause: "let {aa=0}"
+
+                        advance("=");
+                        name.expression = expression();
+                        the_brace.open = true;
+                    }
+                    if (token_next.id === ",") {
+                        advance(",");
+                        return pair();
+                    }
+                }());
+                advance("}");
+                advance("=");
+                the_statement.expression = expression(0);
+            } else if (token_next.id === "[" && the_statement.id !== "var") {
+                const the_bracket = token_next;
+                advance("[");
+                (function element() {
+                    let ellipsis;
+                    if (token_next.id === "...") {
+                        ellipsis = true;
+                        advance("...");
+                    }
+                    if (!token_next.identifier) {
+
+// cause: "let[]"
+
+                        return stop("expected_identifier_a", token_next);
+                    }
+                    const name = token_next;
+                    advance();
+                    the_statement.names.push(name);
+                    enroll(name, "variable", is_const);
+                    name.dead = false;
+                    name.init = true;
+                    if (ellipsis) {
+                        name.ellipsis = true;
+                    } else {
+                        if (token_next.id === "=") {
+                            advance("=");
+                            name.expression = expression();
+                            the_bracket.open = true;
+                        }
+                        if (token_next.id === ",") {
+                            advance(",");
+                            return element();
+                        }
+                    }
+                }());
+                advance("]");
+                advance("=");
+                the_statement.expression = expression(0);
+            } else if (token_next.identifier) {
+                const name = token_next;
+                advance();
+                if (name.id === "ignore") {
+
+// cause: "let ignore;function aa(ignore) {}"
+
+                    warn("unexpected_a", name);
+                }
+                enroll(name, "variable", is_const);
+                if (token_next.id === "=" || is_const) {
+                    advance("=");
+                    name.dead = false;
+                    name.init = true;
+                    name.expression = expression(0);
+                }
+                the_statement.names.push(name);
+            } else {
+
+// cause: "let 0"
+// cause: "var{aa:{aa}}"
+
+                return stop("expected_identifier_a", token_next);
+            }
+        }());
+        semicolon();
+        return the_statement;
+    }
+
+    stmt("const", do_var);
+    stmt("continue", function () {
+        const the_continue = token_curr;
+        if (functionage.loop < 1 || functionage.finally > 0) {
+
+// cause: "continue"
+// cause: "function aa(){while(0){try{}finally{continue}}}"
+
+            warn("unexpected_a", the_continue);
+        }
+        not_top_level(the_continue);
+        the_continue.disrupt = true;
+        warn("unexpected_a", the_continue);
+        advance(";");
+        return the_continue;
+    });
+    stmt("debugger", function () {
+        const the_debug = token_curr;
+        if (!option.devel) {
+
+// cause: "debugger"
+
+            warn("unexpected_a", the_debug);
+        }
+        semicolon();
+        return the_debug;
+    });
+    stmt("delete", function () {
+        const the_token = token_curr;
+        const the_value = expression(0);
+        if (
+            (the_value.id !== "." && the_value.id !== "[")
+            || the_value.arity !== "binary"
+        ) {
+
+// cause: "delete 0"
+
+            stop("expected_a_b", the_value, ".", artifact(the_value));
+        }
+        the_token.expression = the_value;
+        semicolon();
+        return the_token;
+    });
+    stmt("do", function () {
+        const the_do = token_curr;
+        not_top_level(the_do);
+        functionage.loop += 1;
+        the_do.block = block();
+        advance("while");
+        the_do.expression = condition();
+        semicolon();
+        if (the_do.block.disrupt === true) {
+
+// cause: "function aa(){do{break;}while(0)}"
+
+            warn("weird_loop", the_do);
+        }
+        functionage.loop -= 1;
+        return the_do;
+    });
+    stmt("export", function () {
+        const the_export = token_curr;
+        let the_id;
+        let the_name;
+        let the_thing;
+
+        function export_id() {
+            if (!token_next.identifier) {
+
+// cause: "export {}"
+
+                stop("expected_identifier_a");
+            }
+            the_id = token_next.id;
+            the_name = global.context[the_id];
+            if (the_name === undefined) {
+
+// cause: "export {aa}"
+
+                warn("unexpected_a");
+            } else {
+                the_name.used += 1;
+                if (exports[the_id] !== undefined) {
+
+// cause: "let aa;export{aa,aa}"
+
+                    warn("duplicate_a");
+                }
+                exports[the_id] = the_name;
+            }
+            advance();
+            the_export.expression.push(the_thing);
+        }
+
+        the_export.expression = [];
+        if (token_next.id === "default") {
+            if (exports.default !== undefined) {
+
+// cause: "export default 0;export default 0"
+
+                warn("duplicate_a");
+            }
+            advance("default");
+            the_thing = expression(0);
+            if (
+                the_thing.id !== "("
+                || the_thing.expression[0].id !== "."
+                || the_thing.expression[0].expression.id !== "Object"
+                || the_thing.expression[0].name.id !== "freeze"
+            ) {
+
+// cause: "export default {}"
+
+                warn("freeze_exports", the_thing);
+            } else {
+
+// cause: "export default Object.freeze({})"
+
+                semicolon();
+            }
+            exports.default = the_thing;
+            the_export.expression.push(the_thing);
+        } else {
+            if (token_next.id === "function") {
+
+// cause: "export function aa(){}"
+
+                warn("freeze_exports");
+                the_thing = statement();
+                the_name = the_thing.name;
+                the_id = the_name.id;
+                the_name.used += 1;
+
+// cause: "let aa;export{aa};export function aa(){}"
+
+                if (exports[the_id] !== undefined) {
+                    warn("duplicate_a", the_name);
+                }
+                exports[the_id] = the_thing;
+                the_export.expression.push(the_thing);
+                the_thing.statement = false;
+                the_thing.arity = "unary";
+            } else if (
+                token_next.id === "var"
+                || token_next.id === "let"
+                || token_next.id === "const"
+            ) {
+
+// cause: "export const"
+// cause: "export let"
+// cause: "export var"
+
+                warn("unexpected_a", token_next);
+                statement();
+            } else if (token_next.id === "{") {
+
+// cause: "export {}"
+
+                advance("{");
+                (function loop() {
+                    export_id();
+                    if (token_next.id === ",") {
+                        advance(",");
+                        return loop();
+                    }
+                }());
+                advance("}");
+                semicolon();
+            } else {
+
+// cause: "export"
+
+                stop("unexpected_a");
+            }
+        }
+        module_mode = true;
+        return the_export;
+    });
+    stmt("for", function () {
+        let first;
+        const the_for = token_curr;
+        if (!option.for) {
+
+// cause: "for"
+
+            warn("unexpected_a", the_for);
+        }
+        not_top_level(the_for);
+        functionage.loop += 1;
+        advance("(");
+
+// cause: "for(){}"
+
+        token_curr.free = true;
+        if (token_next.id === ";") {
+
+// cause: "for(;;){}"
+
+            return stop("expected_a_b", the_for, "while (", "for (;");
+        }
+        if (
+            token_next.id === "var"
+            || token_next.id === "let"
+            || token_next.id === "const"
+        ) {
+
+// cause: "for(const aa in aa){}"
+
+            return stop("unexpected_a");
+        }
+        first = expression(0);
+        if (first.id === "in") {
+            if (first.expression[0].arity !== "variable") {
+
+// cause: "for(0 in aa){}"
+
+                warn("bad_assignment_a", first.expression[0]);
+            }
+            the_for.name = first.expression[0];
+            the_for.expression = first.expression[1];
+            warn("expected_a_b", the_for, "Object.keys", "for in");
+        } else {
+            the_for.initial = first;
+            advance(";");
+            the_for.expression = expression(0);
+            advance(";");
+            the_for.inc = expression(0);
+            if (the_for.inc.id === "++") {
+
+// cause: "for(aa;aa;aa++){}"
+
+                warn("expected_a_b", the_for.inc, "+= 1", "++");
+            }
+        }
+        advance(")");
+        the_for.block = block();
+        if (the_for.block.disrupt === true) {
+
+// cause: "/*jslint for*/\nfunction aa(bb,cc){for(0;0;0){break;}}"
+
+            warn("weird_loop", the_for);
+        }
+        functionage.loop -= 1;
+        return the_for;
+    });
+    stmt("function", do_function);
+    stmt("if", function () {
+        let the_else;
+        const the_if = token_curr;
+        the_if.expression = condition();
+        the_if.block = block();
+        if (token_next.id === "else") {
+            advance("else");
+            the_else = token_curr;
+            the_if.else = (
+                token_next.id === "if"
+
+// cause: "if(0){0}else if(0){0}"
+
+                ? statement()
+
+// cause: "if(0){0}else{0}"
+
+                : block()
+            );
+            if (the_if.block.disrupt === true) {
+                if (the_if.else.disrupt === true) {
+
+// cause: "if(0){break;}else{}"
+
+                    the_if.disrupt = true;
+                } else {
+
+// cause: "if(0){break;}else{}"
+
+                    warn("unexpected_a", the_else);
+                }
+            }
+        }
+        return the_if;
+    });
+    stmt("import", function () {
+        const the_import = token_curr;
+        if (token_next.id === "(") {
+            the_import.arity = "unary";
+            the_import.constant = true;
+            the_import.statement = false;
+            advance("(");
+            const string = expression(0);
+            if (string.id !== "(string)") {
+
+// cause: "import(aa)"
+
+                warn("expected_string_a", string);
+            }
+            froms.push(token_curr.value);
+            advance(")");
+            advance(".");
+            advance("then");
+            advance("(");
+            the_import.expression = expression(0);
+            advance(")");
+            semicolon();
+            return the_import;
+        }
+        let name;
+        if (typeof module_mode === "object") {
+
+// cause: "/*global aa*/\nimport aa from \"aa\""
+
+            warn("unexpected_directive_a", module_mode, module_mode.directive);
+        }
+        module_mode = true;
+        if (token_next.identifier) {
+            name = token_next;
+            advance();
+            if (name.id === "ignore") {
+
+// cause: "import ignore from \"aa\""
+
+                warn("unexpected_a", name);
+            }
+            enroll(name, "variable", true);
+            the_import.name = name;
+        } else {
+            const names = [];
+            advance("{");
+            if (token_next.id !== "}") {
+                while (true) {
+                    if (!token_next.identifier) {
+
+// cause: "import {"
+
+                        stop("expected_identifier_a");
+                    }
+                    name = token_next;
+                    advance();
+                    if (name.id === "ignore") {
+
+// cause: "import {ignore} from \"aa\""
+
+                        warn("unexpected_a", name);
+                    }
+                    enroll(name, "variable", true);
+                    names.push(name);
+                    if (token_next.id !== ",") {
+                        break;
+                    }
+                    advance(",");
+                }
+            }
+            advance("}");
+            the_import.name = names;
+        }
+        advance("from");
+        advance("(string)");
+        the_import.import = token_curr;
+        if (!rx_module.test(token_curr.value)) {
+
+// cause: "import aa from \"!aa\""
+
+            warn("bad_module_name_a", token_curr);
+        }
+        froms.push(token_curr.value);
+        semicolon();
+        return the_import;
+    });
+    stmt("let", do_var);
+    stmt("return", function () {
+        const the_return = token_curr;
+        not_top_level(the_return);
+        if (functionage.finally > 0) {
+
+// cause: "function aa(){try{}finally{return;}}"
+
+            warn("unexpected_a", the_return);
+        }
+        the_return.disrupt = true;
+        if (token_next.id !== ";" && the_return.line === token_next.line) {
+            the_return.expression = expression(10);
+        }
+        advance(";");
+        return the_return;
+    });
+    stmt("switch", function () {
+        let dups = [];
+        let last;
+        let stmts;
+        const the_cases = [];
+        let the_disrupt = true;
+        const the_switch = token_curr;
+        not_top_level(the_switch);
+        if (functionage.finally > 0) {
+
+// cause: "function aa(){try{}finally{switch(0){}}}"
+
+            warn("unexpected_a", the_switch);
+        }
+        functionage.switch += 1;
+        advance("(");
+
+// cause: "switch(){}"
+
+        token_curr.free = true;
+        the_switch.expression = expression(0);
+        the_switch.block = the_cases;
+        advance(")");
+        advance("{");
+        (function major() {
+            const the_case = token_next;
+            the_case.arity = "statement";
+            the_case.expression = [];
+            (function minor() {
+                advance("case");
+                token_curr.switch = true;
+                const exp = expression(0);
+                if (dups.some(function (thing) {
+                    return are_similar(thing, exp);
+                })) {
+
+// cause: "switch(0){case 0:break;case 0:break}"
+
+                    warn("unexpected_a", exp);
+                }
+                dups.push(exp);
+                the_case.expression.push(exp);
+                advance(":");
+                if (token_next.id === "case") {
+                    return minor();
+                }
+            }());
+            stmts = statements();
+            if (stmts.length < 1) {
+
+// cause: "switch(0){case 0:}"
+
+                warn("expected_statements_a");
+                return;
+            }
+            the_case.block = stmts;
+            the_cases.push(the_case);
+            last = stmts[stmts.length - 1];
+            if (last.disrupt) {
+                if (last.id === "break" && last.label === undefined) {
+                    the_disrupt = false;
+                }
+            } else {
+                warn(
+                    "expected_a_before_b",
+                    token_next,
+                    "break;",
+                    artifact(token_next)
+                );
+            }
+            if (token_next.id === "case") {
+                return major();
+            }
+        }());
+        dups = undefined;
+        if (token_next.id === "default") {
+            const the_default = token_next;
+            advance("default");
+            token_curr.switch = true;
+            advance(":");
+            the_switch.else = statements();
+            if (the_switch.else.length < 1) {
+
+// cause: "switch(0){case 0:break;default:}"
+
+                warn("unexpected_a", the_default);
+                the_disrupt = false;
+            } else {
+                const the_last = the_switch.else[the_switch.else.length - 1];
+                if (the_last.id === "break" && the_last.label === undefined) {
+
+// cause: "switch(0){case 0:break;default:break;}"
+
+                    warn("unexpected_a", the_last);
+                    the_last.disrupt = false;
+                }
+                the_disrupt = the_disrupt && the_last.disrupt;
+            }
+        } else {
+            the_disrupt = false;
+        }
+        advance("}", the_switch);
+        functionage.switch -= 1;
+        the_switch.disrupt = the_disrupt;
+        return the_switch;
+    });
+    stmt("throw", function () {
+        const the_throw = token_curr;
+        the_throw.disrupt = true;
+        the_throw.expression = expression(10);
+        semicolon();
+        if (functionage.try > 0) {
+
+// cause: "try{throw 0}catch(){}"
+
+            warn("unexpected_a", the_throw);
+        }
+        return the_throw;
+    });
+    stmt("try", function () {
+        const the_try = token_curr;
+        let ignored;
+        let the_catch;
+        let the_disrupt;
+        if (functionage.try > 0) {
+
+// cause: "try{try{}catch(){}}catch(){}"
+
+            warn("unexpected_a", the_try);
+        }
+        functionage.try += 1;
+        the_try.block = block();
+        the_disrupt = the_try.block.disrupt;
+        if (token_next.id === "catch") {
+            advance("catch");
+            the_catch = token_next;
+            ignored = "ignore";
+            the_try.catch = the_catch;
+
+// Create new function-scope for catch-parameter.
+
+            stack.push(functionage);
+            functionage = the_catch;
+            functionage.context = empty();
+            if (token_next.id === "(") {
+                advance("(");
+                if (!token_next.identifier) {
+
+// cause: "try{}catch(){}"
+
+                    return stop("expected_identifier_a", token_next);
+                }
+                if (token_next.id !== "ignore") {
+                    ignored = undefined;
+                    the_catch.name = token_next;
+                    enroll(token_next, "exception", true);
+                }
+                advance();
+                advance(")");
+            }
+            the_catch.block = block(ignored);
+            if (the_catch.block.disrupt !== true) {
+                the_disrupt = false;
+            }
+
+// Restore previous function-scope after catch-block.
+
+            functionage = stack.pop();
+        } else {
+
+// cause: "try{}finally{break;}"
+
+            warn(
+                "expected_a_before_b",
+                token_next,
+                "catch",
+                artifact(token_next)
+            );
+
+        }
+        if (token_next.id === "finally") {
+            functionage.finally += 1;
+            advance("finally");
+            the_try.else = block();
+            the_disrupt = the_try.else.disrupt;
+            functionage.finally -= 1;
+        }
+        the_try.disrupt = the_disrupt;
+        functionage.try -= 1;
+        return the_try;
+    });
+    stmt("var", do_var);
+    stmt("while", function () {
+        const the_while = token_curr;
+        not_top_level(the_while);
+        functionage.loop += 1;
+        the_while.expression = condition();
+        the_while.block = block();
+        if (the_while.block.disrupt === true) {
+
+// cause: "function aa(){while(0){break;}}"
+
+            warn("weird_loop", the_while);
+        }
+        functionage.loop -= 1;
+        return the_while;
+    });
+    stmt("with", function () {
+
+// cause: "with"
+
+        stop("unexpected_a", token_curr);
+    });
+
+    ternary("?", ":");
+
+// Ambulation of the parse tree.
+
+    function action(when) {
+
+// Produce a function that will register task functions that will be called as
+// the tree is traversed.
+
+        return function (arity, id, task) {
+            let a_set = when[arity];
+            let i_set;
+
+// The id parameter is optional. If excluded, the task will be applied to all
+// ids.
+
+            if (typeof id !== "string") {
+                task = id;
+                id = "(all)";
+            }
+
+// If this arity has no registrations yet, then create a set object to hold
+// them.
+
+            if (a_set === undefined) {
+                a_set = empty();
+                when[arity] = a_set;
+            }
+
+// If this id has no registrations yet, then create a set array to hold them.
+
+            i_set = a_set[id];
+            if (i_set === undefined) {
+                i_set = [];
+                a_set[id] = i_set;
+            }
+
+// Register the task with the arity and the id.
+
+            i_set.push(task);
+        };
+    }
+
+    function amble(when) {
+
+// Produce a function that will act on the tasks registered by an action
+// function while walking the tree.
+
+        return function (the_token) {
+
+// Given a task set that was built by an action function, run all of the
+// relevant tasks on the token.
+
+            let a_set = when[the_token.arity];
+            let i_set;
+
+// If there are tasks associated with the token's arity...
+
+            if (a_set !== undefined) {
+
+// If there are tasks associated with the token's id...
+
+                i_set = a_set[the_token.id];
+                if (i_set !== undefined) {
+                    i_set.forEach(function (task) {
+                        return task(the_token);
+                    });
+                }
+
+// If there are tasks for all ids.
+
+                i_set = a_set["(all)"];
+                if (i_set !== undefined) {
+                    i_set.forEach(function (task) {
+                        return task(the_token);
+                    });
+                }
+            }
+        };
+    }
+
+    const posts = empty();
+    const pres = empty();
+    const preaction = action(pres);
+    const postaction = action(posts);
+    const preamble = amble(pres);
+    const postamble = amble(posts);
+
+    function walk_expression(thing) {
+        if (thing) {
+            if (Array.isArray(thing)) {
+
+// cause: "(function(){}())"
+// cause: "0&&0"
+
+                thing.forEach(walk_expression);
+            } else {
+                preamble(thing);
+                walk_expression(thing.expression);
+                if (thing.id === "function") {
+
+// cause: "aa=function(){}"
+
+                    walk_statement(thing.block);
+                }
+                if (thing.arity === "pre" || thing.arity === "post") {
+
+// cause: "aa=++aa"
+// cause: "aa=--aa"
+
+                    warn("unexpected_a", thing);
+                } else if (
+
+// cause: "aa=0"
+
+                    thing.arity === "statement"
+                    || thing.arity === "assignment"
+                ) {
+
+// cause: "aa[aa=0]"
+
+                    warn("unexpected_statement_a", thing);
+                }
+                postamble(thing);
+            }
+        }
+    }
+
+    function walk_statement(thing) {
+        if (thing) {
+            if (Array.isArray(thing)) {
+
+// cause: "+[]"
+
+                thing.forEach(walk_statement);
+            } else {
+                preamble(thing);
+                walk_expression(thing.expression);
+                if (thing.arity === "binary") {
+                    if (thing.id !== "(") {
+
+// cause: "0&&0"
+
+                        warn("unexpected_expression_a", thing);
+                    }
+                } else if (
+                    thing.arity !== "statement"
+                    && thing.arity !== "assignment"
+                    && thing.id !== "import"
+                    && thing.id !== "await"
+                ) {
+
+// cause: "!0"
+// cause: "+[]"
+// cause: "+new aa()"
+// cause: "0"
+
+                    warn("unexpected_expression_a", thing);
+                }
+                walk_statement(thing.block);
+                walk_statement(thing.else);
+                postamble(thing);
+            }
+        }
+    }
+
+    function lookup(thing) {
+        if (thing.arity === "variable") {
+
+// Look up the variable in the current context.
+
+            let the_variable = functionage.context[thing.id];
+
+// If it isn't local, search all the other contexts. If there are name
+// collisions, take the most recent.
+
+            if (the_variable === undefined) {
+                stack.forEach(function (outer) {
+                    const a_variable = outer.context[thing.id];
+                    if (
+                        a_variable !== undefined
+                        && a_variable.role !== "label"
+                    ) {
+                        the_variable = a_variable;
+                    }
+                });
+
+// If it isn't in any of those either, perhaps it is a predefined global.
+// If so, add it to the global context.
+
+                if (the_variable === undefined) {
+                    if (declared_globals[thing.id] === undefined) {
+
+// cause: "aa"
+// cause: "class aa{}"
+// cause: "let aa=0;try{aa();}catch(bb){bb();}bb();"
+
+                        warn("undeclared_a", thing);
+                        return;
+                    }
+                    the_variable = {
+                        dead: false,
+                        id: thing.id,
+                        init: true,
+                        parent: global,
+                        role: "variable",
+                        used: 0,
+                        writable: false
+                    };
+                    global.context[thing.id] = the_variable;
+                }
+                the_variable.closure = true;
+                functionage.context[thing.id] = the_variable;
+            } else if (the_variable.role === "label") {
+
+// cause: "aa:while(0){aa;}"
+
+                warn("label_a", thing);
+            }
+            if (
+                the_variable.dead
+                && (
+                    the_variable.calls === undefined
+                    || functionage.name === undefined
+                    || the_variable.calls[functionage.name.id] === undefined
+                )
+            ) {
+
+// cause: "function aa(){bb();}\nfunction bb(){}"
+
+                warn("out_of_scope_a", thing);
+            }
+            return the_variable;
+        }
+    }
+
+    function subactivate(name) {
+        name.init = true;
+        name.dead = false;
+        blockage.live.push(name);
+    }
+
+    function preaction_function(thing) {
+
+// cause: "()=>0"
+// cause: "(function (){}())"
+// cause: "function aa(){}"
+
+        if (thing.arity === "statement" && blockage.body !== true) {
+
+// cause: "if(0){function aa(){}\n}"
+
+            warn("unexpected_a", thing);
+        }
+        stack.push(functionage);
+        block_stack.push(blockage);
+        functionage = thing;
+        blockage = thing;
+        thing.live = [];
+        if (typeof thing.name === "object") {
+            thing.name.dead = false;
+            thing.name.init = true;
+        }
+        if (thing.extra === "get") {
+            if (thing.parameters.length !== 0) {
+
+// cause: "/*jslint getset*/\naa={get aa(aa){}}"
+
+                warn("bad_get", thing);
+            }
+        } else if (thing.extra === "set") {
+            if (thing.parameters.length !== 1) {
+
+// cause: "/*jslint getset*/\naa={set aa(){}}"
+
+                warn("bad_set", thing);
+            }
+        }
+        thing.parameters.forEach(function (name) {
+            walk_expression(name.expression);
+            if (name.id === "{" || name.id === "[") {
+                name.names.forEach(subactivate);
+            } else {
+                name.dead = false;
+                name.init = true;
+            }
+        });
+    }
+
+    function bitwise_check(thing) {
+        if (!option.bitwise && bitwiseop[thing.id] === true) {
+
+// cause: "0&0"
+// cause: "0&=0"
+// cause: "0<<0"
+// cause: "0<<=0"
+// cause: "0>>0"
+// cause: "0>>=0"
+// cause: "0>>>0"
+// cause: "0>>>=0"
+// cause: "0^0"
+// cause: "0^=0"
+// cause: "0|0"
+// cause: "0|=0"
+// cause: "0~0"
+// cause: "~0"
+
+            warn("unexpected_a", thing);
+        }
+        if (
+            thing.id !== "("
+            && thing.id !== "&&"
+            && thing.id !== "||"
+            && thing.id !== "="
+            && Array.isArray(thing.expression)
+            && thing.expression.length === 2
+            && (
+                relationop[thing.expression[0].id] === true
+                || relationop[thing.expression[1].id] === true
+            )
+        ) {
+
+// cause: "0<0<0"
+
+            warn("unexpected_a", thing);
+        }
+    }
+
+    function pop_block() {
+        blockage.live.forEach(function (name) {
+            name.dead = true;
+        });
+        delete blockage.live;
+        blockage = block_stack.pop();
+    }
+
+    function action_var(thing) {
+        thing.names.forEach(function (name) {
+            name.dead = false;
+            if (name.expression !== undefined) {
+                walk_expression(name.expression);
+                assert_or_throw(
+                    !(name.id === "{" || name.id === "["),
+                    `Expected !(name.id === "{" || name.id === "[").`
+                );
+//          Probably deadcode.
+//          if (name.id === "{" || name.id === "[") {
+//              name.names.forEach(subactivate);
+//          } else {
+//              name.init = true;
+//          }
+                name.init = true;
+            }
+            blockage.live.push(name);
+        });
+    }
+
+    preaction("assignment", bitwise_check);
+    preaction("binary", bitwise_check);
+    preaction("binary", function (thing) {
+        if (relationop[thing.id] === true) {
+            const left = thing.expression[0];
+            const right = thing.expression[1];
+            if (left.id === "NaN" || right.id === "NaN") {
+
+// cause: "NaN===NaN"
+
+                warn("number_isNaN", thing);
+            } else if (left.id === "typeof") {
+                if (right.id !== "(string)") {
+                    if (right.id !== "typeof") {
+
+// cause: "typeof 0===0"
+
+                        warn("expected_string_a", right);
+                    }
+                } else {
+                    const value = right.value;
+                    if (value === "null" || value === "undefined") {
+
+// cause: "typeof aa===\"undefined\""
+
+                        warn("unexpected_typeof_a", right, value);
+                    } else if (
+                        value !== "boolean"
+                        && value !== "function"
+                        && value !== "number"
+                        && value !== "object"
+                        && value !== "string"
+                        && value !== "symbol"
+                    ) {
+
+// cause: "typeof 0===\"aa\""
+
+                        warn("expected_type_string_a", right, value);
+                    }
+                }
+            }
+        }
+    });
+    preaction("binary", "==", function (thing) {
+
+// cause: "0==0"
+
+        warn("expected_a_b", thing, "===", "==");
+    });
+    preaction("binary", "!=", function (thing) {
+
+// cause: "0!=0"
+
+        warn("expected_a_b", thing, "!==", "!=");
+    });
+    preaction("binary", "=>", preaction_function);
+    preaction("binary", "||", function (thing) {
+        thing.expression.forEach(function (thang) {
+            if (thang.id === "&&" && !thang.wrapped) {
+
+// cause: "0&&0||0"
+
+                warn("and", thang);
+            }
+        });
+    });
+    preaction("binary", "(", function (thing) {
+        const left = thing.expression[0];
+        if (
+            left.identifier
+            && functionage.context[left.id] === undefined
+            && typeof functionage.name === "object"
+        ) {
+            const parent = functionage.name.parent;
+            if (parent) {
+                const left_variable = parent.context[left.id];
+                if (
+                    left_variable !== undefined
+                    && left_variable.dead
+                    && left_variable.parent === parent
+                    && left_variable.calls !== undefined
+                    && left_variable.calls[functionage.name.id] !== undefined
+                ) {
+                    left_variable.dead = false;
+                }
+            }
+        }
+    });
+    preaction("binary", "in", function (thing) {
+
+// cause: "aa in aa"
+
+        warn("infix_in", thing);
+    });
+    preaction("binary", "instanceof", function (thing) {
+
+// cause: "0 instanceof 0"
+
+        warn("unexpected_a", thing);
+    });
+    preaction("statement", "{", function (thing) {
+        block_stack.push(blockage);
+        blockage = thing;
+        thing.live = [];
+    });
+    preaction("statement", "for", function (thing) {
+        if (thing.name !== undefined) {
+            const the_variable = lookup(thing.name);
+            if (the_variable !== undefined) {
+                the_variable.init = true;
+                if (!the_variable.writable) {
+
+// cause: "const aa=0;for(aa in aa){}"
+
+                    warn("bad_assignment_a", thing.name);
+                }
+            }
+        }
+        walk_statement(thing.initial);
+    });
+    preaction("statement", "function", preaction_function);
+    preaction("statement", "try", function (thing) {
+        if (thing.catch !== undefined) {
+
+// Create new function-scope for catch-parameter.
+
+            stack.push(functionage);
+            functionage = thing.catch;
+        }
+    });
+    preaction("unary", "~", bitwise_check);
+    preaction("unary", "function", preaction_function);
+    preaction("variable", function (thing) {
+        const the_variable = lookup(thing);
+        if (the_variable !== undefined) {
+            thing.variable = the_variable;
+            the_variable.used += 1;
+        }
+    });
+
+    function init_variable(name) {
+        const the_variable = lookup(name);
+        if (the_variable !== undefined) {
+            if (the_variable.writable) {
+                the_variable.init = true;
+                return;
+            }
+        }
+        warn("bad_assignment_a", name);
+    }
+
+    postaction("assignment", "+=", function (thing) {
+        let right = thing.expression[1];
+        if (right.constant) {
+            if (
+                right.value === ""
+                || (right.id === "(number)" && right.value === "0")
+                || right.id === "(boolean)"
+                || right.id === "null"
+                || right.id === "undefined"
+                || Number.isNaN(right.value)
+            ) {
+                warn("unexpected_a", right);
+            }
+        }
+    });
+    postaction("assignment", function (thing) {
+
+// Assignment using = sets the init property of a variable. No other assignment
+// operator can do this. A = token keeps that variable (or array of variables
+// in case of destructuring) in its name property.
+
+        const lvalue = thing.expression[0];
+        if (thing.id === "=") {
+            if (thing.names !== undefined) {
+
+// cause: "if(0){aa=0}"
+
+                assert_or_throw(
+                    !Array.isArray(thing.names),
+                    `Expected !Array.isArray(thing.names).`
+                );
+//          Probably deadcode.
+//          if (Array.isArray(thing.names)) {
+//              thing.names.forEach(init_variable);
+//          } else {
+//              init_variable(thing.names);
+//          }
+                init_variable(thing.names);
+            } else {
+                if (lvalue.id === "[" || lvalue.id === "{") {
+                    lvalue.expression.forEach(function (thing) {
+                        if (thing.variable) {
+                            thing.variable.init = true;
+                        }
+                    });
+                } else if (
+                    lvalue.id === "."
+                    && thing.expression[1].id === "undefined"
+                ) {
+
+// cause: "aa.aa=undefined"
+
+                    warn(
+                        "expected_a_b",
+                        lvalue.expression,
+                        "delete",
+                        "undefined"
+                    );
+                }
+            }
+        } else {
+            if (lvalue.arity === "variable") {
+                if (!lvalue.variable || lvalue.variable.writable !== true) {
+                    warn("bad_assignment_a", lvalue);
+                }
+            }
+            const right = syntax[thing.expression[1].id];
+            if (
+                right !== undefined
+                && (
+                    right.id === "function"
+                    || right.id === "=>"
+                    || (
+                        right.constant
+                        && right.id !== "(number)"
+                        && (right.id !== "(string)" || thing.id !== "+=")
+                    )
+                )
+            ) {
+
+// cause: "aa+=undefined"
+
+                warn("unexpected_a", thing.expression[1]);
+            }
+        }
+    });
+
+    function postaction_function(thing) {
+        delete functionage.finally;
+        delete functionage.loop;
+        delete functionage.switch;
+        delete functionage.try;
+        functionage = stack.pop();
+        if (thing.wrapped) {
+
+// cause: "aa=(function(){})"
+
+            warn("unexpected_parens", thing);
+        }
+        return pop_block();
+    }
+
+    postaction("binary", function (thing) {
+        let right;
+        if (relationop[thing.id]) {
+            if (
+                is_weird(thing.expression[0])
+                || is_weird(thing.expression[1])
+                || are_similar(thing.expression[0], thing.expression[1])
+                || (
+                    thing.expression[0].constant === true
+                    && thing.expression[1].constant === true
+                )
+            ) {
+
+// cause: "if(0===0){0}"
+
+                warn("weird_relation_a", thing);
+            }
+        }
+        if (thing.id === "+") {
+            if (!option.convert) {
+                if (thing.expression[0].value === "") {
+
+// cause: "\"\"+0"
+
+                    warn("expected_a_b", thing, "String(...)", "\"\" +");
+                } else if (thing.expression[1].value === "") {
+
+// cause: "0+\"\""
+
+                    warn("expected_a_b", thing, "String(...)", "+ \"\"");
+                }
+            }
+        } else if (thing.id === "[") {
+            if (thing.expression[0].id === "window") {
+
+// cause: "aa=window[0]"
+
+                warn("weird_expression_a", thing, "window[...]");
+            }
+            if (thing.expression[0].id === "self") {
+
+// cause: "aa=self[0]"
+
+                warn("weird_expression_a", thing, "self[...]");
+            }
+        } else if (thing.id === "." || thing.id === "?.") {
+            if (thing.expression.id === "RegExp") {
+
+// cause: "aa=RegExp.aa"
+
+                warn("weird_expression_a", thing);
+            }
+        } else if (thing.id !== "=>" && thing.id !== "(") {
+            right = thing.expression[1];
+            if (
+                (thing.id === "+" || thing.id === "-")
+                && right.id === thing.id
+                && right.arity === "unary"
+                && !right.wrapped
+            ) {
+
+// cause: "0- -0"
+
+                warn("wrap_unary", right);
+            }
+            if (
+                thing.expression[0].constant === true
+                && right.constant === true
+            ) {
+                thing.constant = true;
+            }
+        }
+    });
+    postaction("binary", "&&", function (thing) {
+        if (
+            is_weird(thing.expression[0])
+            || are_similar(thing.expression[0], thing.expression[1])
+            || thing.expression[0].constant === true
+            || thing.expression[1].constant === true
+        ) {
+
+// cause: "aa=(``?``:``)&&(``?``:``)"
+// cause: "aa=0&&0"
+// cause: "aa=`${0}`&&`${0}`"
+
+            warn("weird_condition_a", thing);
+        }
+    });
+    postaction("binary", "||", function (thing) {
+        if (
+            is_weird(thing.expression[0])
+            || are_similar(thing.expression[0], thing.expression[1])
+            || thing.expression[0].constant === true
+        ) {
+
+// cause: "aa=0||0"
+
+            warn("weird_condition_a", thing);
+        }
+    });
+    postaction("binary", "=>", postaction_function);
+    postaction("binary", "(", function (thing) {
+        let left = thing.expression[0];
+        let the_new;
+        let arg;
+        if (left.id === "new") {
+            the_new = left;
+            left = left.expression;
+        }
+        if (left.id === "function") {
+            if (!thing.wrapped) {
+
+// cause: "aa=function(){}()"
+
+                warn("wrap_immediate", thing);
+            }
+        } else if (left.identifier) {
+            if (the_new !== undefined) {
+                if (
+                    left.id[0] > "Z"
+                    || left.id === "Boolean"
+                    || left.id === "Number"
+                    || left.id === "String"
+                    || left.id === "Symbol"
+                ) {
+
+// cause: "new Boolean()"
+// cause: "new Number()"
+// cause: "new String()"
+// cause: "new Symbol()"
+// cause: "new aa()"
+
+                    warn("unexpected_a", the_new);
+                } else if (left.id === "Function") {
+                    if (!option.eval) {
+
+// cause: "new Function()"
+
+                        warn("unexpected_a", left, "new Function");
+                    }
+                } else if (left.id === "Array") {
+                    arg = thing.expression;
+                    if (arg.length !== 2 || arg[1].id === "(string)") {
+
+// cause: "new Array()"
+
+                        warn("expected_a_b", left, "[]", "new Array");
+                    }
+                } else if (left.id === "Object") {
+
+// cause: "new Object()"
+
+                    warn(
+                        "expected_a_b",
+                        left,
+                        "Object.create(null)",
+                        "new Object"
+                    );
+                }
+            } else {
+                if (
+                    left.id[0] >= "A"
+                    && left.id[0] <= "Z"
+                    && left.id !== "Boolean"
+                    && left.id !== "Number"
+                    && left.id !== "String"
+                    && left.id !== "Symbol"
+                ) {
+
+// cause: "let Aa=Aa()"
+
+                    warn(
+                        "expected_a_before_b",
+                        left,
+                        "new",
+                        artifact(left)
+                    );
+                }
+            }
+        } else if (left.id === ".") {
+            let cack = the_new !== undefined;
+            if (left.expression.id === "Date" && left.name.id === "UTC") {
+
+// cause: "new Date.UTC()"
+
+                cack = !cack;
+            }
+            if (rx_cap.test(left.name.id) !== cack) {
+                if (the_new !== undefined) {
+
+// cause: "new Date.UTC()"
+
+                    warn("unexpected_a", the_new);
+                } else {
+
+// cause: "let Aa=Aa.Aa()"
+
+                    warn(
+                        "expected_a_before_b",
+                        left.expression,
+                        "new",
+                        left.name.id
+                    );
+                }
+            }
+            if (left.name.id === "getTime") {
+                const paren = left.expression;
+                if (paren.id === "(") {
+                    const array = paren.expression;
+                    if (array.length === 1) {
+                        const new_date = array[0];
+                        if (
+                            new_date.id === "new"
+                            && new_date.expression.id === "Date"
+                        ) {
+
+// cause: "new Date().getTime()"
+
+                            warn(
+                                "expected_a_b",
+                                new_date,
+                                "Date.now()",
+                                "new Date().getTime()"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    });
+    postaction("binary", "[", function (thing) {
+        if (thing.expression[0].id === "RegExp") {
+
+// cause: "aa=RegExp[0]"
+
+            warn("weird_expression_a", thing);
+        }
+        if (is_weird(thing.expression[1])) {
+
+// cause: "aa[[0]]"
+
+            warn("weird_expression_a", thing.expression[1]);
+        }
+    });
+    postaction("statement", "{", pop_block);
+    postaction("statement", "const", action_var);
+    postaction("statement", "export", top_level_only);
+    postaction("statement", "for", function (thing) {
+        walk_statement(thing.inc);
+    });
+    postaction("statement", "function", postaction_function);
+    postaction("statement", "import", function (the_thing) {
+        const name = the_thing.name;
+        if (name) {
+            if (Array.isArray(name)) {
+                name.forEach(function (name) {
+                    name.dead = false;
+                    name.init = true;
+                    blockage.live.push(name);
+                });
+            } else {
+                name.dead = false;
+                name.init = true;
+                blockage.live.push(name);
+            }
+            return top_level_only(the_thing);
+        }
+    });
+    postaction("statement", "let", action_var);
+    postaction("statement", "try", function (thing) {
+        if (thing.catch !== undefined) {
+            const the_name = thing.catch.name;
+            if (the_name !== undefined) {
+                const the_variable = functionage.context[the_name.id];
+                the_variable.dead = false;
+                the_variable.init = true;
+            }
+            walk_statement(thing.catch.block);
+
+// Restore previous function-scope after catch-block.
+
+            functionage = stack.pop();
+        }
+    });
+    postaction("statement", "var", action_var);
+    postaction("ternary", function (thing) {
+        if (
+            is_weird(thing.expression[0])
+            || thing.expression[0].constant === true
+            || are_similar(thing.expression[1], thing.expression[2])
+        ) {
+            warn("unexpected_a", thing);
+        } else if (are_similar(thing.expression[0], thing.expression[1])) {
+
+// cause: "aa?aa:0"
+
+            warn("expected_a_b", thing, "||", "?");
+        } else if (are_similar(thing.expression[0], thing.expression[2])) {
+
+// cause: "aa?0:aa"
+
+            warn("expected_a_b", thing, "&&", "?");
+        } else if (
+            thing.expression[1].id === "true"
+            && thing.expression[2].id === "false"
+        ) {
+
+// cause: "aa?true:false"
+
+            warn("expected_a_b", thing, "!!", "?");
+        } else if (
+            thing.expression[1].id === "false"
+            && thing.expression[2].id === "true"
+        ) {
+
+// cause: "aa?false:true"
+
+            warn("expected_a_b", thing, "!", "?");
+        } else if (
+            thing.expression[0].wrapped !== true
+            && (
+                thing.expression[0].id === "||"
+                || thing.expression[0].id === "&&"
+            )
+        ) {
+
+// cause: "(aa&&!aa?0:1)"
+
+            warn("wrap_condition", thing.expression[0]);
+        }
+    });
+    postaction("unary", function (thing) {
+        if (thing.id === "`") {
+            if (thing.expression.every(function (thing) {
+                return thing.constant;
+            })) {
+                thing.constant = true;
+            }
+        } else if (thing.id === "!") {
+            if (thing.expression.constant === true) {
+                warn("unexpected_a", thing);
+            }
+        } else if (thing.id === "!!") {
+            if (!option.convert) {
+
+// cause: "!!0"
+
+                warn("expected_a_b", thing, "Boolean(...)", "!!");
+            }
+        } else if (
+            thing.id !== "["
+            && thing.id !== "{"
+            && thing.id !== "function"
+            && thing.id !== "new"
+        ) {
+            if (thing.expression.constant === true) {
+                thing.constant = true;
+            }
+        }
+    });
+    postaction("unary", "function", postaction_function);
+    postaction("unary", "+", function (thing) {
+        if (!option.convert) {
+
+// cause: "aa=+0"
+
+            warn("expected_a_b", thing, "Number(...)", "+");
+        }
+        const right = thing.expression;
+        if (right.id === "(" && right.expression[0].id === "new") {
+            warn("unexpected_a_before_b", thing, "+", "new");
+        } else if (
+            right.constant
+            || right.id === "{"
+            || (right.id === "[" && right.arity !== "binary")
+        ) {
+            warn("unexpected_a", thing, "+");
+        }
+    });
+
+    function delve(the_function) {
+        Object.keys(the_function.context).forEach(function (id) {
+            if (id !== "ignore") {
+                const name = the_function.context[id];
+                if (name.parent === the_function) {
+
+// cause: "let aa=function bb(){return;};"
+
+                    if (
+                        name.used === 0
+                        && assert_or_throw(
+                            name.role !== "function",
+                            `Expected name.role !== "function".`
+                        )
+//                  Probably deadcode.
+//                  && (
+//                      name.role !== "function"
+//                      || name.parent.arity !== "unary"
+//                  )
+                    ) {
+
+// cause: "/*jslint node*/\nlet aa;"
+// cause: "function aa(aa){return;}"
+
+                        warn("unused_a", name);
+                    } else if (!name.init) {
+
+// cause: "/*jslint node*/\nlet aa;aa();"
+
+                        warn("uninitialized_a", name);
+                    }
+                }
+            }
+
+// cause: "function aa(ignore){return;}"
+
+        });
+    }
+
+    function uninitialized_and_unused() {
+
+// Delve into the functions looking for variables that were not initialized
+// or used. If the file imports or exports, then its global object is also
+// delved.
+
+        if (module_mode === true || option.node) {
+            delve(global);
+        }
+        functions.forEach(delve);
+    }
+
+// Go through the token list, looking at usage of whitespace.
+
+    function whitage() {
+        let closer = "(end)";
+
+// free = false
+
+// cause: "()=>0"
+// cause: "aa()"
+// cause: "aa(0,0)"
+// cause: "function(){}"
+
+        let free = false;
+
+// cause: "(0)"
+// cause: "(aa)"
+// cause: "aa(0)"
+// cause: "do{}while()"
+// cause: "for(){}"
+// cause: "if(){}"
+// cause: "switch(){}"
+// cause: "while(){}"
+
+        // let free = true;
+
+        let left = global;
+        let margin = 0;
+        let nr_comments_skipped = 0;
+        let open = true;
+        let opening = true;
+        let right;
+
+        function pop() {
+            const previous = stack.pop();
+            closer = previous.closer;
+            free = previous.free;
+            margin = previous.margin;
+            open = previous.open;
+            opening = previous.opening;
+        }
+
+        function push() {
+            stack.push({
+                closer,
+                free,
+                margin,
+                open,
+                opening
+            });
+        }
+
+        function expected_at(at) {
+            assert_or_throw(
+                !(right === undefined),
+                `Expected !(right === undefined).`
+            );
+//      Probably deadcode.
+//      if (right === undefined) {
+//          right = token_next;
+//      }
+            warn(
+                "expected_a_at_b_c",
+                right,
+                artifact(right),
+
+// Fudge column numbers in warning message.
+
+                at + fudge,
+                right.from + fudge
+            );
+        }
+
+        function at_margin(fit) {
+            const at = margin + fit;
+            if (right.from !== at) {
+                return expected_at(at);
+            }
+        }
+
+        function no_space_only() {
+            if (
+                left.id !== "(global)"
+                && left.nr + 1 === right.nr
+                && (
+                    left.line !== right.line
+                    || left.thru !== right.from
+                )
+            ) {
+                warn(
+                    "unexpected_space_a_b",
+                    right,
+                    artifact(left),
+                    artifact(right)
+                );
+            }
+        }
+
+        function no_space() {
+            if (left.line === right.line) {
+
+// from:
+//                  if (left.line === right.line) {
+//                      no_space();
+//                  } else {
+
+                if (left.thru !== right.from && nr_comments_skipped === 0) {
+
+// cause: "let aa = aa( );"
+
+                    warn(
+                        "unexpected_space_a_b",
+                        right,
+                        artifact(left),
+                        artifact(right)
+                    );
+                }
+            } else {
+
+// from:
+//                  } else if (
+//                      right.arity === "binary"
+//                      && right.id === "("
+//                      && free
+//                  ) {
+//                      no_space();
+//                  } else if (
+
+                assert_or_throw(open, `Expected open.`);
+                assert_or_throw(free, `Expected free.`);
+//          Probably deadcode.
+//          if (open) {
+//              const at = (
+//                  free
+//                  ? margin
+//                  : margin + 8
+//              );
+//              if (right.from < at) {
+//                  expected_at(at);
+//              }
+//          } else {
+//              if (right.from !== margin + 8) {
+//                  expected_at(margin + 8);
+//              }
+//          }
+                if (right.from < margin) {
+
+// cause:
+// let aa = aa(
+//     aa
+// ()
+// );
+
+                    expected_at(margin);
+                }
+            }
+        }
+
+        function one_space_only() {
+            if (left.line !== right.line || left.thru + 1 !== right.from) {
+                warn(
+                    "expected_space_a_b",
+                    right,
+                    artifact(left),
+                    artifact(right)
+                );
+            }
+        }
+
+        function one_space() {
+            if (left.line === right.line || !open) {
+                if (left.thru + 1 !== right.from && nr_comments_skipped === 0) {
+                    warn(
+                        "expected_space_a_b",
+                        right,
+                        artifact(left),
+                        artifact(right)
+                    );
+                }
+            } else {
+                if (right.from !== margin) {
+                    expected_at(margin);
+                }
+            }
+        }
+
+        stack = [];
+        tokens.forEach(function (the_token) {
+            right = the_token;
+            if (right.id === "(comment)" || right.id === "(end)") {
+                nr_comments_skipped += 1;
+            } else {
+
+// If left is an opener and right is not the closer, then push the previous
+// state. If the token following the opener is on the next line, then this is
+// an open form. If the tokens are on the same line, then it is a closed form.
+// Open form is more readable, with each item (statement, argument, parameter,
+// etc) starting on its own line. Closed form is more compact. Statement blocks
+// are always in open form.
+
+                const new_closer = opener[left.id];
+                if (typeof new_closer === "string") {
+
+// cause: "${"
+// cause: "("
+// cause: "["
+// cause: "{"
+
+                    if (new_closer !== right.id) {
+
+// cause: "${0"
+// cause: "(0"
+// cause: "[0"
+// cause: "{0"
+
+                        opening = left.open || (left.line !== right.line);
+                        push();
+                        closer = new_closer;
+                        if (opening) {
+
+// cause: "${\n0\n}"
+// cause: "(\n0\n)"
+// cause: "[\n0\n]"
+// cause: "{\n0\n}"
+
+                            free = closer === ")" && left.free;
+                            open = true;
+                            margin += 4;
+                            if (right.role === "label") {
+                                if (right.from !== 0) {
+
+// cause:
+// function aa() {
+//  bb:
+//     while (aa) {
+//         if (aa) {
+//             break bb;
+//         }
+//     }
+// }
+
+                                    expected_at(0);
+                                }
+                            } else if (right.switch) {
+                                at_margin(-4);
+                            } else {
+                                at_margin(0);
+                            }
+                        } else {
+                            if (right.statement || right.role === "label") {
+
+// cause:
+// function aa() {bb:
+//     while (aa) {aa();
+//     }
+// }
+
+                                warn(
+                                    "expected_line_break_a_b",
+                                    right,
+                                    artifact(left),
+                                    artifact(right)
+                                );
+                            }
+
+// cause: "${0}"
+// cause: "(0)"
+// cause: "[0]"
+// cause: "{0}"
+
+                            free = false;
+                            open = false;
+
+// cause: "let aa = ( 0 );"
+
+                            no_space_only();
+                        }
+                    } else {
+
+// If left and right are opener and closer, then the placement of right depends
+// on the openness. Illegal pairs (like '{]') have already been detected.
+
+// cause: "${}"
+// cause: "()"
+// cause: "[]"
+// cause: "{}"
+
+                        if (left.line === right.line) {
+
+// cause: "let aa = aa( );"
+
+                            no_space();
+                        } else {
+
+// cause: "let aa = aa(\n );"
+
+                            at_margin(0);
+                        }
+                    }
+                } else {
+                    if (right.statement === true) {
+                        if (left.id === "else") {
+
+// cause:
+// let aa = 0;
+// if (aa) {
+//     aa();
+// } else  if (aa) {
+//     aa();
+// }
+
+                            one_space_only();
+                        } else {
+
+// cause: " let aa = 0;"
+
+                            at_margin(0);
+                            open = false;
+                        }
+
+// If right is a closer, then pop the previous state.
+
+                    } else if (right.id === closer) {
+                        pop();
+                        if (opening && right.id !== ";") {
+                            at_margin(0);
+                        } else {
+                            no_space_only();
+                        }
+                    } else {
+
+// Left is not an opener, and right is not a closer.
+// The nature of left and right will determine the space between them.
+
+// If left is ',' or ';' or right is a statement then if open,
+// right must go at the margin, or if closed, a space between.
+
+                        if (right.switch) {
+                            at_margin(-4);
+                        } else if (right.role === "label") {
+                            if (right.from !== 0) {
+
+// cause:
+// function aa() {
+//     aa();cc:
+//     while (aa) {
+//         if (aa) {
+//             break cc;
+//         }
+//     }
+// }
+
+                                expected_at(0);
+                            }
+                        } else if (left.id === ",") {
+                            if (!open || (
+                                (free || closer === "]")
+                                && left.line === right.line
+                            )) {
+
+// cause: "let {aa,bb} = 0;"
+
+                                one_space();
+                            } else {
+
+// cause:
+// function aa() {
+//     aa(
+//         0,0
+//     );
+// }
+
+                                at_margin(0);
+                            }
+
+// If right is a ternary operator, line it up on the margin.
+
+                        } else if (right.arity === "ternary") {
+                            if (open) {
+
+// cause:
+// let aa = (
+//     aa
+//     ? 0
+// : 1
+// );
+
+                                at_margin(0);
+                            } else {
+
+// cause: "let aa = (aa ? 0 : 1);"
+
+                                warn("use_open", right);
+                            }
+                        } else if (
+                            right.arity === "binary"
+                            && right.id === "("
+                            && free
+                        ) {
+
+// cause:
+// let aa = aa(
+//     aa
+// ()
+// );
+
+                            no_space();
+                        } else if (
+                            left.id === "."
+                            || left.id === "?."
+                            || left.id === "..."
+                            || right.id === ","
+                            || right.id === ";"
+                            || right.id === ":"
+                            || (
+                                right.arity === "binary"
+                                && (right.id === "(" || right.id === "[")
+                            )
+                            || (
+                                right.arity === "function"
+                                && left.id !== "function"
+                            )
+                        ) {
+
+// cause: "let aa = 0 ;"
+
+                            no_space_only();
+                        } else if (right.id === "." || right.id === "?.") {
+
+// cause: "let aa = aa ?.aa;"
+
+                            no_space_only();
+                        } else if (left.id === ";") {
+
+// cause:
+// /*jslint for*/
+// function aa() {
+//     for (
+//         aa();
+// aa;
+//         aa()
+//     ) {
+//         aa();
+//     }
+// }
+
+                            if (open) {
+                                at_margin(0);
+                            }
+                        } else if (
+                            left.arity === "ternary"
+                            || left.id === "case"
+                            || left.id === "catch"
+                            || left.id === "else"
+                            || left.id === "finally"
+                            || left.id === "while"
+                            || left.id === "await"
+                            || right.id === "catch"
+                            || right.id === "else"
+                            || right.id === "finally"
+                            || (right.id === "while" && !right.statement)
+                            || (left.id === ")" && right.id === "{")
+                        ) {
+
+// cause:
+// function aa() {
+//     do {
+//         aa();
+//     } while(aa());
+// }
+
+                            one_space_only();
+                        } else if (
+
+// There is a space between left and right.
+
+                            spaceop[left.id] === true
+                            || spaceop[right.id] === true
+                            || (
+                                left.arity === "binary"
+                                && (left.id === "+" || left.id === "-")
+                            )
+                            || (
+                                right.arity === "binary"
+                                && (right.id === "+" || right.id === "-")
+                            )
+                            || left.id === "function"
+                            || left.id === ":"
+                            || (
+                                (
+                                    left.identifier
+                                    || left.id === "(string)"
+                                    || left.id === "(number)"
+                                )
+                                && (
+                                    right.identifier
+                                    || right.id === "(string)"
+                                    || right.id === "(number)"
+                                )
+                            )
+                            || (left.arity === "statement" && right.id !== ";")
+                        ) {
+
+// cause: "let aa=0;"
+// cause:
+// let aa={
+//     aa:
+// 0
+// };
+
+                            one_space();
+                        } else if (left.arity === "unary" && left.id !== "`") {
+                            no_space_only();
+                        }
+                    }
+                }
+                nr_comments_skipped = 0;
+                delete left.calls;
+                delete left.dead;
+                delete left.free;
+                delete left.init;
+                delete left.open;
+                delete left.used;
+                left = right;
+            }
+        });
     }
 
     function next_line() {
@@ -689,7 +5051,7 @@ function tokenize(source) {
             && whole_line.length > 80
             && disable_line === undefined
             && !json_mode
-            && first
+            && token_frst
             && !regexp_seen
         ) {
 
@@ -914,10 +5276,10 @@ function tokenize(source) {
 // This warning is not suppressed by option.white.
 
         if (
-            previous.line === line
-            && previous.thru === from
+            token_prev.line === line
+            && token_prev.thru === from
             && (id === "(comment)" || id === "(regexp)" || id === "/")
-            && (previous.id === "(comment)" || previous.id === "(regexp)")
+            && (token_prev.id === "(comment)" || token_prev.id === "(regexp)")
         ) {
 
 // cause: "/**//**/"
@@ -925,15 +5287,15 @@ function tokenize(source) {
             warn(
                 "expected_space_a_b",
                 the_token,
-                artifact(previous),
+                artifact(token_prev),
                 artifact(the_token)
             );
         }
-        if (previous.id === "." && id === "(number)") {
+        if (token_prev.id === "." && id === "(number)") {
 
 // cause: ".0"
 
-            warn("expected_a_before_b", previous, "0", ".");
+            warn("expected_a_before_b", token_prev, "0", ".");
         }
         if (prior.id === "." && the_token.identifier) {
             the_token.dot = true;
@@ -941,14 +5303,14 @@ function tokenize(source) {
 
 // The previous token is used to detect adjacency problems.
 
-        previous = the_token;
+        token_prev = the_token;
 
 // The prior token is a previous token that was not a comment. The prior token
 // is used to disambiguate "/", which can mean division or regular expression
 // literal.
 
-        if (previous.id !== "(comment)") {
-            prior = previous;
+        if (token_prev.id !== "(comment)") {
+            prior = token_prev;
         }
         return the_token;
     }
@@ -1734,4418 +6096,35 @@ function tokenize(source) {
         return make(snippet);
     }
 
-    first = lex();
-    json_mode = first.id === "{" || first.id === "[";
-
-// This loop will be replaced with a recursive call to lex when ES6 has been
-// finished and widely deployed and adopted.
-
-    while (true) {
-        if (lex().id === "(end)") {
-            break;
-        }
-    }
-}
-
-// Parsing:
-
-// Parsing weaves the tokens into an abstract syntax tree. During that process,
-// a token may be given any of these properties:
-
-//      arity       string
-//      label       identifier
-//      name        identifier
-//      expression  expressions
-//      block       statements
-//      else        statements (else, default, catch)
-
-// Specialized tokens may have additional properties.
-
-function survey(name) {
-    let id = name.id;
-
-// Tally the property name. If it is a string, only tally strings that conform
-// to the identifier rules.
-
-    if (id === "(string)") {
-        id = name.value;
-        if (!rx_identifier.test(id)) {
-            return id;
-        }
-    } else if (id === "`") {
-        if (name.value.length === 1) {
-            id = name.value[0].value;
-            if (!rx_identifier.test(id)) {
-                return id;
-            }
-        }
-    } else if (!name.identifier) {
-
-// cause: "let aa={0:0}"
-
-        return stop("expected_identifier_a", name);
-    }
-
-// If we have seen this name before, increment its count.
-
-    if (typeof property[id] === "number") {
-        property[id] += 1;
-
-// If this is the first time seeing this property name, and if there is a
-// tenure list, then it must be on the list. Otherwise, it must conform to
-// the rules for good property names.
-
-    } else {
-        if (tenure !== undefined) {
-            if (tenure[id] !== true) {
-
-// cause: "/*property aa*/\naa.bb"
-
-                warn("unregistered_property_a", name);
-            }
-        } else {
-            if (name.identifier && rx_bad_property.test(id)) {
-
-// cause: "aa._"
-
-                warn("bad_property_a", name);
-            }
-        }
-        property[id] = 1;
-    }
-    return id;
-}
-
-function dispense() {
-
-// Deliver the next token, skipping the comments.
-
-    const cadet = tokens[token_nr];
-    token_nr += 1;
-    if (cadet.id === "(comment)") {
-        if (json_mode) {
-
-// cause: "[//]"
-
-            warn("unexpected_a", cadet);
-        }
-        return dispense();
-    } else {
-        return cadet;
-    }
-}
-
-function lookahead() {
-
-// Look ahead one token without advancing.
-
-    const old_token_nr = token_nr;
-    const cadet = dispense(true);
-    token_nr = old_token_nr;
-    return cadet;
-}
-
-function advance(id, match) {
-
-// Produce the next token.
-
-// Attempt to give helpful names to anonymous functions.
-
-    if (token.identifier && token.id !== "function") {
-        anon = token.id;
-    } else if (token.id === "(string)" && rx_identifier.test(token.value)) {
-        anon = token.value;
-    }
-
-// Attempt to match next_token with an expected id.
-
-    if (id !== undefined && next_token.id !== id) {
-        return (
-            match === undefined
-
-// cause: "()"
-
-            ? stop("expected_a_b", next_token, id, artifact())
-
-// cause: "{\"aa\":0"
-
-            : stop(
-                "expected_a_b_from_c_d",
-                next_token,
-                id,
-                artifact(match),
-                match.line,
-                artifact(next_token)
-            )
-        );
-    }
-
-// Promote the tokens, skipping comments.
-
-    token = next_token;
-    next_token = dispense();
-    if (next_token.id === "(end)") {
-        token_nr -= 1;
-    }
-}
-
-// Parsing of JSON is simple:
-
-function json_value() {
-    let negative;
-    if (next_token.id === "{") {
-        return (function json_object() {
-            const brace = next_token;
-            const object = empty();
-            const properties = [];
-            brace.expression = properties;
-            advance("{");
-            if (next_token.id !== "}") {
-                (function next() {
-                    let name;
-                    let value;
-                    if (next_token.quote !== "\"") {
-                        warn(
-                            "unexpected_a",
-                            next_token,
-                            next_token.quote
-                        );
-                    }
-                    name = next_token;
-                    advance("(string)");
-                    if (object[token.value] !== undefined) {
-
-// cause: "{\"aa\":0,\"aa\":0}"
-
-                        warn("duplicate_a", token);
-                    } else if (token.value === "__proto__") {
-
-// cause: "{\"__proto__\":0}"
-
-                        warn("bad_property_a", token);
-                    } else {
-                        object[token.value] = token;
-                    }
-                    advance(":");
-                    value = json_value();
-                    value.label = name;
-                    properties.push(value);
-                    if (next_token.id === ",") {
-                        advance(",");
-                        return next();
-                    }
-                }());
-            }
-            advance("}", brace);
-            return brace;
-        }());
-    }
-    if (next_token.id === "[") {
-        return (function json_array() {
-            const bracket = next_token;
-            const elements = [];
-            bracket.expression = elements;
-            advance("[");
-            if (next_token.id !== "]") {
-                (function next() {
-                    elements.push(json_value());
-                    if (next_token.id === ",") {
-                        advance(",");
-                        return next();
-                    }
-                }());
-            }
-            advance("]", bracket);
-            return bracket;
-        }());
-    }
-    if (
-        next_token.id === "true"
-        || next_token.id === "false"
-        || next_token.id === "null"
-    ) {
-        advance();
-        return token;
-    }
-    if (next_token.id === "(number)") {
-
-// cause: "[0x0]"
-
-        if (!rx_JSON_number.test(next_token.value)) {
-            warn("unexpected_a");
-        }
-        advance();
-        return token;
-    }
-    if (next_token.id === "(string)") {
-
-// cause: "['']"
-
-        if (next_token.quote !== "\"") {
-            warn("unexpected_a", next_token, next_token.quote);
-        }
-        advance();
-        return token;
-    }
-    if (next_token.id === "-") {
-        negative = next_token;
-        negative.arity = "unary";
-        advance("-");
-        advance("(number)");
-        if (!rx_JSON_number.test(token.value)) {
-
-// cause: "[-0x0]"
-
-            warn("unexpected_a", token);
-        }
-        negative.expression = token;
-        return negative;
-    }
-    stop("unexpected_a");
-}
-
-// Now we parse JavaScript.
-
-function enroll(name, role, readonly) {
-
-// Enroll a name into the current function context. The role can be exception,
-// function, label, parameter, or variable. We look for variable redefinition
-// because it causes confusion.
-
-    const id = name.id;
-
-// Reserved words may not be enrolled.
-
-    if (syntax[id] !== undefined && id !== "ignore") {
-
-// cause: "let undefined"
-
-        warn("reserved_a", name);
-    } else {
-
-// Has the name been enrolled in this context?
-
-        let earlier = functionage.context[id];
-        if (earlier) {
-
-// cause: "let aa;let aa"
-
-            warn(
-                "redefinition_a_b",
-                name,
-                name.id,
-                earlier.line
-            );
-
-// Has the name been enrolled in an outer context?
-
-        } else {
-            stack.forEach(function (value) {
-                const item = value.context[id];
-                if (item !== undefined) {
-                    earlier = item;
-                }
-            });
-            if (earlier) {
-                if (id === "ignore") {
-                    if (earlier.role === "variable") {
-
-// cause: "let ignore;function aa(ignore){}"
-
-                        warn("unexpected_a", name);
-                    }
-                } else {
-                    if (
-                        (
-                            role !== "exception"
-                            || earlier.role !== "exception"
-                        )
-                        && role !== "parameter"
-                        && role !== "function"
-                    ) {
-
-// cause: "function aa(){try{aa();}catch(aa){aa();}}"
-// cause: "function aa(){var aa;}"
-
-                        warn(
-                            "redefinition_a_b",
-                            name,
-                            name.id,
-                            earlier.line
-                        );
-                    }
-                }
-            }
-
-// Enroll it.
-
-            functionage.context[id] = name;
-            name.dead = true;
-            name.parent = functionage;
-            name.init = false;
-            name.role = role;
-            name.used = 0;
-            name.writable = !readonly;
-        }
-    }
-}
-
-function expression(rbp, initial) {
-
-// This is the heart of the Pratt parser. I retained Pratt's nomenclature.
-// They are elements of the parsing method called Top Down Operator Precedence.
-
-// nud     Null denotation
-// led     Left denotation
-// lbp     Left binding power
-// rbp     Right binding power
-
-// It processes a nud (variable, constant, prefix operator). It will then
-// process leds (infix operators) until the bind powers cause it to stop. It
-// returns the expression's parse tree.
-
-    let left;
-    let the_symbol;
-
-// Statements will have already advanced, so advance now only if the token is
-// not the first of a statement,
-
-    if (!initial) {
-        advance();
-    }
-    the_symbol = syntax[token.id];
-    if (the_symbol !== undefined && the_symbol.nud !== undefined) {
-
-// cause: "0"
-
-        left = the_symbol.nud();
-    } else if (token.identifier) {
-
-// cause: "aa"
-
-        left = token;
-        left.arity = "variable";
-    } else {
-
-// cause: "!"
-
-        return stop("unexpected_a", token);
-    }
-    (function right() {
-        the_symbol = syntax[next_token.id];
-        if (
-            the_symbol !== undefined
-            && the_symbol.led !== undefined
-            && rbp < the_symbol.lbp
-        ) {
-            advance();
-            left = the_symbol.led(left);
-            return right();
-        }
-    }());
-    return left;
-}
-
-function condition() {
-
-// Parse the condition part of a do, if, while.
-
-    const the_paren = next_token;
-    let the_value;
-
-// cause: "do{}while()"
-// cause: "if(){}"
-// cause: "while(){}"
-
-    the_paren.free = true;
-    advance("(");
-    the_value = expression(0);
-    advance(")");
-    if (the_value.wrapped === true) {
-
-// cause: "while((0)){}"
-
-        warn("unexpected_a", the_paren);
-    }
-    if (anticondition[the_value.id] === true) {
-
-// cause: "while(~0){}"
-
-        warn("unexpected_a", the_value);
-    }
-    return the_value;
-}
-
-function is_weird(thing) {
-    return (
-        thing.id === "(regexp)"
-        || thing.id === "{"
-        || thing.id === "=>"
-        || thing.id === "function"
-        || (thing.id === "[" && thing.arity === "unary")
-    );
-}
-
-function are_similar(a, b) {
-
-// cause: "0&&0"
-
-    assert_or_throw(!(a === b), `Expected !(a === b).`);
-//  Probably deadcode.
-//  if (a === b) {
-//      return true;
-//  }
-    if (Array.isArray(a)) {
-        return (
-            Array.isArray(b)
-            && a.length === b.length
-            && a.every(function (value, index) {
-
-// cause: "`${0}`&&`${0}`"
-
-                return are_similar(value, b[index]);
-            })
-        );
-    }
-    assert_or_throw(!Array.isArray(b), `Expected !Array.isArray(b).`);
-//  Probably deadcode.
-//  if (Array.isArray(b)) {
-//      return false;
-//  }
-    if (a.id === "(number)" && b.id === "(number)") {
-        return a.value === b.value;
-    }
-    let a_string;
-    let b_string;
-    if (a.id === "(string)") {
-        a_string = a.value;
-    } else if (a.id === "`" && a.constant) {
-        a_string = a.value[0];
-    }
-    if (b.id === "(string)") {
-        b_string = b.value;
-    } else if (b.id === "`" && b.constant) {
-        b_string = b.value[0];
-    }
-    if (typeof a_string === "string") {
-        return a_string === b_string;
-    }
-    if (is_weird(a) || is_weird(b)) {
-        return false;
-    }
-    if (a.arity === b.arity && a.id === b.id) {
-
-// cause: "aa.bb&&aa.bb"
-
-        if (a.id === ".") {
-            return (
-                are_similar(a.expression, b.expression)
-                && are_similar(a.name, b.name)
-            );
-        }
-
-// cause: "+0&&+0"
-
-        if (a.arity === "unary") {
-            return are_similar(a.expression, b.expression);
-        }
-        if (a.arity === "binary") {
-
-// cause: "aa[0]&&aa[0]"
-
-            return (
-                a.id !== "("
-                && are_similar(a.expression[0], b.expression[0])
-                && are_similar(a.expression[1], b.expression[1])
-            );
-        }
-        if (a.arity === "ternary") {
-
-// cause: "aa=(``?``:``)&&(``?``:``)"
-
-            return (
-                are_similar(a.expression[0], b.expression[0])
-                && are_similar(a.expression[1], b.expression[1])
-                && are_similar(a.expression[2], b.expression[2])
-            );
-        }
-        assert_or_throw(
-            !(a.arity === "function" || a.arity === "regexp"),
-            `Expected !(a.arity === "function" || a.arity === "regexp").`
-        );
-//      Probably deadcode.
-//      if (a.arity === "function" || a.arity === "regexp") {
-//          return false;
-//      }
-
-// cause: "undefined&&undefined"
-
-        return true;
-    }
-
-// cause: "null&&undefined"
-
-    return false;
-}
-
-function semicolon() {
-
-// Try to match a semicolon.
-
-    if (next_token.id === ";") {
-        advance(";");
-    } else {
-
-// cause: "0"
-
-        warn_at(
-            "expected_a_b",
-            token.line,
-            token.thru,
-            ";",
-            artifact(next_token)
-        );
-    }
-    anon = "anonymous";
-}
-
-function statement() {
-
-// Parse a statement. Any statement may have a label, but only four statements
-// have use for one. A statement can be one of the standard statements, or
-// an assignment expression, or an invocation expression.
-
-    let first;
-    let the_label;
-    let the_statement;
-    let the_symbol;
-    advance();
-    if (token.identifier && next_token.id === ":") {
-        the_label = token;
-        if (the_label.id === "ignore") {
-
-// cause: "ignore:"
-
-            warn("unexpected_a", the_label);
-        }
-        advance(":");
-        if (
-            next_token.id === "do"
-            || next_token.id === "for"
-            || next_token.id === "switch"
-            || next_token.id === "while"
-        ) {
-            enroll(the_label, "label", true);
-            the_label.init = true;
-            the_label.dead = false;
-            the_statement = statement();
-            the_statement.label = the_label;
-            the_statement.statement = true;
-            return the_statement;
-        }
-        advance();
-
-// cause: "aa:"
-
-        warn("unexpected_label_a", the_label);
-    }
-
-// Parse the statement.
-
-    first = token;
-    first.statement = true;
-    the_symbol = syntax[first.id];
-    if (the_symbol !== undefined && the_symbol.fud !== undefined) {
-        the_symbol.disrupt = false;
-        the_symbol.statement = true;
-        the_statement = the_symbol.fud();
-    } else {
-
-// It is an expression statement.
-
-        the_statement = expression(0, true);
-        if (the_statement.wrapped && the_statement.id !== "(") {
-
-// cause: "(0)"
-
-            warn("unexpected_a", first);
-        }
-        semicolon();
-    }
-    if (the_label !== undefined) {
-        the_label.dead = true;
-    }
-    return the_statement;
-}
-
-function statements() {
-
-// Parse a list of statements. Give a warning if an unreachable statement
-// follows a disruptive statement.
-
-    const array = [];
-    (function next(disrupt) {
-        if (
-            next_token.id !== "}"
-            && next_token.id !== "case"
-            && next_token.id !== "default"
-            && next_token.id !== "else"
-            && next_token.id !== "(end)"
-        ) {
-            let a_statement = statement();
-            array.push(a_statement);
-            if (disrupt) {
-
-// cause: "while(0){break;0;}"
-
-                warn("unreachable_a", a_statement);
-            }
-            return next(a_statement.disrupt);
-        }
-    }(false));
-    return array;
-}
-
-function not_top_level(thing) {
-
-// Some features should not be at the outermost level.
-
-    if (functionage === global) {
-
-// cause: "while(0){}"
-
-        warn("unexpected_at_top_level_a", thing);
-    }
-}
-
-function top_level_only(the_thing) {
-
-// Some features must be at the most outermost level.
-
-    if (blockage !== global) {
-
-// cause: "if(0){import aa from \"aa\";}"
-
-        warn("misplaced_a", the_thing);
-    }
-}
-
-function block(special) {
-
-// Parse a block, a sequence of statements wrapped in braces.
-//  special "body"      The block is a function body.
-//          "ignore"    No warning on an empty block.
-//          "naked"     No advance.
-//          undefined   An ordinary block.
-
-    let stmts;
-    let the_block;
-    if (special !== "naked") {
-        advance("{");
-    }
-    the_block = token;
-    the_block.arity = "statement";
-    the_block.body = special === "body";
-
-// Top level function bodies may include the "use strict" pragma.
-
-    if (
-        special === "body"
-        && stack.length === 1
-        && next_token.value === "use strict"
-    ) {
-        next_token.statement = true;
-        advance("(string)");
-        advance(";");
-    }
-    stmts = statements();
-    the_block.block = stmts;
-    if (stmts.length === 0) {
-        if (!option.devel && special !== "ignore") {
-
-// cause: "function aa(){}"
-
-            warn("empty_block", the_block);
-        }
-        the_block.disrupt = false;
-    } else {
-        the_block.disrupt = stmts[stmts.length - 1].disrupt;
-    }
-    advance("}");
-    return the_block;
-}
-
-function mutation_check(the_thing) {
-
-// The only expressions that may be assigned to are
-//      e.b
-//      e[b]
-//      v
-//      [destructure]
-//      {destructure}
-
-    if (
-        the_thing.arity !== "variable"
-        && the_thing.id !== "."
-        && the_thing.id !== "["
-        && the_thing.id !== "{"
-    ) {
-
-// cause: "0=0"
-
-        warn("bad_assignment_a", the_thing);
-        return false;
-    }
-    return true;
-}
-
-function left_check(left, right) {
-
-// Warn if the left is not one of these:
-//      ?.
-//      ?:
-//      e()
-//      e.b
-//      e[b]
-//      identifier
-
-    const id = left.id;
-    if (
-        !left.identifier
-        && (
-            left.arity !== "ternary"
-            || (
-                !left_check(left.expression[1])
-                && !left_check(left.expression[2])
-            )
-        )
-        && (
-            left.arity !== "binary"
-            || (id !== "." && id !== "?." && id !== "(" && id !== "[")
-        )
-    ) {
-        warn("unexpected_a", right);
-        return false;
-    }
-    return true;
-}
-
-// These functions are used to specify the grammar of our language:
-
-function symbol(id, bp) {
-
-// Make a symbol if it does not already exist in the language's syntax.
-
-    let the_symbol = syntax[id];
-    if (the_symbol === undefined) {
-        the_symbol = empty();
-        the_symbol.id = id;
-        the_symbol.lbp = bp || 0;
-        syntax[id] = the_symbol;
-    }
-    return the_symbol;
-}
-
-function assignment(id) {
-
-// Make an assignment operator. The one true assignment is different because
-// its left side, when it is a variable, is not treated as an expression.
-// That case is special because that is when a variable gets initialized. The
-// other assignment operators can modify, but they cannot initialize.
-
-    const the_symbol = symbol(id, 20);
-    the_symbol.led = function (left) {
-        const the_token = token;
-        let right;
-        the_token.arity = "assignment";
-        right = expression(20 - 1);
-        if (id === "=" && left.arity === "variable") {
-            the_token.names = left;
-            the_token.expression = right;
-        } else {
-            the_token.expression = [left, right];
-        }
-        if (
-            right.arity === "assignment"
-            || right.arity === "pre"
-            || right.arity === "post"
-        ) {
-            warn("unexpected_a", right);
-        }
-        mutation_check(left);
-        return the_token;
-    };
-    return the_symbol;
-}
-
-function constant(id, type, value) {
-
-// Make a constant symbol.
-
-    const the_symbol = symbol(id);
-    the_symbol.constant = true;
-    the_symbol.nud = (
-        typeof value === "function"
-        ? value
-        : function () {
-            token.constant = true;
-            if (value !== undefined) {
-                token.value = value;
-            }
-            return token;
-        }
-    );
-    the_symbol.type = type;
-    the_symbol.value = value;
-    return the_symbol;
-}
-
-function infix(id, bp, f) {
-
-// Make an infix operator.
-
-    const the_symbol = symbol(id, bp);
-    the_symbol.led = function (left) {
-        const the_token = token;
-        the_token.arity = "binary";
-        if (f !== undefined) {
-            return f(left);
-        }
-        the_token.expression = [left, expression(bp)];
-        return the_token;
-    };
-    return the_symbol;
-}
-
-function infixr(id, bp) {
-
-// Make a right associative infix operator.
-
-    const the_symbol = symbol(id, bp);
-    the_symbol.led = function (left) {
-
-// cause: "0**0"
-
-        const the_token = token;
-        the_token.arity = "binary";
-        the_token.expression = [left, expression(bp - 1)];
-        return the_token;
-    };
-    return the_symbol;
-}
-
-function post(id) {
-
-// Make one of the post operators.
-
-    const the_symbol = symbol(id, 150);
-    the_symbol.led = function (left) {
-        token.expression = left;
-        token.arity = "post";
-        mutation_check(token.expression);
-        return token;
-    };
-    return the_symbol;
-}
-
-function pre(id) {
-
-// Make one of the pre operators.
-
-    const the_symbol = symbol(id);
-    the_symbol.nud = function () {
-        const the_token = token;
-        the_token.arity = "pre";
-        the_token.expression = expression(150);
-        mutation_check(the_token.expression);
-        return the_token;
-    };
-    return the_symbol;
-}
-
-function prefix(id, f) {
-
-// Make a prefix operator.
-
-    const the_symbol = symbol(id);
-    the_symbol.nud = function () {
-        const the_token = token;
-        the_token.arity = "unary";
-        if (typeof f === "function") {
-            return f();
-        }
-        the_token.expression = expression(150);
-        return the_token;
-    };
-    return the_symbol;
-}
-
-function stmt(id, f) {
-
-// Make a statement.
-
-    const the_symbol = symbol(id);
-    the_symbol.fud = function () {
-        token.arity = "statement";
-        return f();
-    };
-    return the_symbol;
-}
-
-function ternary(id1, id2) {
-
-// Make a ternary operator.
-
-    const the_symbol = symbol(id1, 30);
-    the_symbol.led = function (left) {
-        const the_token = token;
-        const second = expression(20);
-        advance(id2);
-        token.arity = "ternary";
-        the_token.arity = "ternary";
-        the_token.expression = [left, second, expression(10)];
-        if (next_token.id !== ")") {
-
-// cause: "0?0:0"
-
-            warn("use_open", the_token);
-        }
-        return the_token;
-    };
-    return the_symbol;
-}
-
-// Begin defining the language.
-
-syntax = empty();
-
-symbol("}");
-symbol(")");
-symbol("]");
-symbol(",");
-symbol(";");
-symbol(":");
-symbol("*/");
-symbol("async");
-symbol("await");
-symbol("case");
-symbol("catch");
-symbol("class");
-symbol("default");
-symbol("else");
-symbol("enum");
-symbol("finally");
-symbol("implements");
-symbol("interface");
-symbol("package");
-symbol("private");
-symbol("protected");
-symbol("public");
-symbol("static");
-symbol("super");
-symbol("void");
-symbol("yield");
-
-constant("(number)", "number");
-constant("(regexp)", "regexp");
-constant("(string)", "string");
-constant("arguments", "object", function () {
-
-// cause: "arguments"
-
-    warn("unexpected_a", token);
-    return token;
-});
-constant("eval", "function", function () {
-    if (!option.eval) {
-
-// cause: "eval"
-
-        warn("unexpected_a", token);
-    } else if (next_token.id !== "(") {
-
-// cause: "/*jslint eval*/\neval"
-
-        warn("expected_a_before_b", next_token, "(", artifact());
-    }
-    return token;
-});
-constant("false", "boolean", false);
-constant("Function", "function", function () {
-    if (!option.eval) {
-
-// cause: "Function()"
-
-        warn("unexpected_a", token);
-    } else if (next_token.id !== "(") {
-
-// cause: "/*jslint eval*/\nFunction"
-
-        warn("expected_a_before_b", next_token, "(", artifact());
-    }
-    return token;
-});
-constant("ignore", "undefined", function () {
-
-// cause: "ignore"
-
-    warn("unexpected_a", token);
-    return token;
-});
-constant("Infinity", "number", Infinity);
-constant("isFinite", "function", function () {
-
-// cause: "isFinite"
-
-    warn("expected_a_b", token, "Number.isFinite", "isFinite");
-    return token;
-});
-constant("isNaN", "function", function () {
-
-// cause: "isNaN(0)"
-
-    warn("number_isNaN", token);
-    return token;
-});
-constant("NaN", "number", NaN);
-constant("null", "null", null);
-constant("this", "object", function () {
-    if (!option.this) {
-
-// cause: "this"
-
-        warn("unexpected_a", token);
-    }
-    return token;
-});
-constant("true", "boolean", true);
-constant("undefined", "undefined");
-
-assignment("=");
-assignment("+=");
-assignment("-=");
-assignment("*=");
-assignment("/=");
-assignment("%=");
-assignment("&=");
-assignment("|=");
-assignment("^=");
-assignment("<<=");
-assignment(">>=");
-assignment(">>>=");
-
-infix("??", 35);
-infix("||", 40);
-infix("&&", 50);
-infix("|", 70);
-infix("^", 80);
-infix("&", 90);
-infix("==", 100);
-infix("===", 100);
-infix("!=", 100);
-infix("!==", 100);
-infix("<", 110);
-infix(">", 110);
-infix("<=", 110);
-infix(">=", 110);
-infix("in", 110);
-infix("instanceof", 110);
-infix("<<", 120);
-infix(">>", 120);
-infix(">>>", 120);
-infix("+", 130);
-infix("-", 130);
-infix("*", 140);
-infix("/", 140);
-infix("%", 140);
-infixr("**", 150);
-infix("(", 160, function (left) {
-    const the_paren = token;
-    let the_argument;
-    if (left.id !== "function") {
-
-// cause: "(0?0:0)()"
-// cause: "0()"
-
-        left_check(left, the_paren);
-    }
-    if (functionage.arity === "statement" && left.identifier) {
-        functionage.name.calls[left.id] = left;
-    }
-    the_paren.expression = [left];
-    if (next_token.id !== ")") {
-        (function next() {
-            let ellipsis;
-            if (next_token.id === "...") {
-                ellipsis = true;
-                advance("...");
-            }
-            the_argument = expression(10);
-            if (ellipsis) {
-                the_argument.ellipsis = true;
-            }
-            the_paren.expression.push(the_argument);
-            if (next_token.id === ",") {
-                advance(",");
-                return next();
-            }
-        }());
-    }
-    advance(")", the_paren);
-    if (the_paren.expression.length === 2) {
-
-// cause: "aa(0)"
-
-        the_paren.free = true;
-        if (the_argument.wrapped === true) {
-
-// cause: "aa((0))"
-
-            warn("unexpected_a", the_paren);
-        }
-        if (the_argument.id === "(") {
-            the_argument.wrapped = true;
-        }
-    } else {
-
-// cause: "aa()"
-// cause: "aa(0,0)"
-
-        the_paren.free = false;
-    }
-    return the_paren;
-});
-infix(".", 170, function (left) {
-    const the_token = token;
-    const name = next_token;
-    if (
-        (
-            left.id !== "(string)"
-            || (name.id !== "indexOf" && name.id !== "repeat")
-        )
-        && (
-            left.id !== "["
-            || (
-                name.id !== "concat"
-                && name.id !== "forEach"
-                && name.id !== "join"
-                && name.id !== "map"
-            )
-        )
-        && (left.id !== "+" || name.id !== "slice")
-        && (
-            left.id !== "(regexp)"
-            || (name.id !== "exec" && name.id !== "test")
-        )
-    ) {
-
-// cause: "\"\".aa"
-
-        left_check(left, the_token);
-    }
-    if (!name.identifier) {
-
-// cause: "aa.0"
-
-        stop("expected_identifier_a");
-    }
-    advance();
-    survey(name);
-
-// The property name is not an expression.
-
-    the_token.name = name;
-    the_token.expression = left;
-    return the_token;
-});
-infix("?.", 170, function (left) {
-    const the_token = token;
-    const name = next_token;
-    if (
-        (
-            left.id !== "(string)"
-            || (name.id !== "indexOf" && name.id !== "repeat")
-        )
-        && (
-            left.id !== "["
-            || (
-                name.id !== "concat"
-                && name.id !== "forEach"
-                && name.id !== "join"
-                && name.id !== "map"
-            )
-        )
-
-// cause: "(0+0)?.0"
-
-        && (left.id !== "+" || name.id !== "slice")
-        && (
-            left.id !== "(regexp)"
-            || (name.id !== "exec" && name.id !== "test")
-        )
-    ) {
-
-// cause: "\"aa\"?.0"
-// cause: "(/./)?.0"
-// cause: "aa=[]?.aa"
-
-        left_check(left, the_token);
-    }
-    if (!name.identifier) {
-
-// cause: "aa?.0"
-
-        stop("expected_identifier_a");
-    }
-    advance();
-    survey(name);
-
-// The property name is not an expression.
-
-    the_token.name = name;
-    the_token.expression = left;
-    return the_token;
-});
-infix("[", 170, function (left) {
-    const the_token = token;
-    const the_subscript = expression(0);
-    if (the_subscript.id === "(string)" || the_subscript.id === "`") {
-        const name = survey(the_subscript);
-        if (rx_identifier.test(name)) {
-
-// cause: "aa[`aa`]"
-
-            warn("subscript_a", the_subscript, name);
-        }
-    }
-
-// cause: "0[0]"
-
-    left_check(left, the_token);
-    the_token.expression = [left, the_subscript];
-    advance("]");
-    return the_token;
-});
-infix("=>", 170, function (left) {
-
-// cause: "aa=>0"
-
-    return stop("wrap_parameter", left);
-});
-
-function do_tick() {
-    const the_tick = token;
-    the_tick.value = [];
-    the_tick.expression = [];
-    if (next_token.id !== "`") {
-        (function part() {
-            advance("(string)");
-            the_tick.value.push(token);
-            if (next_token.id === "${") {
-                advance("${");
-                the_tick.expression.push(expression(0));
-                advance("}");
-                return part();
-            }
-        }());
-    }
-    advance("`");
-    return the_tick;
-}
-
-infix("`", 160, function (left) {
-    const the_tick = do_tick();
-
-// cause: "0``"
-
-    left_check(left, the_tick);
-    the_tick.expression = [left].concat(the_tick.expression);
-    return the_tick;
-});
-
-post("++");
-post("--");
-pre("++");
-pre("--");
-
-prefix("+");
-prefix("-");
-prefix("~");
-prefix("!");
-prefix("!!");
-prefix("[", function () {
-    const the_token = token;
-    the_token.expression = [];
-    if (next_token.id !== "]") {
-        (function next() {
-            let element;
-            let ellipsis = false;
-            if (next_token.id === "...") {
-                ellipsis = true;
-                advance("...");
-            }
-            element = expression(10);
-            if (ellipsis) {
-                element.ellipsis = true;
-            }
-            the_token.expression.push(element);
-            if (next_token.id === ",") {
-                advance(",");
-                return next();
-            }
-        }());
-    }
-    advance("]");
-    return the_token;
-});
-prefix("/=", function () {
-
-// cause: "/="
-
-    stop("expected_a_b", token, "/\\=", "/=");
-});
-prefix("=>", function () {
-
-// cause: "=>0"
-
-    return stop("expected_a_before_b", token, "()", "=>");
-});
-prefix("new", function () {
-    const the_new = token;
-    const right = expression(160);
-    if (next_token.id !== "(") {
-
-// cause: "new aa"
-
-        warn("expected_a_before_b", next_token, "()", artifact(next_token));
-    }
-    the_new.expression = right;
-    return the_new;
-});
-prefix("typeof");
-prefix("void", function () {
-    const the_void = token;
-
-// cause: "void"
-// cause: "void 0"
-
-    warn("unexpected_a", the_void);
-    the_void.expression = expression(0);
-    return the_void;
-});
-
-function parameter_list() {
-    const list = [];
-    let optional;
-    const signature = ["("];
-    if (next_token.id !== ")" && next_token.id !== "(end)") {
-        (function parameter() {
-            let ellipsis = false;
-            let param;
-            if (next_token.id === "{") {
-                let a;
-                let b = "";
-                if (optional !== undefined) {
-
-// cause: "function aa(aa=0,{}){}"
-
-                    warn(
-                        "required_a_optional_b",
-                        next_token,
-                        next_token.id,
-                        optional.id
-                    );
-                }
-                param = next_token;
-                param.names = [];
-                advance("{");
-                signature.push("{");
-                (function subparameter() {
-                    let subparam = next_token;
-                    if (!subparam.identifier) {
-
-// cause: "function aa(aa=0,{}){}"
-// cause: "function aa({0}){}"
-
-                        return stop("expected_identifier_a");
-                    }
-                    survey(subparam);
-                    a = b;
-                    b = String(subparam.value || subparam.id);
-                    if (!option.unordered && a > b) {
-
-// cause: "function aa({bb,aa}){}"
-
-                        warn(
-                            "unordered_a_b",
-                            subparam,
-                            "Parameter",
-                            artifact(subparam)
-                        );
-                    }
-                    advance();
-                    signature.push(subparam.id);
-                    if (next_token.id === ":") {
-                        advance(":");
-                        advance();
-                        token.label = subparam;
-                        subparam = token;
-                        if (!subparam.identifier) {
-
-// cause: "function aa({aa:0}){}"
-
-                            return stop("expected_identifier_a");
-                        }
-                    }
-
-// cause: "function aa({aa=aa},aa){}"
-
-                    if (next_token.id === "=") {
-                        advance("=");
-                        subparam.expression = expression();
-                        param.open = true;
-                    }
-                    param.names.push(subparam);
-                    if (next_token.id === ",") {
-                        advance(",");
-                        signature.push(", ");
-                        return subparameter();
-                    }
-                }());
-                list.push(param);
-                advance("}");
-                signature.push("}");
-                if (next_token.id === ",") {
-                    advance(",");
-                    signature.push(", ");
-                    return parameter();
-                }
-            } else if (next_token.id === "[") {
-                if (optional !== undefined) {
-
-// cause: "function aa(aa=0,[]){}"
-
-                    warn(
-                        "required_a_optional_b",
-                        next_token,
-                        next_token.id,
-                        optional.id
-                    );
-                }
-                param = next_token;
-                param.names = [];
-                advance("[");
-                signature.push("[]");
-                (function subparameter() {
-                    const subparam = next_token;
-                    if (!subparam.identifier) {
-
-// cause: "function aa(aa=0,[]){}"
-
-                        return stop("expected_identifier_a");
-                    }
-                    advance();
-                    param.names.push(subparam);
-
-// cause: "function aa([aa=aa],aa){}"
-
-                    if (next_token.id === "=") {
-                        advance("=");
-                        subparam.expression = expression();
-                        param.open = true;
-                    }
-                    if (next_token.id === ",") {
-                        advance(",");
-                        return subparameter();
-                    }
-                }());
-                list.push(param);
-                advance("]");
-                if (next_token.id === ",") {
-                    advance(",");
-                    signature.push(", ");
-                    return parameter();
-                }
-            } else {
-                if (next_token.id === "...") {
-                    ellipsis = true;
-                    signature.push("...");
-                    advance("...");
-                    if (optional !== undefined) {
-
-// cause: "function aa(aa=0,...){}"
-
-                        warn(
-                            "required_a_optional_b",
-                            next_token,
-                            next_token.id,
-                            optional.id
-                        );
-                    }
-                }
-                if (!next_token.identifier) {
-
-// cause: "function aa(0){}"
-
-                    return stop("expected_identifier_a");
-                }
-                param = next_token;
-                list.push(param);
-                advance();
-                signature.push(param.id);
-                if (ellipsis) {
-                    param.ellipsis = true;
-                } else {
-                    if (next_token.id === "=") {
-                        optional = param;
-                        advance("=");
-                        param.expression = expression(0);
-                    } else {
-                        if (optional !== undefined) {
-
-// cause: "function aa(aa=0,bb){}"
-
-                            warn(
-                                "required_a_optional_b",
-                                param,
-                                param.id,
-                                optional.id
-                            );
-                        }
-                    }
-                    if (next_token.id === ",") {
-                        advance(",");
-                        signature.push(", ");
-                        return parameter();
-                    }
-                }
-            }
-        }());
-    }
-    advance(")");
-    signature.push(")");
-    return [list, signature.join("")];
-}
-
-function do_function(the_function) {
-    let name;
-    if (the_function === undefined) {
-        the_function = token;
-
-// A function statement must have a name that will be in the parent's scope.
-
-        if (the_function.arity === "statement") {
-            if (!next_token.identifier) {
-
-// cause: "function(){}"
-// cause: "function*aa(){}"
-
-                return stop("expected_identifier_a", next_token);
-            }
-            name = next_token;
-            enroll(name, "variable", true);
-            the_function.name = name;
-            name.init = true;
-            name.calls = empty();
-            advance();
-        } else if (name === undefined) {
-
-// A function expression may have an optional name.
-
-            if (next_token.identifier) {
-                name = next_token;
-                the_function.name = name;
-                advance();
-            } else {
-                the_function.name = anon;
-            }
-        }
-    } else {
-        name = the_function.name;
-    }
-    the_function.level = functionage.level + 1;
-    assert_or_throw(!mega_mode, `Expected !mega_mode.`);
-//  Probably deadcode.
-//  if (mega_mode) {
-//      warn("unexpected_a", the_function);
-//  }
-
-// Don't make functions in loops. It is inefficient, and it can lead to scoping
-// errors.
-
-    if (functionage.loop > 0) {
-
-// cause: "while(0){aa.map(function(){});}"
-
-        warn("function_in_loop", the_function);
-    }
-
-// Give the function properties for storing its names and for observing the
-// depth of loops and switches.
-
-    the_function.context = empty();
-    the_function.finally = 0;
-    the_function.loop = 0;
-    the_function.switch = 0;
-    the_function.try = 0;
-
-// Push the current function context and establish a new one.
-
-    stack.push(functionage);
-    functions.push(the_function);
-    functionage = the_function;
-    if (the_function.arity !== "statement" && typeof name === "object") {
-
-// cause: "let aa=function bb(){return;};"
-
-        enroll(name, "function", true);
-        name.dead = false;
-        name.init = true;
-        name.used = 1;
-    }
-
-// Parse the parameter list.
-
-    advance("(");
-
-// cause: "function(){}"
-
-    token.free = false;
-    token.arity = "function";
-    [functionage.parameters, functionage.signature] = parameter_list();
-    functionage.parameters.forEach(function enroll_parameter(name) {
-        if (name.identifier) {
-            enroll(name, "parameter", false);
-        } else {
-            name.names.forEach(enroll_parameter);
-        }
-    });
-
-// The function's body is a block.
-
-    the_function.block = block("body");
-    if (
-        the_function.arity === "statement"
-        && next_token.line === token.line
-    ) {
-
-// cause: "function aa(){}0"
-
-        return stop("unexpected_a", next_token);
-    }
-    if (
-        next_token.id === "."
-        || next_token.id === "?."
-        || next_token.id === "["
-    ) {
-
-// cause: "function aa(){}\n[]"
-
-        warn("unexpected_a");
-    }
-
-// Restore the previous context.
-
-    functionage = stack.pop();
-    return the_function;
-}
-
-function do_async() {
-    let the_async;
-    let the_function;
-    the_async = token;
-    advance("function");
-    the_function = token;
-    the_function.is_async = true;
-    the_function.arity = the_async.arity;
-    do_function();
-    if (!the_function.has_await) {
-
-// cause: "async function aa(){}"
-
-        warn("missing_await_statement", the_function);
-    }
-    return the_function;
-}
-
-prefix("async", do_async);
-prefix("function", do_function);
-prefix("await", function () {
-    let the_await;
-    the_await = token;
-    if (!functionage.is_async) {
-
-// cause: "await"
-// cause: "function aa(){await 0;}"
-
-        return stop("unexpected_a", the_await);
-    }
-    functionage.has_await = true;
-    the_await.expression = expression(150);
-    return the_await;
-});
-
-function fart(pl) {
-    advance("=>");
-    const the_fart = token;
-    the_fart.arity = "binary";
-    the_fart.name = "=>";
-    the_fart.level = functionage.level + 1;
-    functions.push(the_fart);
-    if (functionage.loop > 0) {
-
-// cause: "while(0){aa.map(()=>0);}"
-
-        warn("function_in_loop", the_fart);
-    }
-
-// Give the function properties storing its names and for observing the depth
-// of loops and switches.
-
-    the_fart.context = empty();
-    the_fart.finally = 0;
-    the_fart.loop = 0;
-    the_fart.switch = 0;
-    the_fart.try = 0;
-
-// Push the current function context and establish a new one.
-
-    stack.push(functionage);
-    functionage = the_fart;
-    the_fart.parameters = pl[0];
-    the_fart.signature = pl[1];
-    the_fart.parameters.forEach(function (name) {
-
-// cause: "(aa)=>{}"
-
-        enroll(name, "parameter", true);
-    });
-    if (next_token.id === "{") {
-
-// cause: "()=>{}"
-
-        warn("expected_a_b", the_fart, "function", "=>");
-        the_fart.block = block("body");
-    } else {
-        the_fart.expression = expression(0);
-    }
-    functionage = stack.pop();
-    return the_fart;
-}
-
-prefix("(", function () {
-    const the_paren = token;
-    let the_value;
-    const cadet = lookahead().id;
-
-// We can distinguish between a parameter list for => and a wrapped expression
-// with one token of lookahead.
-
-    if (
-        next_token.id === ")"
-        || next_token.id === "..."
-        || (next_token.identifier && (cadet === "," || cadet === "="))
-    ) {
-
-// cause: "()=>0"
-
-        the_paren.free = false;
-        return fart(parameter_list());
-    }
-
-// cause: "(0)"
-
-    the_paren.free = true;
-    the_value = expression(0);
-    if (the_value.wrapped === true) {
-
-// cause: "((0))"
-
-        warn("unexpected_a", the_paren);
-    }
-    the_value.wrapped = true;
-    advance(")", the_paren);
-    if (next_token.id === "=>") {
-        if (the_value.arity !== "variable") {
-            if (the_value.id === "{" || the_value.id === "[") {
-
-// cause: "([])=>0"
-// cause: "({})=>0"
-
-                warn("expected_a_before_b", the_paren, "function", "(");
-
-// cause: "([])=>0"
-// cause: "({})=>0"
-
-                return stop("expected_a_b", next_token, "{", "=>");
-            }
-
-// cause: "(0)=>0"
-
-            return stop("expected_identifier_a", the_value);
-        }
-        the_paren.expression = [the_value];
-        return fart([the_paren.expression, "(" + the_value.id + ")"]);
-    }
-    return the_value;
-});
-prefix("`", do_tick);
-prefix("{", function () {
-    const the_brace = token;
-    const seen = empty();
-    the_brace.expression = [];
-    if (next_token.id !== "}") {
-        let a;
-        let b = "";
-        (function member() {
-            let extra;
-            let full;
-            let id;
-            let name = next_token;
-            let value;
-            advance();
-            a = b;
-            b = String(name.value || name.id);
-            if (!option.unordered && a > b) {
-
-// cause: "aa={bb,aa}"
-
-                warn("unordered_a_b", name, "Property", artifact(name));
-            }
-            if (
-                (name.id === "get" || name.id === "set")
-                && next_token.identifier
-            ) {
-                if (!option.getset) {
-
-// cause: "aa={get aa(){}}"
-
-                    warn("unexpected_a", name);
-                }
-                extra = name.id;
-                full = extra + " " + next_token.id;
-                name = next_token;
-                advance();
-                id = survey(name);
-                if (seen[full] === true || seen[id] === true) {
-
-// cause: "aa={get aa(){},get aa(){}}"
-
-                    warn("duplicate_a", name);
-                }
-                seen[id] = false;
-                seen[full] = true;
-            } else {
-                id = survey(name);
-                if (typeof seen[id] === "boolean") {
-
-// cause: "aa={aa,aa}"
-
-                    warn("duplicate_a", name);
-                }
-                seen[id] = true;
-            }
-            if (name.identifier) {
-                if (next_token.id === "}" || next_token.id === ",") {
-                    if (typeof extra === "string") {
-
-// cause: "aa={get aa}"
-
-                        advance("(");
-                    }
-                    value = expression(Infinity, true);
-                } else if (next_token.id === "(") {
-                    value = do_function({
-                        arity: "unary",
-                        from: name.from,
-                        id: "function",
-                        line: name.line,
-                        name: (
-                            typeof extra === "string"
-
-// cause: "aa={get aa(){}}"
-
-                            ? extra
-
-// cause: "aa={aa()}"
-
-                            : id
-                        ),
-                        thru: name.from
-                    });
-                } else {
-                    if (typeof extra === "string") {
-
-// cause: "aa={get aa.aa}"
-
-                        advance("(");
-                    }
-                    let the_colon = next_token;
-                    advance(":");
-                    value = expression(0);
-                    if (value.id === name.id && value.id !== "function") {
-
-// cause: "aa={aa:aa}"
-
-                        warn("unexpected_a", the_colon, ": " + name.id);
-                    }
-                }
-                value.label = name;
-                if (typeof extra === "string") {
-                    value.extra = extra;
-                }
-                the_brace.expression.push(value);
-            } else {
-                advance(":");
-                value = expression(0);
-                value.label = name;
-                the_brace.expression.push(value);
-            }
-            if (next_token.id === ",") {
-                advance(",");
-                return member();
-            }
-        }());
-    }
-    advance("}");
-    return the_brace;
-});
-
-stmt(";", function () {
-
-// cause: ";"
-
-    warn("unexpected_a", token);
-    return token;
-});
-stmt("{", function () {
-
-// cause: ";{}"
-// cause: "class aa{}"
-
-    warn("naked_block", token);
-    return block("naked");
-});
-stmt("async", do_async);
-stmt("break", function () {
-    const the_break = token;
-    let the_label;
-    if (
-        (functionage.loop < 1 && functionage.switch < 1)
-        || functionage.finally > 0
-    ) {
-
-// cause: "break"
-
-        warn("unexpected_a", the_break);
-    }
-    the_break.disrupt = true;
-    if (next_token.identifier && token.line === next_token.line) {
-        the_label = functionage.context[next_token.id];
-        if (
-            the_label === undefined
-            || the_label.role !== "label"
-            || the_label.dead
-        ) {
-            if (the_label !== undefined && the_label.dead) {
-
-// cause: "aa:{function aa(aa){break aa;}}"
-
-                warn("out_of_scope_a");
-            } else {
-
-// cause: "aa:{break aa;}"
-
-                warn("not_label_a");
-            }
-        } else {
-            the_label.used += 1;
-        }
-        the_break.label = next_token;
-        advance();
-    }
-    advance(";");
-    return the_break;
-});
-
-function do_var() {
-    const the_statement = token;
-    const is_const = the_statement.id === "const";
-    the_statement.names = [];
-
-// A program may use var or let, but not both.
-
-    if (!is_const) {
-        if (var_mode === undefined) {
-            var_mode = the_statement.id;
-        } else if (the_statement.id !== var_mode) {
-
-// cause: "let aa;var aa"
-
-            warn(
-                "expected_a_b",
-                the_statement,
-                var_mode,
-                the_statement.id
-            );
-        }
-    }
-
-// We don't expect to see variables created in switch statements.
-
-    if (functionage.switch > 0) {
-
-// cause: "switch(0){case 0:var aa}"
-
-        warn("var_switch", the_statement);
-    }
-    if (functionage.loop > 0 && the_statement.id === "var") {
-
-// cause: "while(0){var aa;}"
-
-        warn("var_loop", the_statement);
-    }
-    (function next() {
-        if (next_token.id === "{" && the_statement.id !== "var") {
-            let a;
-            let b = "";
-            const the_brace = next_token;
-            advance("{");
-            (function pair() {
-                if (!next_token.identifier) {
-
-// cause: "let {0}"
-
-                    return stop("expected_identifier_a", next_token);
-                }
-                const name = next_token;
-                survey(name);
-                a = b;
-                b = String(name.value || name.id);
-                if (!option.unordered && a > b) {
-
-// cause: "let{bb,aa}"
-
-                    warn("unordered_a_b", name, "Parameter", artifact(name));
-                }
-                advance();
-                if (next_token.id === ":") {
-                    advance(":");
-                    if (!next_token.identifier) {
-
-// cause: "let {aa:0}"
-// cause: "let {aa:{aa}}"
-
-                        return stop("expected_identifier_a", next_token);
-                    }
-                    next_token.label = name;
-                    the_statement.names.push(next_token);
-                    enroll(next_token, "variable", is_const);
-                    advance();
-                    the_brace.open = true;
-                } else {
-                    the_statement.names.push(name);
-                    enroll(name, "variable", is_const);
-                }
-                name.dead = false;
-                name.init = true;
-                if (next_token.id === "=") {
-
-// cause: "let {aa=0}"
-
-                    advance("=");
-                    name.expression = expression();
-                    the_brace.open = true;
-                }
-                if (next_token.id === ",") {
-                    advance(",");
-                    return pair();
-                }
-            }());
-            advance("}");
-            advance("=");
-            the_statement.expression = expression(0);
-        } else if (next_token.id === "[" && the_statement.id !== "var") {
-            const the_bracket = next_token;
-            advance("[");
-            (function element() {
-                let ellipsis;
-                if (next_token.id === "...") {
-                    ellipsis = true;
-                    advance("...");
-                }
-                if (!next_token.identifier) {
-
-// cause: "let[]"
-
-                    return stop("expected_identifier_a", next_token);
-                }
-                const name = next_token;
-                advance();
-                the_statement.names.push(name);
-                enroll(name, "variable", is_const);
-                name.dead = false;
-                name.init = true;
-                if (ellipsis) {
-                    name.ellipsis = true;
-                } else {
-                    if (next_token.id === "=") {
-                        advance("=");
-                        name.expression = expression();
-                        the_bracket.open = true;
-                    }
-                    if (next_token.id === ",") {
-                        advance(",");
-                        return element();
-                    }
-                }
-            }());
-            advance("]");
-            advance("=");
-            the_statement.expression = expression(0);
-        } else if (next_token.identifier) {
-            const name = next_token;
-            advance();
-            if (name.id === "ignore") {
-
-// cause: "let ignore;function aa(ignore) {}"
-
-                warn("unexpected_a", name);
-            }
-            enroll(name, "variable", is_const);
-            if (next_token.id === "=" || is_const) {
-                advance("=");
-                name.dead = false;
-                name.init = true;
-                name.expression = expression(0);
-            }
-            the_statement.names.push(name);
-        } else {
-
-// cause: "let 0"
-// cause: "var{aa:{aa}}"
-
-            return stop("expected_identifier_a", next_token);
-        }
-    }());
-    semicolon();
-    return the_statement;
-}
-
-stmt("const", do_var);
-stmt("continue", function () {
-    const the_continue = token;
-    if (functionage.loop < 1 || functionage.finally > 0) {
-
-// cause: "continue"
-// cause: "function aa(){while(0){try{}finally{continue}}}"
-
-        warn("unexpected_a", the_continue);
-    }
-    not_top_level(the_continue);
-    the_continue.disrupt = true;
-    warn("unexpected_a", the_continue);
-    advance(";");
-    return the_continue;
-});
-stmt("debugger", function () {
-    const the_debug = token;
-    if (!option.devel) {
-
-// cause: "debugger"
-
-        warn("unexpected_a", the_debug);
-    }
-    semicolon();
-    return the_debug;
-});
-stmt("delete", function () {
-    const the_token = token;
-    const the_value = expression(0);
-    if (
-        (the_value.id !== "." && the_value.id !== "[")
-        || the_value.arity !== "binary"
-    ) {
-
-// cause: "delete 0"
-
-        stop("expected_a_b", the_value, ".", artifact(the_value));
-    }
-    the_token.expression = the_value;
-    semicolon();
-    return the_token;
-});
-stmt("do", function () {
-    const the_do = token;
-    not_top_level(the_do);
-    functionage.loop += 1;
-    the_do.block = block();
-    advance("while");
-    the_do.expression = condition();
-    semicolon();
-    if (the_do.block.disrupt === true) {
-
-// cause: "function aa(){do{break;}while(0)}"
-
-        warn("weird_loop", the_do);
-    }
-    functionage.loop -= 1;
-    return the_do;
-});
-stmt("export", function () {
-    const the_export = token;
-    let the_id;
-    let the_name;
-    let the_thing;
-
-    function export_id() {
-        if (!next_token.identifier) {
-
-// cause: "export {}"
-
-            stop("expected_identifier_a");
-        }
-        the_id = next_token.id;
-        the_name = global.context[the_id];
-        if (the_name === undefined) {
-
-// cause: "export {aa}"
-
-            warn("unexpected_a");
-        } else {
-            the_name.used += 1;
-            if (exports[the_id] !== undefined) {
-
-// cause: "let aa;export{aa,aa}"
-
-                warn("duplicate_a");
-            }
-            exports[the_id] = the_name;
-        }
-        advance();
-        the_export.expression.push(the_thing);
-    }
-
-    the_export.expression = [];
-    if (next_token.id === "default") {
-        if (exports.default !== undefined) {
-
-// cause: "export default 0;export default 0"
-
-            warn("duplicate_a");
-        }
-        advance("default");
-        the_thing = expression(0);
-        if (
-            the_thing.id !== "("
-            || the_thing.expression[0].id !== "."
-            || the_thing.expression[0].expression.id !== "Object"
-            || the_thing.expression[0].name.id !== "freeze"
-        ) {
-
-// cause: "export default {}"
-
-            warn("freeze_exports", the_thing);
-        } else {
-
-// cause: "export default Object.freeze({})"
-
-            semicolon();
-        }
-        exports.default = the_thing;
-        the_export.expression.push(the_thing);
-    } else {
-        if (next_token.id === "function") {
-
-// cause: "export function aa(){}"
-
-            warn("freeze_exports");
-            the_thing = statement();
-            the_name = the_thing.name;
-            the_id = the_name.id;
-            the_name.used += 1;
-
-// cause: "let aa;export{aa};export function aa(){}"
-
-            if (exports[the_id] !== undefined) {
-                warn("duplicate_a", the_name);
-            }
-            exports[the_id] = the_thing;
-            the_export.expression.push(the_thing);
-            the_thing.statement = false;
-            the_thing.arity = "unary";
-        } else if (
-            next_token.id === "var"
-            || next_token.id === "let"
-            || next_token.id === "const"
-        ) {
-
-// cause: "export const"
-// cause: "export let"
-// cause: "export var"
-
-            warn("unexpected_a", next_token);
-            statement();
-        } else if (next_token.id === "{") {
-
-// cause: "export {}"
-
-            advance("{");
-            (function loop() {
-                export_id();
-                if (next_token.id === ",") {
-                    advance(",");
-                    return loop();
-                }
-            }());
-            advance("}");
-            semicolon();
-        } else {
-
-// cause: "export"
-
-            stop("unexpected_a");
-        }
-    }
-    module_mode = true;
-    return the_export;
-});
-stmt("for", function () {
-    let first;
-    const the_for = token;
-    if (!option.for) {
-
-// cause: "for"
-
-        warn("unexpected_a", the_for);
-    }
-    not_top_level(the_for);
-    functionage.loop += 1;
-    advance("(");
-
-// cause: "for(){}"
-
-    token.free = true;
-    if (next_token.id === ";") {
-
-// cause: "for(;;){}"
-
-        return stop("expected_a_b", the_for, "while (", "for (;");
-    }
-    if (
-        next_token.id === "var"
-        || next_token.id === "let"
-        || next_token.id === "const"
-    ) {
-
-// cause: "for(const aa in aa){}"
-
-        return stop("unexpected_a");
-    }
-    first = expression(0);
-    if (first.id === "in") {
-        if (first.expression[0].arity !== "variable") {
-
-// cause: "for(0 in aa){}"
-
-            warn("bad_assignment_a", first.expression[0]);
-        }
-        the_for.name = first.expression[0];
-        the_for.expression = first.expression[1];
-        warn("expected_a_b", the_for, "Object.keys", "for in");
-    } else {
-        the_for.initial = first;
-        advance(";");
-        the_for.expression = expression(0);
-        advance(";");
-        the_for.inc = expression(0);
-        if (the_for.inc.id === "++") {
-
-// cause: "for(aa;aa;aa++){}"
-
-            warn("expected_a_b", the_for.inc, "+= 1", "++");
-        }
-    }
-    advance(")");
-    the_for.block = block();
-    if (the_for.block.disrupt === true) {
-
-// cause: "/*jslint for*/\nfunction aa(bb,cc){for(0;0;0){break;}}"
-
-        warn("weird_loop", the_for);
-    }
-    functionage.loop -= 1;
-    return the_for;
-});
-stmt("function", do_function);
-stmt("if", function () {
-    let the_else;
-    const the_if = token;
-    the_if.expression = condition();
-    the_if.block = block();
-    if (next_token.id === "else") {
-        advance("else");
-        the_else = token;
-        the_if.else = (
-            next_token.id === "if"
-
-// cause: "if(0){0}else if(0){0}"
-
-            ? statement()
-
-// cause: "if(0){0}else{0}"
-
-            : block()
-        );
-        if (the_if.block.disrupt === true) {
-            if (the_if.else.disrupt === true) {
-
-// cause: "if(0){break;}else{}"
-
-                the_if.disrupt = true;
-            } else {
-
-// cause: "if(0){break;}else{}"
-
-                warn("unexpected_a", the_else);
-            }
-        }
-    }
-    return the_if;
-});
-stmt("import", function () {
-    const the_import = token;
-    if (next_token.id === "(") {
-        the_import.arity = "unary";
-        the_import.constant = true;
-        the_import.statement = false;
-        advance("(");
-        const string = expression(0);
-        if (string.id !== "(string)") {
-
-// cause: "import(aa)"
-
-            warn("expected_string_a", string);
-        }
-        froms.push(token.value);
-        advance(")");
-        advance(".");
-        advance("then");
-        advance("(");
-        the_import.expression = expression(0);
-        advance(")");
-        semicolon();
-        return the_import;
-    }
-    let name;
-    if (typeof module_mode === "object") {
-
-// cause: "/*global aa*/\nimport aa from \"aa\""
-
-        warn("unexpected_directive_a", module_mode, module_mode.directive);
-    }
-    module_mode = true;
-    if (next_token.identifier) {
-        name = next_token;
-        advance();
-        if (name.id === "ignore") {
-
-// cause: "import ignore from \"aa\""
-
-            warn("unexpected_a", name);
-        }
-        enroll(name, "variable", true);
-        the_import.name = name;
-    } else {
-        const names = [];
-        advance("{");
-        if (next_token.id !== "}") {
-            while (true) {
-                if (!next_token.identifier) {
-
-// cause: "import {"
-
-                    stop("expected_identifier_a");
-                }
-                name = next_token;
-                advance();
-                if (name.id === "ignore") {
-
-// cause: "import {ignore} from \"aa\""
-
-                    warn("unexpected_a", name);
-                }
-                enroll(name, "variable", true);
-                names.push(name);
-                if (next_token.id !== ",") {
-                    break;
-                }
-                advance(",");
-            }
-        }
-        advance("}");
-        the_import.name = names;
-    }
-    advance("from");
-    advance("(string)");
-    the_import.import = token;
-    if (!rx_module.test(token.value)) {
-
-// cause: "import aa from \"!aa\""
-
-        warn("bad_module_name_a", token);
-    }
-    froms.push(token.value);
-    semicolon();
-    return the_import;
-});
-stmt("let", do_var);
-stmt("return", function () {
-    const the_return = token;
-    not_top_level(the_return);
-    if (functionage.finally > 0) {
-
-// cause: "function aa(){try{}finally{return;}}"
-
-        warn("unexpected_a", the_return);
-    }
-    the_return.disrupt = true;
-    if (next_token.id !== ";" && the_return.line === next_token.line) {
-        the_return.expression = expression(10);
-    }
-    advance(";");
-    return the_return;
-});
-stmt("switch", function () {
-    let dups = [];
-    let last;
-    let stmts;
-    const the_cases = [];
-    let the_disrupt = true;
-    const the_switch = token;
-    not_top_level(the_switch);
-    if (functionage.finally > 0) {
-
-// cause: "function aa(){try{}finally{switch(0){}}}"
-
-        warn("unexpected_a", the_switch);
-    }
-    functionage.switch += 1;
-    advance("(");
-
-// cause: "switch(){}"
-
-    token.free = true;
-    the_switch.expression = expression(0);
-    the_switch.block = the_cases;
-    advance(")");
-    advance("{");
-    (function major() {
-        const the_case = next_token;
-        the_case.arity = "statement";
-        the_case.expression = [];
-        (function minor() {
-            advance("case");
-            token.switch = true;
-            const exp = expression(0);
-            if (dups.some(function (thing) {
-                return are_similar(thing, exp);
-            })) {
-
-// cause: "switch(0){case 0:break;case 0:break}"
-
-                warn("unexpected_a", exp);
-            }
-            dups.push(exp);
-            the_case.expression.push(exp);
-            advance(":");
-            if (next_token.id === "case") {
-                return minor();
-            }
-        }());
-        stmts = statements();
-        if (stmts.length < 1) {
-
-// cause: "switch(0){case 0:}"
-
-            warn("expected_statements_a");
-            return;
-        }
-        the_case.block = stmts;
-        the_cases.push(the_case);
-        last = stmts[stmts.length - 1];
-        if (last.disrupt) {
-            if (last.id === "break" && last.label === undefined) {
-                the_disrupt = false;
-            }
-        } else {
-            warn(
-                "expected_a_before_b",
-                next_token,
-                "break;",
-                artifact(next_token)
-            );
-        }
-        if (next_token.id === "case") {
-            return major();
-        }
-    }());
-    dups = undefined;
-    if (next_token.id === "default") {
-        const the_default = next_token;
-        advance("default");
-        token.switch = true;
-        advance(":");
-        the_switch.else = statements();
-        if (the_switch.else.length < 1) {
-
-// cause: "switch(0){case 0:break;default:}"
-
-            warn("unexpected_a", the_default);
-            the_disrupt = false;
-        } else {
-            const the_last = the_switch.else[the_switch.else.length - 1];
-            if (the_last.id === "break" && the_last.label === undefined) {
-
-// cause: "switch(0){case 0:break;default:break;}"
-
-                warn("unexpected_a", the_last);
-                the_last.disrupt = false;
-            }
-            the_disrupt = the_disrupt && the_last.disrupt;
-        }
-    } else {
-        the_disrupt = false;
-    }
-    advance("}", the_switch);
-    functionage.switch -= 1;
-    the_switch.disrupt = the_disrupt;
-    return the_switch;
-});
-stmt("throw", function () {
-    const the_throw = token;
-    the_throw.disrupt = true;
-    the_throw.expression = expression(10);
-    semicolon();
-    if (functionage.try > 0) {
-
-// cause: "try{throw 0}catch(){}"
-
-        warn("unexpected_a", the_throw);
-    }
-    return the_throw;
-});
-stmt("try", function () {
-    const the_try = token;
-    let ignored;
-    let the_catch;
-    let the_disrupt;
-    if (functionage.try > 0) {
-
-// cause: "try{try{}catch(){}}catch(){}"
-
-        warn("unexpected_a", the_try);
-    }
-    functionage.try += 1;
-    the_try.block = block();
-    the_disrupt = the_try.block.disrupt;
-    if (next_token.id === "catch") {
-        advance("catch");
-        the_catch = next_token;
-        ignored = "ignore";
-        the_try.catch = the_catch;
-
-// Create new function-scope for catch-parameter.
-
-        stack.push(functionage);
-        functionage = the_catch;
-        functionage.context = empty();
-        if (next_token.id === "(") {
-            advance("(");
-            if (!next_token.identifier) {
-
-// cause: "try{}catch(){}"
-
-                return stop("expected_identifier_a", next_token);
-            }
-            if (next_token.id !== "ignore") {
-                ignored = undefined;
-                the_catch.name = next_token;
-                enroll(next_token, "exception", true);
-            }
-            advance();
-            advance(")");
-        }
-        the_catch.block = block(ignored);
-        if (the_catch.block.disrupt !== true) {
-            the_disrupt = false;
-        }
-
-// Restore previous function-scope after catch-block.
-
-        functionage = stack.pop();
-    } else {
-
-// cause: "try{}finally{break;}"
-
-        warn(
-            "expected_a_before_b",
-            next_token,
-            "catch",
-            artifact(next_token)
-        );
-
-    }
-    if (next_token.id === "finally") {
-        functionage.finally += 1;
-        advance("finally");
-        the_try.else = block();
-        the_disrupt = the_try.else.disrupt;
-        functionage.finally -= 1;
-    }
-    the_try.disrupt = the_disrupt;
-    functionage.try -= 1;
-    return the_try;
-});
-stmt("var", do_var);
-stmt("while", function () {
-    const the_while = token;
-    not_top_level(the_while);
-    functionage.loop += 1;
-    the_while.expression = condition();
-    the_while.block = block();
-    if (the_while.block.disrupt === true) {
-
-// cause: "function aa(){while(0){break;}}"
-
-        warn("weird_loop", the_while);
-    }
-    functionage.loop -= 1;
-    return the_while;
-});
-stmt("with", function () {
-
-// cause: "with"
-
-    stop("unexpected_a", token);
-});
-
-ternary("?", ":");
-
-// Ambulation of the parse tree.
-
-function action(when) {
-
-// Produce a function that will register task functions that will be called as
-// the tree is traversed.
-
-    return function (arity, id, task) {
-        let a_set = when[arity];
-        let i_set;
-
-// The id parameter is optional. If excluded, the task will be applied to all
-// ids.
-
-        if (typeof id !== "string") {
-            task = id;
-            id = "(all)";
-        }
-
-// If this arity has no registrations yet, then create a set object to hold
-// them.
-
-        if (a_set === undefined) {
-            a_set = empty();
-            when[arity] = a_set;
-        }
-
-// If this id has no registrations yet, then create a set array to hold them.
-
-        i_set = a_set[id];
-        if (i_set === undefined) {
-            i_set = [];
-            a_set[id] = i_set;
-        }
-
-// Register the task with the arity and the id.
-
-        i_set.push(task);
-    };
-}
-
-function amble(when) {
-
-// Produce a function that will act on the tasks registered by an action
-// function while walking the tree.
-
-    return function (the_token) {
-
-// Given a task set that was built by an action function, run all of the
-// relevant tasks on the token.
-
-        let a_set = when[the_token.arity];
-        let i_set;
-
-// If there are tasks associated with the token's arity...
-
-        if (a_set !== undefined) {
-
-// If there are tasks associated with the token's id...
-
-            i_set = a_set[the_token.id];
-            if (i_set !== undefined) {
-                i_set.forEach(function (task) {
-                    return task(the_token);
-                });
-            }
-
-// If there are tasks for all ids.
-
-            i_set = a_set["(all)"];
-            if (i_set !== undefined) {
-                i_set.forEach(function (task) {
-                    return task(the_token);
-                });
-            }
-        }
-    };
-}
-
-const posts = empty();
-const pres = empty();
-const preaction = action(pres);
-const postaction = action(posts);
-const preamble = amble(pres);
-const postamble = amble(posts);
-
-function walk_expression(thing) {
-    if (thing) {
-        if (Array.isArray(thing)) {
-
-// cause: "(function(){}())"
-// cause: "0&&0"
-
-            thing.forEach(walk_expression);
-        } else {
-            preamble(thing);
-            walk_expression(thing.expression);
-            if (thing.id === "function") {
-
-// cause: "aa=function(){}"
-
-                walk_statement(thing.block);
-            }
-            if (thing.arity === "pre" || thing.arity === "post") {
-
-// cause: "aa=++aa"
-// cause: "aa=--aa"
-
-                warn("unexpected_a", thing);
-            } else if (
-
-// cause: "aa=0"
-
-                thing.arity === "statement"
-                || thing.arity === "assignment"
-            ) {
-
-// cause: "aa[aa=0]"
-
-                warn("unexpected_statement_a", thing);
-            }
-            postamble(thing);
-        }
-    }
-}
-
-function walk_statement(thing) {
-    if (thing) {
-        if (Array.isArray(thing)) {
-
-// cause: "+[]"
-
-            thing.forEach(walk_statement);
-        } else {
-            preamble(thing);
-            walk_expression(thing.expression);
-            if (thing.arity === "binary") {
-                if (thing.id !== "(") {
-
-// cause: "0&&0"
-
-                    warn("unexpected_expression_a", thing);
-                }
-            } else if (
-                thing.arity !== "statement"
-                && thing.arity !== "assignment"
-                && thing.id !== "import"
-                && thing.id !== "await"
-            ) {
-
-// cause: "!0"
-// cause: "+[]"
-// cause: "+new aa()"
-// cause: "0"
-
-                warn("unexpected_expression_a", thing);
-            }
-            walk_statement(thing.block);
-            walk_statement(thing.else);
-            postamble(thing);
-        }
-    }
-}
-
-function lookup(thing) {
-    if (thing.arity === "variable") {
-
-// Look up the variable in the current context.
-
-        let the_variable = functionage.context[thing.id];
-
-// If it isn't local, search all the other contexts. If there are name
-// collisions, take the most recent.
-
-        if (the_variable === undefined) {
-            stack.forEach(function (outer) {
-                const a_variable = outer.context[thing.id];
-                if (
-                    a_variable !== undefined
-                    && a_variable.role !== "label"
-                ) {
-                    the_variable = a_variable;
-                }
-            });
-
-// If it isn't in any of those either, perhaps it is a predefined global.
-// If so, add it to the global context.
-
-            if (the_variable === undefined) {
-                if (declared_globals[thing.id] === undefined) {
-
-// cause: "aa"
-// cause: "class aa{}"
-// cause: "let aa=0;try{aa();}catch(bb){bb();}bb();"
-
-                    warn("undeclared_a", thing);
-                    return;
-                }
-                the_variable = {
-                    dead: false,
-                    id: thing.id,
-                    init: true,
-                    parent: global,
-                    role: "variable",
-                    used: 0,
-                    writable: false
-                };
-                global.context[thing.id] = the_variable;
-            }
-            the_variable.closure = true;
-            functionage.context[thing.id] = the_variable;
-        } else if (the_variable.role === "label") {
-
-// cause: "aa:while(0){aa;}"
-
-            warn("label_a", thing);
-        }
-        if (
-            the_variable.dead
-            && (
-                the_variable.calls === undefined
-                || functionage.name === undefined
-                || the_variable.calls[functionage.name.id] === undefined
-            )
-        ) {
-
-// cause: "function aa(){bb();}\nfunction bb(){}"
-
-            warn("out_of_scope_a", thing);
-        }
-        return the_variable;
-    }
-}
-
-function subactivate(name) {
-    name.init = true;
-    name.dead = false;
-    blockage.live.push(name);
-}
-
-function preaction_function(thing) {
-
-// cause: "()=>0"
-// cause: "(function (){}())"
-// cause: "function aa(){}"
-
-    if (thing.arity === "statement" && blockage.body !== true) {
-
-// cause: "if(0){function aa(){}\n}"
-
-        warn("unexpected_a", thing);
-    }
-    stack.push(functionage);
-    block_stack.push(blockage);
-    functionage = thing;
-    blockage = thing;
-    thing.live = [];
-    if (typeof thing.name === "object") {
-        thing.name.dead = false;
-        thing.name.init = true;
-    }
-    if (thing.extra === "get") {
-        if (thing.parameters.length !== 0) {
-
-// cause: "/*jslint getset*/\naa={get aa(aa){}}"
-
-            warn("bad_get", thing);
-        }
-    } else if (thing.extra === "set") {
-        if (thing.parameters.length !== 1) {
-
-// cause: "/*jslint getset*/\naa={set aa(){}}"
-
-            warn("bad_set", thing);
-        }
-    }
-    thing.parameters.forEach(function (name) {
-        walk_expression(name.expression);
-        if (name.id === "{" || name.id === "[") {
-            name.names.forEach(subactivate);
-        } else {
-            name.dead = false;
-            name.init = true;
-        }
-    });
-}
-
-function bitwise_check(thing) {
-    if (!option.bitwise && bitwiseop[thing.id] === true) {
-
-// cause: "0&0"
-// cause: "0&=0"
-// cause: "0<<0"
-// cause: "0<<=0"
-// cause: "0>>0"
-// cause: "0>>=0"
-// cause: "0>>>0"
-// cause: "0>>>=0"
-// cause: "0^0"
-// cause: "0^=0"
-// cause: "0|0"
-// cause: "0|=0"
-// cause: "0~0"
-// cause: "~0"
-
-        warn("unexpected_a", thing);
-    }
-    if (
-        thing.id !== "("
-        && thing.id !== "&&"
-        && thing.id !== "||"
-        && thing.id !== "="
-        && Array.isArray(thing.expression)
-        && thing.expression.length === 2
-        && (
-            relationop[thing.expression[0].id] === true
-            || relationop[thing.expression[1].id] === true
-        )
-    ) {
-
-// cause: "0<0<0"
-
-        warn("unexpected_a", thing);
-    }
-}
-
-function pop_block() {
-    blockage.live.forEach(function (name) {
-        name.dead = true;
-    });
-    delete blockage.live;
-    blockage = block_stack.pop();
-}
-
-function action_var(thing) {
-    thing.names.forEach(function (name) {
-        name.dead = false;
-        if (name.expression !== undefined) {
-            walk_expression(name.expression);
-            assert_or_throw(
-                !(name.id === "{" || name.id === "["),
-                `Expected !(name.id === "{" || name.id === "[").`
-            );
-//          Probably deadcode.
-//          if (name.id === "{" || name.id === "[") {
-//              name.names.forEach(subactivate);
-//          } else {
-//              name.init = true;
-//          }
-            name.init = true;
-        }
-        blockage.live.push(name);
-    });
-}
-
-preaction("assignment", bitwise_check);
-preaction("binary", bitwise_check);
-preaction("binary", function (thing) {
-    if (relationop[thing.id] === true) {
-        const left = thing.expression[0];
-        const right = thing.expression[1];
-        if (left.id === "NaN" || right.id === "NaN") {
-
-// cause: "NaN===NaN"
-
-            warn("number_isNaN", thing);
-        } else if (left.id === "typeof") {
-            if (right.id !== "(string)") {
-                if (right.id !== "typeof") {
-
-// cause: "typeof 0===0"
-
-                    warn("expected_string_a", right);
-                }
-            } else {
-                const value = right.value;
-                if (value === "null" || value === "undefined") {
-
-// cause: "typeof aa===\"undefined\""
-
-                    warn("unexpected_typeof_a", right, value);
-                } else if (
-                    value !== "boolean"
-                    && value !== "function"
-                    && value !== "number"
-                    && value !== "object"
-                    && value !== "string"
-                    && value !== "symbol"
-                ) {
-
-// cause: "typeof 0===\"aa\""
-
-                    warn("expected_type_string_a", right, value);
-                }
-            }
-        }
-    }
-});
-preaction("binary", "==", function (thing) {
-
-// cause: "0==0"
-
-    warn("expected_a_b", thing, "===", "==");
-});
-preaction("binary", "!=", function (thing) {
-
-// cause: "0!=0"
-
-    warn("expected_a_b", thing, "!==", "!=");
-});
-preaction("binary", "=>", preaction_function);
-preaction("binary", "||", function (thing) {
-    thing.expression.forEach(function (thang) {
-        if (thang.id === "&&" && !thang.wrapped) {
-
-// cause: "0&&0||0"
-
-            warn("and", thang);
-        }
-    });
-});
-preaction("binary", "(", function (thing) {
-    const left = thing.expression[0];
-    if (
-        left.identifier
-        && functionage.context[left.id] === undefined
-        && typeof functionage.name === "object"
-    ) {
-        const parent = functionage.name.parent;
-        if (parent) {
-            const left_variable = parent.context[left.id];
-            if (
-                left_variable !== undefined
-                && left_variable.dead
-                && left_variable.parent === parent
-                && left_variable.calls !== undefined
-                && left_variable.calls[functionage.name.id] !== undefined
-            ) {
-                left_variable.dead = false;
-            }
-        }
-    }
-});
-preaction("binary", "in", function (thing) {
-
-// cause: "aa in aa"
-
-    warn("infix_in", thing);
-});
-preaction("binary", "instanceof", function (thing) {
-
-// cause: "0 instanceof 0"
-
-    warn("unexpected_a", thing);
-});
-preaction("statement", "{", function (thing) {
-    block_stack.push(blockage);
-    blockage = thing;
-    thing.live = [];
-});
-preaction("statement", "for", function (thing) {
-    if (thing.name !== undefined) {
-        const the_variable = lookup(thing.name);
-        if (the_variable !== undefined) {
-            the_variable.init = true;
-            if (!the_variable.writable) {
-
-// cause: "const aa=0;for(aa in aa){}"
-
-                warn("bad_assignment_a", thing.name);
-            }
-        }
-    }
-    walk_statement(thing.initial);
-});
-preaction("statement", "function", preaction_function);
-preaction("statement", "try", function (thing) {
-    if (thing.catch !== undefined) {
-
-// Create new function-scope for catch-parameter.
-
-        stack.push(functionage);
-        functionage = thing.catch;
-    }
-});
-preaction("unary", "~", bitwise_check);
-preaction("unary", "function", preaction_function);
-preaction("variable", function (thing) {
-    const the_variable = lookup(thing);
-    if (the_variable !== undefined) {
-        thing.variable = the_variable;
-        the_variable.used += 1;
-    }
-});
-
-function init_variable(name) {
-    const the_variable = lookup(name);
-    if (the_variable !== undefined) {
-        if (the_variable.writable) {
-            the_variable.init = true;
-            return;
-        }
-    }
-    warn("bad_assignment_a", name);
-}
-
-postaction("assignment", "+=", function (thing) {
-    let right = thing.expression[1];
-    if (right.constant) {
-        if (
-            right.value === ""
-            || (right.id === "(number)" && right.value === "0")
-            || right.id === "(boolean)"
-            || right.id === "null"
-            || right.id === "undefined"
-            || Number.isNaN(right.value)
-        ) {
-            warn("unexpected_a", right);
-        }
-    }
-});
-postaction("assignment", function (thing) {
-
-// Assignment using = sets the init property of a variable. No other assignment
-// operator can do this. A = token keeps that variable (or array of variables
-// in case of destructuring) in its name property.
-
-    const lvalue = thing.expression[0];
-    if (thing.id === "=") {
-        if (thing.names !== undefined) {
-
-// cause: "if(0){aa=0}"
-
-            assert_or_throw(
-                !Array.isArray(thing.names),
-                `Expected !Array.isArray(thing.names).`
-            );
-//          Probably deadcode.
-//          if (Array.isArray(thing.names)) {
-//              thing.names.forEach(init_variable);
-//          } else {
-//              init_variable(thing.names);
-//          }
-            init_variable(thing.names);
-        } else {
-            if (lvalue.id === "[" || lvalue.id === "{") {
-                lvalue.expression.forEach(function (thing) {
-                    if (thing.variable) {
-                        thing.variable.init = true;
-                    }
-                });
-            } else if (
-                lvalue.id === "."
-                && thing.expression[1].id === "undefined"
-            ) {
-
-// cause: "aa.aa=undefined"
-
-                warn(
-                    "expected_a_b",
-                    lvalue.expression,
-                    "delete",
-                    "undefined"
-                );
-            }
-        }
-    } else {
-        if (lvalue.arity === "variable") {
-            if (!lvalue.variable || lvalue.variable.writable !== true) {
-                warn("bad_assignment_a", lvalue);
-            }
-        }
-        const right = syntax[thing.expression[1].id];
-        if (
-            right !== undefined
-            && (
-                right.id === "function"
-                || right.id === "=>"
-                || (
-                    right.constant
-                    && right.id !== "(number)"
-                    && (right.id !== "(string)" || thing.id !== "+=")
-                )
-            )
-        ) {
-
-// cause: "aa+=undefined"
-
-            warn("unexpected_a", thing.expression[1]);
-        }
-    }
-});
-
-function postaction_function(thing) {
-    delete functionage.finally;
-    delete functionage.loop;
-    delete functionage.switch;
-    delete functionage.try;
-    functionage = stack.pop();
-    if (thing.wrapped) {
-
-// cause: "aa=(function(){})"
-
-        warn("unexpected_parens", thing);
-    }
-    return pop_block();
-}
-
-postaction("binary", function (thing) {
-    let right;
-    if (relationop[thing.id]) {
-        if (
-            is_weird(thing.expression[0])
-            || is_weird(thing.expression[1])
-            || are_similar(thing.expression[0], thing.expression[1])
-            || (
-                thing.expression[0].constant === true
-                && thing.expression[1].constant === true
-            )
-        ) {
-
-// cause: "if(0===0){0}"
-
-            warn("weird_relation_a", thing);
-        }
-    }
-    if (thing.id === "+") {
-        if (!option.convert) {
-            if (thing.expression[0].value === "") {
-
-// cause: "\"\"+0"
-
-                warn("expected_a_b", thing, "String(...)", "\"\" +");
-            } else if (thing.expression[1].value === "") {
-
-// cause: "0+\"\""
-
-                warn("expected_a_b", thing, "String(...)", "+ \"\"");
-            }
-        }
-    } else if (thing.id === "[") {
-        if (thing.expression[0].id === "window") {
-
-// cause: "aa=window[0]"
-
-            warn("weird_expression_a", thing, "window[...]");
-        }
-        if (thing.expression[0].id === "self") {
-
-// cause: "aa=self[0]"
-
-            warn("weird_expression_a", thing, "self[...]");
-        }
-    } else if (thing.id === "." || thing.id === "?.") {
-        if (thing.expression.id === "RegExp") {
-
-// cause: "aa=RegExp.aa"
-
-            warn("weird_expression_a", thing);
-        }
-    } else if (thing.id !== "=>" && thing.id !== "(") {
-        right = thing.expression[1];
-        if (
-            (thing.id === "+" || thing.id === "-")
-            && right.id === thing.id
-            && right.arity === "unary"
-            && !right.wrapped
-        ) {
-
-// cause: "0- -0"
-
-            warn("wrap_unary", right);
-        }
-        if (
-            thing.expression[0].constant === true
-            && right.constant === true
-        ) {
-            thing.constant = true;
-        }
-    }
-});
-postaction("binary", "&&", function (thing) {
-    if (
-        is_weird(thing.expression[0])
-        || are_similar(thing.expression[0], thing.expression[1])
-        || thing.expression[0].constant === true
-        || thing.expression[1].constant === true
-    ) {
-
-// cause: "aa=(``?``:``)&&(``?``:``)"
-// cause: "aa=0&&0"
-// cause: "aa=`${0}`&&`${0}`"
-
-        warn("weird_condition_a", thing);
-    }
-});
-postaction("binary", "||", function (thing) {
-    if (
-        is_weird(thing.expression[0])
-        || are_similar(thing.expression[0], thing.expression[1])
-        || thing.expression[0].constant === true
-    ) {
-
-// cause: "aa=0||0"
-
-        warn("weird_condition_a", thing);
-    }
-});
-postaction("binary", "=>", postaction_function);
-postaction("binary", "(", function (thing) {
-    let left = thing.expression[0];
-    let the_new;
-    let arg;
-    if (left.id === "new") {
-        the_new = left;
-        left = left.expression;
-    }
-    if (left.id === "function") {
-        if (!thing.wrapped) {
-
-// cause: "aa=function(){}()"
-
-            warn("wrap_immediate", thing);
-        }
-    } else if (left.identifier) {
-        if (the_new !== undefined) {
-            if (
-                left.id[0] > "Z"
-                || left.id === "Boolean"
-                || left.id === "Number"
-                || left.id === "String"
-                || left.id === "Symbol"
-            ) {
-
-// cause: "new Boolean()"
-// cause: "new Number()"
-// cause: "new String()"
-// cause: "new Symbol()"
-// cause: "new aa()"
-
-                warn("unexpected_a", the_new);
-            } else if (left.id === "Function") {
-                if (!option.eval) {
-
-// cause: "new Function()"
-
-                    warn("unexpected_a", left, "new Function");
-                }
-            } else if (left.id === "Array") {
-                arg = thing.expression;
-                if (arg.length !== 2 || arg[1].id === "(string)") {
-
-// cause: "new Array()"
-
-                    warn("expected_a_b", left, "[]", "new Array");
-                }
-            } else if (left.id === "Object") {
-
-// cause: "new Object()"
-
-                warn(
-                    "expected_a_b",
-                    left,
-                    "Object.create(null)",
-                    "new Object"
-                );
-            }
-        } else {
-            if (
-                left.id[0] >= "A"
-                && left.id[0] <= "Z"
-                && left.id !== "Boolean"
-                && left.id !== "Number"
-                && left.id !== "String"
-                && left.id !== "Symbol"
-            ) {
-
-// cause: "let Aa=Aa()"
-
-                warn(
-                    "expected_a_before_b",
-                    left,
-                    "new",
-                    artifact(left)
-                );
-            }
-        }
-    } else if (left.id === ".") {
-        let cack = the_new !== undefined;
-        if (left.expression.id === "Date" && left.name.id === "UTC") {
-
-// cause: "new Date.UTC()"
-
-            cack = !cack;
-        }
-        if (rx_cap.test(left.name.id) !== cack) {
-            if (the_new !== undefined) {
-
-// cause: "new Date.UTC()"
-
-                warn("unexpected_a", the_new);
-            } else {
-
-// cause: "let Aa=Aa.Aa()"
-
-                warn(
-                    "expected_a_before_b",
-                    left.expression,
-                    "new",
-                    left.name.id
-                );
-            }
-        }
-        if (left.name.id === "getTime") {
-            const paren = left.expression;
-            if (paren.id === "(") {
-                const array = paren.expression;
-                if (array.length === 1) {
-                    const new_date = array[0];
-                    if (
-                        new_date.id === "new"
-                        && new_date.expression.id === "Date"
-                    ) {
-
-// cause: "new Date().getTime()"
-
-                        warn(
-                            "expected_a_b",
-                            new_date,
-                            "Date.now()",
-                            "new Date().getTime()"
-                        );
-                    }
-                }
-            }
-        }
-    }
-});
-postaction("binary", "[", function (thing) {
-    if (thing.expression[0].id === "RegExp") {
-
-// cause: "aa=RegExp[0]"
-
-        warn("weird_expression_a", thing);
-    }
-    if (is_weird(thing.expression[1])) {
-
-// cause: "aa[[0]]"
-
-        warn("weird_expression_a", thing.expression[1]);
-    }
-});
-postaction("statement", "{", pop_block);
-postaction("statement", "const", action_var);
-postaction("statement", "export", top_level_only);
-postaction("statement", "for", function (thing) {
-    walk_statement(thing.inc);
-});
-postaction("statement", "function", postaction_function);
-postaction("statement", "import", function (the_thing) {
-    const name = the_thing.name;
-    if (name) {
-        if (Array.isArray(name)) {
-            name.forEach(function (name) {
-                name.dead = false;
-                name.init = true;
-                blockage.live.push(name);
-            });
-        } else {
-            name.dead = false;
-            name.init = true;
-            blockage.live.push(name);
-        }
-        return top_level_only(the_thing);
-    }
-});
-postaction("statement", "let", action_var);
-postaction("statement", "try", function (thing) {
-    if (thing.catch !== undefined) {
-        const the_name = thing.catch.name;
-        if (the_name !== undefined) {
-            const the_variable = functionage.context[the_name.id];
-            the_variable.dead = false;
-            the_variable.init = true;
-        }
-        walk_statement(thing.catch.block);
-
-// Restore previous function-scope after catch-block.
-
-        functionage = stack.pop();
-    }
-});
-postaction("statement", "var", action_var);
-postaction("ternary", function (thing) {
-    if (
-        is_weird(thing.expression[0])
-        || thing.expression[0].constant === true
-        || are_similar(thing.expression[1], thing.expression[2])
-    ) {
-        warn("unexpected_a", thing);
-    } else if (are_similar(thing.expression[0], thing.expression[1])) {
-
-// cause: "aa?aa:0"
-
-        warn("expected_a_b", thing, "||", "?");
-    } else if (are_similar(thing.expression[0], thing.expression[2])) {
-
-// cause: "aa?0:aa"
-
-        warn("expected_a_b", thing, "&&", "?");
-    } else if (
-        thing.expression[1].id === "true"
-        && thing.expression[2].id === "false"
-    ) {
-
-// cause: "aa?true:false"
-
-        warn("expected_a_b", thing, "!!", "?");
-    } else if (
-        thing.expression[1].id === "false"
-        && thing.expression[2].id === "true"
-    ) {
-
-// cause: "aa?false:true"
-
-        warn("expected_a_b", thing, "!", "?");
-    } else if (
-        thing.expression[0].wrapped !== true
-        && (
-            thing.expression[0].id === "||"
-            || thing.expression[0].id === "&&"
-        )
-    ) {
-
-// cause: "(aa&&!aa?0:1)"
-
-        warn("wrap_condition", thing.expression[0]);
-    }
-});
-postaction("unary", function (thing) {
-    if (thing.id === "`") {
-        if (thing.expression.every(function (thing) {
-            return thing.constant;
-        })) {
-            thing.constant = true;
-        }
-    } else if (thing.id === "!") {
-        if (thing.expression.constant === true) {
-            warn("unexpected_a", thing);
-        }
-    } else if (thing.id === "!!") {
-        if (!option.convert) {
-
-// cause: "!!0"
-
-            warn("expected_a_b", thing, "Boolean(...)", "!!");
-        }
-    } else if (
-        thing.id !== "["
-        && thing.id !== "{"
-        && thing.id !== "function"
-        && thing.id !== "new"
-    ) {
-        if (thing.expression.constant === true) {
-            thing.constant = true;
-        }
-    }
-});
-postaction("unary", "function", postaction_function);
-postaction("unary", "+", function (thing) {
-    if (!option.convert) {
-
-// cause: "aa=+0"
-
-        warn("expected_a_b", thing, "Number(...)", "+");
-    }
-    const right = thing.expression;
-    if (right.id === "(" && right.expression[0].id === "new") {
-        warn("unexpected_a_before_b", thing, "+", "new");
-    } else if (
-        right.constant
-        || right.id === "{"
-        || (right.id === "[" && right.arity !== "binary")
-    ) {
-        warn("unexpected_a", thing, "+");
-    }
-});
-
-function delve(the_function) {
-    Object.keys(the_function.context).forEach(function (id) {
-        if (id !== "ignore") {
-            const name = the_function.context[id];
-            if (name.parent === the_function) {
-
-// cause: "let aa=function bb(){return;};"
-
-                if (
-                    name.used === 0
-                    && assert_or_throw(
-                        name.role !== "function",
-                        `Expected name.role !== "function".`
-                    )
-//                  Probably deadcode.
-//                  && (
-//                      name.role !== "function"
-//                      || name.parent.arity !== "unary"
-//                  )
-                ) {
-
-// cause: "/*jslint node*/\nlet aa;"
-// cause: "function aa(aa){return;}"
-
-                    warn("unused_a", name);
-                } else if (!name.init) {
-
-// cause: "/*jslint node*/\nlet aa;aa();"
-
-                    warn("uninitialized_a", name);
-                }
-            }
-        }
-
-// cause: "function aa(ignore){return;}"
-
-    });
-}
-
-function uninitialized_and_unused() {
-
-// Delve into the functions looking for variables that were not initialized
-// or used. If the file imports or exports, then its global object is also
-// delved.
-
-    if (module_mode === true || option.node) {
-        delve(global);
-    }
-    functions.forEach(delve);
-}
-
-// Go through the token list, looking at usage of whitespace.
-
-function whitage() {
-    let closer = "(end)";
-
-// free = false
-
-// cause: "()=>0"
-// cause: "aa()"
-// cause: "aa(0,0)"
-// cause: "function(){}"
-
-    let free = false;
-
-// cause: "(0)"
-// cause: "(aa)"
-// cause: "aa(0)"
-// cause: "do{}while()"
-// cause: "for(){}"
-// cause: "if(){}"
-// cause: "switch(){}"
-// cause: "while(){}"
-
-    // let free = true;
-
-    let left = global;
-    let margin = 0;
-    let nr_comments_skipped = 0;
-    let open = true;
-    let opening = true;
-    let right;
-
-    function pop() {
-        const previous = stack.pop();
-        closer = previous.closer;
-        free = previous.free;
-        margin = previous.margin;
-        open = previous.open;
-        opening = previous.opening;
-    }
-
-    function push() {
-        stack.push({
-            closer,
-            free,
-            margin,
-            open,
-            opening
-        });
-    }
-
-    function expected_at(at) {
-        assert_or_throw(
-            !(right === undefined),
-            `Expected !(right === undefined).`
-        );
-//      Probably deadcode.
-//      if (right === undefined) {
-//          right = next_token;
-//      }
-        warn(
-            "expected_a_at_b_c",
-            right,
-            artifact(right),
-
-// Fudge column numbers in warning message.
-
-            at + fudge,
-            right.from + fudge
-        );
-    }
-
-    function at_margin(fit) {
-        const at = margin + fit;
-        if (right.from !== at) {
-            return expected_at(at);
-        }
-    }
-
-    function no_space_only() {
-        if (
-            left.id !== "(global)"
-            && left.nr + 1 === right.nr
-            && (
-                left.line !== right.line
-                || left.thru !== right.from
-            )
-        ) {
-            warn(
-                "unexpected_space_a_b",
-                right,
-                artifact(left),
-                artifact(right)
-            );
-        }
-    }
-
-    function no_space() {
-        if (left.line === right.line) {
-
-// from:
-//                  if (left.line === right.line) {
-//                      no_space();
-//                  } else {
-
-            if (left.thru !== right.from && nr_comments_skipped === 0) {
-
-// cause: "let aa = aa( );"
-
-                warn(
-                    "unexpected_space_a_b",
-                    right,
-                    artifact(left),
-                    artifact(right)
-                );
-            }
-        } else {
-
-// from:
-//                  } else if (
-//                      right.arity === "binary"
-//                      && right.id === "("
-//                      && free
-//                  ) {
-//                      no_space();
-//                  } else if (
-
-            assert_or_throw(open, `Expected open.`);
-            assert_or_throw(free, `Expected free.`);
-//          Probably deadcode.
-//          if (open) {
-//              const at = (
-//                  free
-//                  ? margin
-//                  : margin + 8
-//              );
-//              if (right.from < at) {
-//                  expected_at(at);
-//              }
-//          } else {
-//              if (right.from !== margin + 8) {
-//                  expected_at(margin + 8);
-//              }
-//          }
-            if (right.from < margin) {
-
-// cause:
-// let aa = aa(
-//     aa
-// ()
-// );
-
-                expected_at(margin);
-            }
-        }
-    }
-
-    function one_space_only() {
-        if (left.line !== right.line || left.thru + 1 !== right.from) {
-            warn(
-                "expected_space_a_b",
-                right,
-                artifact(left),
-                artifact(right)
-            );
-        }
-    }
-
-    function one_space() {
-        if (left.line === right.line || !open) {
-            if (left.thru + 1 !== right.from && nr_comments_skipped === 0) {
-                warn(
-                    "expected_space_a_b",
-                    right,
-                    artifact(left),
-                    artifact(right)
-                );
-            }
-        } else {
-            if (right.from !== margin) {
-                expected_at(margin);
-            }
-        }
-    }
-
-    stack = [];
-    tokens.forEach(function (the_token) {
-        right = the_token;
-        if (right.id === "(comment)" || right.id === "(end)") {
-            nr_comments_skipped += 1;
-        } else {
-
-// If left is an opener and right is not the closer, then push the previous
-// state. If the token following the opener is on the next line, then this is
-// an open form. If the tokens are on the same line, then it is a closed form.
-// Open form is more readable, with each item (statement, argument, parameter,
-// etc) starting on its own line. Closed form is more compact. Statement blocks
-// are always in open form.
-
-            const new_closer = opener[left.id];
-            if (typeof new_closer === "string") {
-
-// cause: "${"
-// cause: "("
-// cause: "["
-// cause: "{"
-
-                if (new_closer !== right.id) {
-
-// cause: "${0"
-// cause: "(0"
-// cause: "[0"
-// cause: "{0"
-
-                    opening = left.open || (left.line !== right.line);
-                    push();
-                    closer = new_closer;
-                    if (opening) {
-
-// cause: "${\n0\n}"
-// cause: "(\n0\n)"
-// cause: "[\n0\n]"
-// cause: "{\n0\n}"
-
-                        free = closer === ")" && left.free;
-                        open = true;
-                        margin += 4;
-                        if (right.role === "label") {
-                            if (right.from !== 0) {
-
-// cause:
-// function aa() {
-//  bb:
-//     while (aa) {
-//         if (aa) {
-//             break bb;
-//         }
-//     }
-// }
-
-                                expected_at(0);
-                            }
-                        } else if (right.switch) {
-                            at_margin(-4);
-                        } else {
-                            at_margin(0);
-                        }
-                    } else {
-                        if (right.statement || right.role === "label") {
-
-// cause:
-// function aa() {bb:
-//     while (aa) {aa();
-//     }
-// }
-
-                            warn(
-                                "expected_line_break_a_b",
-                                right,
-                                artifact(left),
-                                artifact(right)
-                            );
-                        }
-
-// cause: "${0}"
-// cause: "(0)"
-// cause: "[0]"
-// cause: "{0}"
-
-                        free = false;
-                        open = false;
-
-// cause: "let aa = ( 0 );"
-
-                        no_space_only();
-                    }
-                } else {
-
-// If left and right are opener and closer, then the placement of right depends
-// on the openness. Illegal pairs (like '{]') have already been detected.
-
-// cause: "${}"
-// cause: "()"
-// cause: "[]"
-// cause: "{}"
-
-                    if (left.line === right.line) {
-
-// cause: "let aa = aa( );"
-
-                        no_space();
-                    } else {
-
-// cause: "let aa = aa(\n );"
-
-                        at_margin(0);
-                    }
-                }
-            } else {
-                if (right.statement === true) {
-                    if (left.id === "else") {
-
-// cause:
-// let aa = 0;
-// if (aa) {
-//     aa();
-// } else  if (aa) {
-//     aa();
-// }
-
-                        one_space_only();
-                    } else {
-
-// cause: " let aa = 0;"
-
-                        at_margin(0);
-                        open = false;
-                    }
-
-// If right is a closer, then pop the previous state.
-
-                } else if (right.id === closer) {
-                    pop();
-                    if (opening && right.id !== ";") {
-                        at_margin(0);
-                    } else {
-                        no_space_only();
-                    }
-                } else {
-
-// Left is not an opener, and right is not a closer.
-// The nature of left and right will determine the space between them.
-
-// If left is ',' or ';' or right is a statement then if open,
-// right must go at the margin, or if closed, a space between.
-
-                    if (right.switch) {
-                        at_margin(-4);
-                    } else if (right.role === "label") {
-                        if (right.from !== 0) {
-
-// cause:
-// function aa() {
-//     aa();cc:
-//     while (aa) {
-//         if (aa) {
-//             break cc;
-//         }
-//     }
-// }
-
-                            expected_at(0);
-                        }
-                    } else if (left.id === ",") {
-                        if (!open || (
-                            (free || closer === "]")
-                            && left.line === right.line
-                        )) {
-
-// cause: "let {aa,bb} = 0;"
-
-                            one_space();
-                        } else {
-
-// cause:
-// function aa() {
-//     aa(
-//         0,0
-//     );
-// }
-
-                            at_margin(0);
-                        }
-
-// If right is a ternary operator, line it up on the margin.
-
-                    } else if (right.arity === "ternary") {
-                        if (open) {
-
-// cause:
-// let aa = (
-//     aa
-//     ? 0
-// : 1
-// );
-
-                            at_margin(0);
-                        } else {
-
-// cause: "let aa = (aa ? 0 : 1);"
-
-                            warn("use_open", right);
-                        }
-                    } else if (
-                        right.arity === "binary"
-                        && right.id === "("
-                        && free
-                    ) {
-
-// cause:
-// let aa = aa(
-//     aa
-// ()
-// );
-
-                        no_space();
-                    } else if (
-                        left.id === "."
-                        || left.id === "?."
-                        || left.id === "..."
-                        || right.id === ","
-                        || right.id === ";"
-                        || right.id === ":"
-                        || (
-                            right.arity === "binary"
-                            && (right.id === "(" || right.id === "[")
-                        )
-                        || (
-                            right.arity === "function"
-                            && left.id !== "function"
-                        )
-                    ) {
-
-// cause: "let aa = 0 ;"
-
-                        no_space_only();
-                    } else if (right.id === "." || right.id === "?.") {
-
-// cause: "let aa = aa ?.aa;"
-
-                        no_space_only();
-                    } else if (left.id === ";") {
-
-// cause:
-// /*jslint for*/
-// function aa() {
-//     for (
-//         aa();
-// aa;
-//         aa()
-//     ) {
-//         aa();
-//     }
-// }
-
-                        if (open) {
-                            at_margin(0);
-                        }
-                    } else if (
-                        left.arity === "ternary"
-                        || left.id === "case"
-                        || left.id === "catch"
-                        || left.id === "else"
-                        || left.id === "finally"
-                        || left.id === "while"
-                        || left.id === "await"
-                        || right.id === "catch"
-                        || right.id === "else"
-                        || right.id === "finally"
-                        || (right.id === "while" && !right.statement)
-                        || (left.id === ")" && right.id === "{")
-                    ) {
-
-// cause:
-// function aa() {
-//     do {
-//         aa();
-//     } while(aa());
-// }
-
-                        one_space_only();
-                    } else if (
-
-// There is a space between left and right.
-
-                        spaceop[left.id] === true
-                        || spaceop[right.id] === true
-                        || (
-                            left.arity === "binary"
-                            && (left.id === "+" || left.id === "-")
-                        )
-                        || (
-                            right.arity === "binary"
-                            && (right.id === "+" || right.id === "-")
-                        )
-                        || left.id === "function"
-                        || left.id === ":"
-                        || (
-                            (
-                                left.identifier
-                                || left.id === "(string)"
-                                || left.id === "(number)"
-                            )
-                            && (
-                                right.identifier
-                                || right.id === "(string)"
-                                || right.id === "(number)"
-                            )
-                        )
-                        || (left.arity === "statement" && right.id !== ";")
-                    ) {
-
-// cause: "let aa=0;"
-// cause:
-// let aa={
-//     aa:
-// 0
-// };
-
-                        one_space();
-                    } else if (left.arity === "unary" && left.id !== "`") {
-                        no_space_only();
-                    }
-                }
-            }
-            nr_comments_skipped = 0;
-            delete left.calls;
-            delete left.dead;
-            delete left.free;
-            delete left.init;
-            delete left.open;
-            delete left.used;
-            left = right;
-        }
-    });
-}
-
 // The jslint function itself.
 
-function jslint(
-    source = "",
-    option_object = empty(),
-    global_array = []
-) {
     try {
-        warnings = [];
-        option = Object.assign(empty(), option_object);
         anon = "anonymous";
         block_stack = [];
+        blockage = global;
         declared_globals = empty();
         directive_mode = true;
         directives = [];
         early_stop = true;
         exports = empty();
         froms = [];
-        functions = [];
-        global = {
-            body: true,
-            context: empty(),
-            finally: 0,
-            from: 0,
-            id: "(global)",
-            level: 0,
-            line: fudge,
-            live: [],
-            loop: 0,
-            switch: 0,
-            thru: 0,
-            try: 0
-        };
-        blockage = global;
         functionage = global;
+        functions = [];
         json_mode = false;
         mega_mode = false;
         module_mode = false;
-        next_token = global;
+        option = Object.assign(empty(), option);
+        populate(global_array, declared_globals, false);
+        populate(standard, declared_globals, false);
         property = empty();
         shebang = false;
         stack = [];
         tenure = undefined;
-        token = global;
+        token_curr = global;
+        token_next = global;
         token_nr = 0;
         var_mode = undefined;
-        populate(standard, declared_globals, false);
-        populate(global_array, declared_globals, false);
+        warnings = [];
         Object.keys(option).forEach(function (name) {
             if (option[name] === true) {
                 const allowed = allowed_option[name];
@@ -6157,7 +6136,41 @@ function jslint(
 
 // 1. Tokenize source into ast.
 
-        tokenize(source);
+// tokenize takes a source and produces from it an array of token objects.
+// JavaScript is notoriously difficult to tokenize because of the horrible
+// interactions between automatic semicolon insertion, regular expression
+// literals, and now megastring literals. JSLint benefits from eliminating
+// automatic semicolon insertion and nested megastring literals, which allows
+// full tokenization to precede parsing.
+
+// Split source into lines at the carriage return/linefeed.
+
+        lines = String("\n" + source).split(
+            /\n|\r\n?/
+        ).map(function (source_line) {
+            return {
+                source_line
+            };
+        });
+        tokens = [];
+
+// Scan first line for "#!" and ignore it.
+
+        if (lines[fudge].source_line.startsWith("#!")) {
+            line += 1;
+            shebang = true;
+        }
+        token_frst = lex();
+        json_mode = token_frst.id === "{" || token_frst.id === "[";
+
+// This loop will be replaced with a recursive call to lex when ES6 has been
+// finished and widely deployed and adopted.
+
+        while (true) {
+            if (lex().id === "(end)") {
+                break;
+            }
+        }
 
 // 2. Walk ast.
 
@@ -6171,7 +6184,7 @@ function jslint(
 // be a semicolon to defend against a missing semicolon in the preceding file.
 
             if (option.browser) {
-                if (next_token.id === ";") {
+                if (token_next.id === ";") {
                     advance(";");
                 }
             } else {
@@ -6179,7 +6192,7 @@ function jslint(
 // If we are not in a browser, then the file form of strict pragma may be used.
 
                 if (
-                    next_token.value === "use strict"
+                    token_next.value === "use strict"
                 ) {
                     advance("(string)");
                     advance(";");


### PR DESCRIPTION
this looks like a big pr, but its mostly just adding 4-space indents to global variables/functions, and moving them into jslint's function-scope, to remove any module-level state.