### PR TITLE
- directive - re-introduce `/*jslint name*/` to ignore "Bad property name" warning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ## v2021.6.4-beta
 - bugfix - fix cli appending slash "/" to normalized filename.
 - bugfix - fix try-catch-block complaining about "Unexpected await" inside async-function.
+- directive - re-introduce `/*jslint nomen*/` to ignore "Bad property name" warning.
 - jslint - add warning for unexpected ? in example `aa=/.{0}?/`.
 - jslint-refactor-1 - make "stateful" variables scoped outside of jslint() "stateless" by moving them into jslint().
 - jslint-refactor-2 - inline constants anticondition, bitwiseop, escapeable, and opener directly into code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 ## v2021.6.4-beta
 - bugfix - fix cli appending slash "/" to normalized filename.
 - bugfix - fix try-catch-block complaining about "Unexpected await" inside async-function.
-- directive - re-introduce `/*jslint nomen*/` to ignore "Bad property name" warning.
+- directive - re-introduce `/*jslint name*/` to ignore "Bad property name" warning.
 - jslint - add warning for unexpected ? in example `aa=/.{0}?/`.
 - jslint-refactor-1 - make "stateful" variables scoped outside of jslint() "stateless" by moving them into jslint().
 - jslint-refactor-2 - inline constants anticondition, bitwiseop, escapeable, and opener directly into code.

--- a/help.html
+++ b/help.html
@@ -428,6 +428,15 @@ a:active {
             <td><code>true</code> if a line can contain more than 80 characters.</td>
         </tr>
         <tr>
+            <td id="name">Tolerate bad property names</td>
+            <td><code>name</code></td>
+            <td>
+                <code>true</code> if bad property names like
+                <code>$, _foo, fooSync, foo_</code>
+                are allowed.
+            </td>
+        </tr>
+        <tr>
             <td id="node">Assume <a href="https://nodejs.org/">Node.js</a></td>
             <td><code>node</code></td>
             <td><code>true</code> if Node.js globals should be predefined. It
@@ -441,15 +450,6 @@ a:active {
         TextEncoder, URL, URLSearchParams, __dirname, __filename
 </code></div>
     <code>*/</code></blockquote></td>
-        </tr>
-        <tr>
-            <td id="nomen">Tolerate bad property names</td>
-            <td><code>nomen</code></td>
-            <td>
-                <code>true</code> if weird property names like
-                <code>$, _foo, fooSync, foo_</code>
-                are allowed.
-            </td>
         </tr>
         <tr>
             <td id="single">Tolerate single quote strings</td>

--- a/help.html
+++ b/help.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <meta
@@ -435,11 +435,21 @@ a:active {
                 It adds the same globals as this directive:
                 <blockquote><code>/*global </code>
     <div><code>
-        Buffer, clearImmediate, clearInterval, clearTimeout, console, exports,
-        module, process, require, setImmediate, setInterval, setTimeout, URL,
-        URLSearchParams, __dirname, __filename
+        Buffer, clearImmediate, clearInterval, clearTimeout,
+        console, exports, module, process, require,
+        setImmediate, setInterval, setTimeout, TextDecoder,
+        TextEncoder, URL, URLSearchParams, __dirname, __filename
 </code></div>
     <code>*/</code></blockquote></td>
+        </tr>
+        <tr>
+            <td id="nomen">Tolerate bad property names</td>
+            <td><code>nomen</code></td>
+            <td>
+                <code>true</code> if weird property names like
+                <code>$, _foo, fooSync, foo_</code>
+                are allowed.
+            </td>
         </tr>
         <tr>
             <td id="single">Tolerate single quote strings</td>
@@ -481,7 +491,7 @@ a:active {
     <code>/*property*/</code> directive. It contains all of the names that were
     used with dot notation, subscript notation, and object literals to name the
     properties of objects. You can look through the list for misspellings. You
-    can copy the <code>/*property*/</code></code> directive to the top of your
+    can copy the <code>/*property*/</code> directive to the top of your
     script file. JSLint will check the spelling of all property
     names against the list. That way, you can have JSLint look for
     misspellings for you.</p>

--- a/index.html
+++ b/index.html
@@ -464,7 +464,7 @@ style="
   <fieldset id=JSLINT_OPTIONS><legend>Options</legend>
     <div>Assume...
       <div><label><input title=devel type=checkbox>in development</label></div>
-      <div><label><input title=browser type=checkbox>a browser</label></div>
+      <div><label><input title=browser type=checkbox>browser</label></div>
       <div><label><input title=couch type=checkbox>CouchDB</label></div>
       <div><label><input title=node type=checkbox>Node.js</label></div>
     </div>
@@ -475,9 +475,10 @@ style="
       <div><label><input title=for type=checkbox>for statement</label></div>
       <div><label><input title=getset type=checkbox>get and set</label></div>
       <div><label><input title=long type=checkbox>long lines</label></div>
+      <div><label><input title=nomen type=checkbox>bad property names</label></div>
       <div><label><input title=single type=checkbox>single quote strings</label></div>
       <div><label><input title=this type=checkbox>this</label></div>
-      <div><label><input title=unordered type=checkbox>unordered properties and params</label></div>
+      <div><label><input title=unordered type=checkbox>unordered params/props</label></div>
       <div><label><input title=white type=checkbox>whitespace mess</label></div>
     </div>
     <div>Global variables...

--- a/index.html
+++ b/index.html
@@ -475,7 +475,7 @@ style="
       <div><label><input title=for type=checkbox>for statement</label></div>
       <div><label><input title=getset type=checkbox>get and set</label></div>
       <div><label><input title=long type=checkbox>long lines</label></div>
-      <div><label><input title=nomen type=checkbox>bad property names</label></div>
+      <div><label><input title=name type=checkbox>bad property names</label></div>
       <div><label><input title=single type=checkbox>single quote strings</label></div>
       <div><label><input title=this type=checkbox>this</label></div>
       <div><label><input title=unordered type=checkbox>unordered params/props</label></div>

--- a/jslint.js
+++ b/jslint.js
@@ -90,7 +90,7 @@
 /*jslint node*/
 
 /*property
-    bind, cli, cwd, directive_quiet, endsWith, jslint, line_source, nomen,
+    bind, cli, cwd, directive_quiet, endsWith, jslint, line_source, name,
     resolve,
     unclosed_disable, unopened_enable, unordered,
     JSLINT_CLI, a, all, and, argv, arity, assign, b, bad_assignment_a,
@@ -220,13 +220,13 @@ function jslint(
         for: true,
         getset: true,
         long: true,
+        name: true,
         node: [
             "Buffer", "clearImmediate", "clearInterval", "clearTimeout",
             "console", "exports", "module", "process", "require",
             "setImmediate", "setInterval", "setTimeout", "TextDecoder",
             "TextEncoder", "URL", "URLSearchParams", "__dirname", "__filename"
         ],
-        nomen: true,
         single: true,
         test_internal_error: true,
         this: true,
@@ -748,7 +748,7 @@ function jslint(
                     warn("unregistered_property_a", name);
                 }
             } else if (
-                !option_object.nomen
+                !option_object.name
                 && name.identifier
                 && (
                     // rx_bad_property

--- a/jslint.js
+++ b/jslint.js
@@ -90,7 +90,8 @@
 /*jslint node*/
 
 /*property
-    bind, cli, cwd, directive_quiet, endsWith, jslint, line_source, resolve,
+    bind, cli, cwd, directive_quiet, endsWith, jslint, line_source, nomen,
+    resolve,
     unclosed_disable, unopened_enable, unordered,
     JSLINT_CLI, a, all, and, argv, arity, assign, b, bad_assignment_a,
     bad_directive_a, bad_get, bad_module_name_a, bad_option_a, bad_property_a,
@@ -225,6 +226,7 @@ function jslint(
             "setImmediate", "setInterval", "setTimeout", "TextDecoder",
             "TextEncoder", "URL", "URLSearchParams", "__dirname", "__filename"
         ],
+        nomen: true,
         single: true,
         test_internal_error: true,
         this: true,
@@ -407,12 +409,6 @@ function jslint(
         [ a-z A-Z 0-9 _ $ ]*
     )$`;
     const rx_module = tag_regexp ` ^ [ a-z A-Z 0-9 _ $ : . @ \- \/ ]+ $ `;
-    const rx_bad_property = tag_regexp `
-        ^_
-      | \$
-      | Sync $
-      | _ $
-    `;
 // star slash
     const rx_star_slash = tag_regexp ` \* \/ `;
 // slash star
@@ -751,13 +747,22 @@ function jslint(
 
                     warn("unregistered_property_a", name);
                 }
-            } else {
-                if (name.identifier && rx_bad_property.test(id)) {
+            } else if (
+                !option_object.nomen
+                && name.identifier
+                && (
+                    // rx_bad_property
+                    /^_|\$|Sync$|_$/m
+                ).test(id)
+            ) {
 
+// cause: "aa.$"
 // cause: "aa._"
+// cause: "aa._aa"
+// cause: "aa.aaSync"
+// cause: "aa.aa_"
 
-                    warn("bad_property_a", name);
-                }
+                warn("bad_property_a", name);
             }
             property[id] = 1;
         }
@@ -6315,6 +6320,7 @@ function jslint(
 // PHASE 1. split the <source> by newlines into <line_array>.
 
         line_array = String("\n" + source).split(
+            // rx_crlf
             /\n|\r\n?/
         ).map(function (line_source) {
             return {

--- a/test.js
+++ b/test.js
@@ -74,6 +74,7 @@ function noop() {
         getset: true,
         long: true,
         node: true,
+        nomen: true,
         single: true,
         this: true,
         white: true
@@ -115,6 +116,8 @@ function noop() {
             "/*jslint eval*/\nnew Function();\neval();",
             "/*jslint getset*/\nlet aa = {get aa() {\n    return;\n}};",
             "/*jslint getset*/\nlet aa = {set aa(aa) {\n    return aa;\n}};",
+            "/*jslint nomen*/\nlet aa = aa._;",
+            "/*jslint single*/\nlet aa = 'aa';",
             "/*jslint this*/\nlet aa = this;",
             "/*jslint unordered*/\nlet {bb, aa} = 0;",
             "/*jslint white*/\n\t",

--- a/test.js
+++ b/test.js
@@ -73,8 +73,8 @@ function noop() {
         for: true,
         getset: true,
         long: true,
+        name: true,
         node: true,
-        nomen: true,
         single: true,
         this: true,
         white: true
@@ -116,7 +116,7 @@ function noop() {
             "/*jslint eval*/\nnew Function();\neval();",
             "/*jslint getset*/\nlet aa = {get aa() {\n    return;\n}};",
             "/*jslint getset*/\nlet aa = {set aa(aa) {\n    return aa;\n}};",
-            "/*jslint nomen*/\nlet aa = aa._;",
+            "/*jslint name*/\nlet aa = aa._;",
             "/*jslint single*/\nlet aa = 'aa';",
             "/*jslint this*/\nlet aa = this;",
             "/*jslint unordered*/\nlet {bb, aa} = 0;",


### PR DESCRIPTION
decided to re-include the nomen-directive, to make things easier for newcomers to onboard jslint.
