### PR TITLE
- jslint-refactor-4 - document jslint process and each recursion-loop converted to while-loop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - website - replace current-editor with CodeMirror-editor and change programming-font-family from `Programma` to `Consolas, Menlo, monospace`.
 
 ## v2021.6.4-beta
+- bugfix - fix cli appending slash "/" to normalized filename.
+- bugfix - fix try-catch-block complaining about "Unexpected await" inside async-function.
 - jslint - add warning for unexpected ? in example `aa=/.{0}?/`.
 - jslint-refactor-1 - make "stateful" variables scoped outside of jslint() "stateless" by moving them into jslint().
 - jslint-refactor-2 - inline constants anticondition, bitwiseop, escapeable, and opener directly into code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - jslint-refactor-1 - make "stateful" variables scoped outside of jslint() "stateless" by moving them into jslint().
 - jslint-refactor-2 - inline constants anticondition, bitwiseop, escapeable, and opener directly into code.
 - jslint-refactor-3 - inline regexp-functions quantifier(), ranges(), klass(), choice(), directly into code.
+- jslint-refactor-4 - document jslint process and each recursion-loop converted to while-loop.
 - website - add ui-loader-animation.
 
 ## v2021.6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 ## Todo
 - app - deploy jslint as chrome-extension.
 - jslint - add `for...of` syntax support.
+- jslint - remove unnecessary grammar-article "the" from documentations.
 - jslint - add html and css linting back into jslint.
 - jslint - add new warning if case-statements are not sorted.
 - jslint - add new warning if const/let/var statements are not declared at top of function-scope.
 - jslint - add new warning if const/let/var statements are not sorted.
 - jslint-refactor - migrate recursive-loops to for/while loops.
+    - inline functions number(), string().
+    - rename var regexp_seen to mode_regexp.
 - node - after node-v12 is deprecated, change `require("fs").promises` to `require("fs/promises")`.
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - tests - update function warn_at() with assertion-check matching column with artifact.
@@ -19,6 +22,12 @@
 - jslint-refactor-2 - inline constants anticondition, bitwiseop, escapeable, and opener directly into code.
 - jslint-refactor-3 - inline regexp-functions quantifier(), ranges(), klass(), choice(), directly into code.
 - jslint-refactor-4 - document jslint process and each recursion-loop converted to while-loop.
+    - remove unnecessary variables nr.
+    - rename artifact-related variables a, b to let artifact_now, artifact_nxt.
+    - rename functions make() to token_create().
+    - rename line-related variables from xxx_line to line_xxx.
+    - rename mode-related variables from xxx_mode to mode_xxx.
+    - rename token-related variables from xxx_token to token_xxx.
 - website - add ui-loader-animation.
 
 ## v2021.6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,15 @@
 ## Todo
 - app - deploy jslint as chrome-extension.
 - jslint - add `for...of` syntax support.
-- jslint - remove unnecessary grammar-article "the" from documentations.
 - jslint - add html and css linting back into jslint.
 - jslint - add new warning if case-statements are not sorted.
 - jslint - add new warning if const/let/var statements are not declared at top of function-scope.
 - jslint - add new warning if const/let/var statements are not sorted.
+- jslint - remove directive "eval" (use line-specific ignore-directive "//jslint-quiet" instead).
+- jslint - simplify comments/docs by removing unnecessary grammar-article "the".
+- jslint-refactor - group/localize code together by phases.
 - jslint-refactor - migrate recursive-loops to for/while loops.
     - inline functions number(), string().
-    - rename var regexp_seen to mode_regexp.
 - node - after node-v12 is deprecated, change `require("fs").promises` to `require("fs/promises")`.
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - tests - update function warn_at() with assertion-check matching column with artifact.
@@ -25,9 +26,8 @@
     - remove unnecessary variables nr.
     - rename artifact-related variables a, b to let artifact_now, artifact_nxt.
     - rename functions make() to token_create().
-    - rename line-related variables from xxx_line to line_xxx.
-    - rename mode-related variables from xxx_mode to mode_xxx.
-    - rename token-related variables from xxx_token to token_xxx.
+    - reorganize/rename "global" variables by topical-prefixes:
+        artifact_xxx, export_xxx, from_xxx, import_xxx, line_xxx, mode_xxx, token_xxx
 - website - add ui-loader-animation.
 
 ## v2021.6.3

--- a/browser.js
+++ b/browser.js
@@ -7,7 +7,7 @@
 */
 
 /*property
-    addEventListener, ctrlKey, key, querySelector, source_line, stack_trace,
+    addEventListener, ctrlKey, key, querySelector, line_source, stack_trace,
     checked, closure, column, context, create, disable, display, edition,
     exports, filter, focus, forEach, froms, functions, getElementById,
     global, id, innerHTML, isArray, join, json, keys, length, level, line,
@@ -69,8 +69,8 @@ function error_report(data) {
     data.warnings.forEach(function ({
         column,
         line,
+        line_source,
         message,
-        source_line,
         stack_trace = ""
     }) {
         output.push(
@@ -81,7 +81,7 @@ function error_report(data) {
             "</address>",
             entityify(message),
             "</cite><samp>",
-            entityify(source_line + "\n" + stack_trace),
+            entityify(line_source + "\n" + stack_trace),
             "</samp>"
         );
     });

--- a/jslint.js
+++ b/jslint.js
@@ -90,8 +90,7 @@
 /*jslint node*/
 
 /*property
-    bind, cli, cwd, directive_quiet, endsWith, jslint, resolve, sep,
-    line_source,
+    bind, cli, cwd, directive_quiet, endsWith, jslint, line_source, resolve,
     unclosed_disable, unopened_enable, unordered,
     JSLINT_CLI, a, all, and, argv, arity, assign, b, bad_assignment_a,
     bad_directive_a, bad_get, bad_module_name_a, bad_option_a, bad_property_a,
@@ -158,6 +157,16 @@ function empty() {
 
     return Object.create(null);
 }
+
+function noop() {
+
+// This function will do nothing.
+
+    return;
+}
+
+// coverage-hack
+noop();
 
 function populate(array, object = empty(), value = true) {
 
@@ -3486,14 +3495,15 @@ function jslint(
         if (token_nxt.id === "catch") {
             advance("catch");
             the_catch = token_nxt;
-            ignored = "ignore";
+            the_catch.context = empty();
+            the_catch.is_async = functionage.is_async;
             the_try.catch = the_catch;
 
 // Create new function-scope for catch-parameter.
 
             stack.push(functionage);
             functionage = the_catch;
-            functionage.context = empty();
+            ignored = "ignore";
             if (token_nxt.id === "(") {
                 advance("(");
                 if (!token_nxt.identifier) {
@@ -6588,13 +6598,15 @@ async function cli({
 
 // Normalize file relative to process.cwd().
 
-    file = path.resolve(file) + path.sep;
-    if (file.startsWith(process.cwd() + path.sep)) {
-        file = file.replace(process.cwd() + path.sep, "").slice(0, -1) || ".";
+    file = path.resolve(file) + "/";
+    if (file.startsWith(process.cwd() + "/")) {
+        file = file.replace(process.cwd() + "/", "").slice(0, -1) || ".";
     }
     file = file.replace((
         /\\/g
-    ), "/");
+    ), "/").replace((
+        /\/$/g
+    ), "");
     if (source) {
         jslint_from_file({
             code: source,

--- a/test.js
+++ b/test.js
@@ -92,7 +92,14 @@ function noop() {
             "new Array(0);"
         ],
         async_await: [
-            "async function aa() {\n    await aa();\n}"
+            "async function aa() {\n    await aa();\n}",
+            "async function aa() {\n"
+            + "    try {\n"
+            + "        await aa();\n"
+            + "    } catch (err) {\n"
+            + "        await err();\n"
+            + "    }\n"
+            + "}\n"
         ],
         date: [
             "Date.getTime();",
@@ -173,14 +180,20 @@ function noop() {
             + "aa();\n"
         ],
         var: [
-            "let [...aa] = [...aa];",
             "let [\n    aa, bb = 0\n] = 0;",
-            "let {aa, bb} = 0;",
-            "let {\n    aa: bb\n} = 0;"
+            "let [...aa] = [...aa];",
+            "let {\n    aa: bb\n} = 0;",
+            "let {aa, bb} = 0;"
         ]
     }).forEach(function (codeList) {
+        let code0 = "";
         codeList.forEach(function (code) {
             let warnings;
+            // Assert codeList is sorted.
+            assertOrThrow(code0 < code, JSON.stringify([
+                code0, code
+            ], undefined, 4));
+            code0 = code;
             warnings = jslint(code).warnings;
             assertOrThrow(
                 warnings.length === 0,
@@ -204,7 +217,7 @@ function noop() {
     ), "gm"))).forEach(function ([
         match0, causeList, warning
     ]) {
-        let cause0;
+        let cause0 = "";
         let expectedWarningCode;
         let fnc;
         // debug match0
@@ -255,7 +268,6 @@ function noop() {
                 break;
             }
         }
-        cause0 = "";
         causeList.split(
             /\/\/\u0020cause:[\n|\u0020]/
         ).slice(1).forEach(function (cause) {
@@ -269,7 +281,7 @@ function noop() {
                     /^\/\/\u0020/gm
                 ), "")
             );
-            // Assert causes are sorted.
+            // Assert causeList is sorted.
             assertOrThrow(cause0 < cause, JSON.stringify([
                 cause0, cause
             ], undefined, 4));


### PR DESCRIPTION
    - remove unnecessary variables nr.
    - rename artifact-related variables a, b to let artifact_now, artifact_nxt.
    - rename functions make() to token_create().
    - reorganize/rename "global" variables by topical-prefixes:
        artifact_xxx, export_xxx, from_xxx, import_xxx, line_xxx, mode_xxx, token_xxx
