### PR TITLE
- jslint-refactor-5 - split jslint-core-logic into 5-phases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - jslint-refactor-5 - split jslint-core-logic into 5-phases.
     - move phase-sub-functions out of function-jslint().
     - move global-vars into state-object, that can be passed between functions.
+    - migrate recursive-loops to while-loops in sub-function phase2_lex().
 - website - add ui-loader-animation.
 
 ## v2021.6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
         artifact_xxx, export_xxx, from_xxx, import_xxx, line_xxx, mode_xxx, token_xxx
 - jslint-refactor-5 - split jslint-core-logic into 5-phases.
     - move phase-sub-functions out of function-jslint().
+    - move global-vars into state-object, that can be passed between functions.
 - website - add ui-loader-animation.
 
 ## v2021.6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 - jslint - add new warning if const/let/var statements are not sorted.
 - jslint - remove directive "eval" (use line-specific ignore-directive "//jslint-quiet" instead).
 - jslint - simplify comments/docs by removing unnecessary grammar-article "the".
-- jslint-refactor - group/localize code together by phases.
 - jslint-refactor - migrate recursive-loops to for/while loops.
     - inline functions number(), string().
 - node - after node-v12 is deprecated, change `require("fs").promises` to `require("fs/promises")`.
@@ -36,6 +35,7 @@
     - rename functions make() to token_create().
     - reorganize/rename "global" variables by topical-prefixes:
         artifact_xxx, export_xxx, from_xxx, import_xxx, line_xxx, mode_xxx, token_xxx
+- jslint-refactor-5 - split jslint-core-logic into 5-phases.
 - website - add ui-loader-animation.
 
 ## v2021.6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
     - move phase-sub-functions out of function-jslint().
     - move global-vars into state-object, that can be passed between functions.
     - migrate recursive-loops to while-loops in sub-function phase2_lex().
+    - move remaining global-vars into sub-functions or hardcode.
 - website - add ui-loader-animation.
 
 ## v2021.6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
     - reorganize/rename "global" variables by topical-prefixes:
         artifact_xxx, export_xxx, from_xxx, import_xxx, line_xxx, mode_xxx, token_xxx
 - jslint-refactor-5 - split jslint-core-logic into 5-phases.
+    - move phase-sub-functions out of function-jslint().
 - website - add ui-loader-animation.
 
 ## v2021.6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
     - move global-vars into state-object, that can be passed between functions.
     - migrate recursive-loops to while-loops in sub-function phase2_lex().
     - move remaining global-vars into sub-functions or hardcode.
+    - update functions artifact(), stop(), warn() with fallback-code `the_token = the_token || state.token_nxt;`.
 - website - add ui-loader-animation.
 
 ## v2021.6.3

--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ node jslint.mjs .
 
 # stderr:
 #
-# jslint - 20ms - ./CHANGELOG.md
-# jslint - 20ms - ./README.md
-# jslint - 20ms - ./browser.js
-# jslint - 20ms - ./function.html
-# jslint - 20ms - ./image-jslint.html
-# jslint - 20ms - ./index.html
-# jslint - 20ms - ./package.json
-# jslint - 20ms - ./test.js
+# jslint - 25ms - ./CHANGELOG.md
+# jslint - 25ms - ./README.md
+# jslint - 25ms - ./browser.js
+# jslint - 25ms - ./function.html
+# jslint - 25ms - ./image-jslint.html
+# jslint - 25ms - ./index.html
+# jslint - 25ms - ./package.json
+# jslint - 25ms - ./test.js
 # jslint - 50ms - ./ci.sh
 # jslint - 50ms - ./help.html
 # jslint - 150ms - ./jslint.mjs

--- a/jslint.js
+++ b/jslint.js
@@ -22,12 +22,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// jslint(source, option_object, global_array) is a function that takes 3
+// jslint(source, option_dict, global_list) is a function that takes 3
 // arguments. The second two arguments are optional.
 
 //      source          A text to analyze, a string or an array of strings.
-//      option_object   An object whose keys correspond to option names.
-//      global_array    An array of strings containing global variables that
+//      option_dict     An object whose keys correspond to option names.
+//      global_list     An array of strings containing global variables that
 //                      the file is allowed readonly access.
 
 // jslint returns an object containing its results. The object contains a lot
@@ -70,13 +70,13 @@
 
 // Phases:
 
-// PHASE 1. Split <source> by newlines into <line_array>.
-// PHASE 2. Lex <line_array> into <token_array>.
-// PHASE 3. Parse <token_array> into <token_tree> using Pratt parsing.
+// PHASE 1. Split <source> by newlines into <line_list>.
+// PHASE 2. Lex <line_list> into <token_list>.
+// PHASE 3. Parse <token_list> into <token_tree> using Pratt parsing.
 // PHASE 4. Walk <token_tree>, traversing all of the nodes of the tree. It is a
 //          recursive traversal. Each node may be processed on the way down
 //          (preaction) and on the way up (postaction).
-// PHASE 5. Check whitespace between tokens in <token_array>.
+// PHASE 5. Check whitespace between tokens in <token_list>.
 
 // jslint can also examine JSON text. It decides that a file is JSON text if
 // the first token is "[" or "{". Processing of JSON text is much simpler than
@@ -85,7 +85,7 @@
 
 // WARNING: JSLint will hurt your feelings.
 
-/*jslint node*/
+/*jslint debug, node*/
 
 /*property
     JSLINT_CLI, a, all, and, argv, arity, assign, async, b, bad_assignment_a,
@@ -175,92 +175,84 @@ function populate(array, object = empty(), value = true) {
     return object;
 }
 
-function jslint(
-    source = "",
-    option_object = empty(),
-    global_array = []
-) {
-
-// The jslint function itself.
-
-    const allowed_option = {
+const allowed_option = {
 
 // These are the options that are recognized in the option object or that may
 // appear in a /*jslint*/ directive. Most options will have a boolean value,
 // usually true. Some options will also predefine some number of global
 // variables.
 
-        bitwise: true,
-        browser: [
-            "caches", "CharacterData", "clearInterval", "clearTimeout",
-            "document",
-            "DocumentType", "DOMException", "Element", "Event", "event",
-            "fetch",
-            "FileReader", "FontFace", "FormData", "history",
-            "IntersectionObserver",
-            "localStorage", "location", "MutationObserver", "name", "navigator",
-            "screen", "sessionStorage", "setInterval", "setTimeout", "Storage",
-            "TextDecoder", "TextEncoder", "URL", "window", "Worker",
-            "XMLHttpRequest"
-        ],
-        convert: true,
-        couch: [
-            "emit", "getRow", "isArray", "log", "provides", "registerType",
-            "require", "send", "start", "sum", "toJSON"
-        ],
-        debug: true,
-        devel: [
-            "alert", "confirm", "console", "prompt"
-        ],
-        eval: true,
-        for: true,
-        getset: true,
-        long: true,
-        name: true,
-        node: [
-            "Buffer", "clearImmediate", "clearInterval", "clearTimeout",
-            "console", "exports", "module", "process", "require",
-            "setImmediate", "setInterval", "setTimeout", "TextDecoder",
-            "TextEncoder", "URL", "URLSearchParams", "__dirname", "__filename"
-        ],
-        single: true,
-        test_internal_error: true,
-        this: true,
-        unordered: true,
-        white: true
-    };
+    bitwise: true,
+    browser: [
+        "caches", "CharacterData", "clearInterval", "clearTimeout",
+        "document",
+        "DocumentType", "DOMException", "Element", "Event", "event",
+        "fetch",
+        "FileReader", "FontFace", "FormData", "history",
+        "IntersectionObserver",
+        "localStorage", "location", "MutationObserver", "name", "navigator",
+        "screen", "sessionStorage", "setInterval", "setTimeout", "Storage",
+        "TextDecoder", "TextEncoder", "URL", "window", "Worker",
+        "XMLHttpRequest"
+    ],
+    convert: true,
+    couch: [
+        "emit", "getRow", "isArray", "log", "provides", "registerType",
+        "require", "send", "start", "sum", "toJSON"
+    ],
+    debug: true,
+    devel: [
+        "alert", "confirm", "console", "prompt"
+    ],
+    eval: true,
+    for: true,
+    getset: true,
+    long: true,
+    name: true,
+    node: [
+        "Buffer", "clearImmediate", "clearInterval", "clearTimeout",
+        "console", "exports", "module", "process", "require",
+        "setImmediate", "setInterval", "setTimeout", "TextDecoder",
+        "TextEncoder", "URL", "URLSearchParams", "__dirname", "__filename"
+    ],
+    single: true,
+    test_internal_error: true,
+    this: true,
+    unordered: true,
+    white: true
+};
 
 // The relational operators.
 
-    const relationop = populate([
-        "!=", "!==", "==", "===", "<", "<=", ">", ">="
-    ]);
+const relationop = populate([
+    "!=", "!==", "==", "===", "<", "<=", ">", ">="
+]);
 
 // This is the set of infix operators that require a space on each side.
 
-    const spaceop = populate([
-        "!=", "!==", "%", "%=", "&", "&=", "&&", "*", "*=", "+=", "-=", "/",
-        "/=", "<", "<=", "<<", "<<=", "=", "==", "===", "=>", ">", ">=",
-        ">>", ">>=", ">>>", ">>>=", "^", "^=", "|", "|=", "||"
-    ]);
+const spaceop = populate([
+    "!=", "!==", "%", "%=", "&", "&=", "&&", "*", "*=", "+=", "-=", "/",
+    "/=", "<", "<=", "<<", "<<=", "=", "==", "===", "=>", ">", ">=",
+    ">>", ">>=", ">>>", ">>>=", "^", "^=", "|", "|=", "||"
+]);
 
-    const standard = [
+const standard = [
 
 // These are the globals that are provided by the language standard.
 
-        "Array", "ArrayBuffer", "Boolean", "DataView", "Date", "Error",
-        "EvalError",
-        "Float32Array", "Float64Array", "Generator", "GeneratorFunction",
-        "Int16Array", "Int32Array", "Int8Array", "Intl", "JSON", "Map", "Math",
-        "Number", "Object", "Promise", "Proxy", "RangeError", "ReferenceError",
-        "Reflect", "RegExp", "Set", "String", "Symbol", "SyntaxError", "System",
-        "TypeError", "URIError", "Uint16Array", "Uint32Array", "Uint8Array",
-        "Uint8ClampedArray", "WeakMap", "WeakSet", "decodeURI",
-        "decodeURIComponent", "encodeURI", "encodeURIComponent", "globalThis",
-        "import", "parseFloat", "parseInt"
-    ];
+    "Array", "ArrayBuffer", "Boolean", "DataView", "Date", "Error",
+    "EvalError",
+    "Float32Array", "Float64Array", "Generator", "GeneratorFunction",
+    "Int16Array", "Int32Array", "Int8Array", "Intl", "JSON", "Map", "Math",
+    "Number", "Object", "Promise", "Proxy", "RangeError", "ReferenceError",
+    "Reflect", "RegExp", "Set", "String", "Symbol", "SyntaxError", "System",
+    "TypeError", "URIError", "Uint16Array", "Uint32Array", "Uint8Array",
+    "Uint8ClampedArray", "WeakMap", "WeakSet", "decodeURI",
+    "decodeURIComponent", "encodeURI", "encodeURIComponent", "globalThis",
+    "import", "parseFloat", "parseInt"
+];
 
-    const bundle = {
+const bundle = {
 
 // The bundle contains the raw text messages that are generated by jslint. It
 // seems that they are all error messages and warnings. There are no "Atta
@@ -269,481 +261,468 @@ function jslint(
 // wound the inner child. But if you accept it as sound advice rather than as
 // personal criticism, it can make your programs better.
 
-        and: "The '&&' subexpression should be wrapped in parens.",
-        bad_assignment_a: "Bad assignment to '{a}'.",
-        bad_directive_a: "Bad directive '{a}'.",
-        bad_get: "A get function takes no parameters.",
-        bad_module_name_a: "Bad module name '{a}'.",
-        bad_option_a: "Bad option '{a}'.",
-        bad_property_a: "Bad property name '{a}'.",
-        bad_set: "A set function takes one parameter.",
-        duplicate_a: "Duplicate '{a}'.",
-        empty_block: "Empty block.",
-        expected_a: "Expected '{a}'.",
-        expected_a_at_b_c: "Expected '{a}' at column {b}, not column {c}.",
-        expected_a_b: "Expected '{a}' and instead saw '{b}'.",
-        expected_a_b_from_c_d: (
-            "Expected '{a}' to match '{b}' from line {c} and instead saw '{d}'."
-        ),
-        expected_a_before_b: "Expected '{a}' before '{b}'.",
-        expected_digits_after_a: "Expected digits after '{a}'.",
-        expected_four_digits: "Expected four digits after '\\u'.",
-        expected_identifier_a: "Expected an identifier and instead saw '{a}'.",
-        expected_line_break_a_b: (
-            "Expected a line break between '{a}' and '{b}'."
-        ),
-        expected_regexp_factor_a: (
-            "Expected a regexp factor and instead saw '{a}'."
-        ),
-        expected_space_a_b: "Expected one space between '{a}' and '{b}'.",
-        expected_statements_a: "Expected statements before '{a}'.",
-        expected_string_a: "Expected a string and instead saw '{a}'.",
-        expected_type_string_a: "Expected a type string and instead saw '{a}'.",
-        freeze_exports: (
-            "Expected 'Object.freeze('. All export values should be frozen."
-        ),
-        function_in_loop: "Don't create functions within a loop.",
-        infix_in: (
-            "Unexpected 'in'. Compare with undefined, "
-            + "or use the hasOwnProperty method instead."
-        ),
-        label_a: "'{a}' is a statement label.",
-        misplaced_a: "Place '{a}' at the outermost level.",
-        misplaced_directive_a: (
-            "Place the '/*{a}*/' directive before the first statement."
-        ),
-        missing_await_statement: "Expected await statement in async function.",
-        missing_browser: "/*global*/ requires the Assume a browser option.",
-        missing_m: "Expected 'm' flag on a multiline regular expression.",
-        naked_block: "Naked block.",
-        nested_comment: "Nested comment.",
-        not_label_a: "'{a}' is not a label.",
-        number_isNaN: "Use Number.isNaN function to compare with NaN.",
-        out_of_scope_a: "'{a}' is out of scope.",
-        redefinition_a_b: "Redefinition of '{a}' from line {b}.",
-        required_a_optional_b: (
-            "Required parameter '{a}' after optional parameter '{b}'."
-        ),
-        reserved_a: "Reserved name '{a}'.",
-        subscript_a: "['{a}'] is better written in dot notation.",
-        todo_comment: "Unexpected TODO comment.",
-        too_long: "Line is longer than 80 characters.",
-        too_many_digits: "Too many digits.",
-        unclosed_comment: "Unclosed comment.",
-        unclosed_disable: (
-            "Directive '/*jslint-disable*/' was not closed "
-            + "with '/*jslint-enable*/'."
-        ),
-        unclosed_mega: "Unclosed mega literal.",
-        unclosed_string: "Unclosed string.",
-        undeclared_a: "Undeclared '{a}'.",
-        unexpected_a: "Unexpected '{a}'.",
-        unexpected_a_after_b: "Unexpected '{a}' after '{b}'.",
-        unexpected_a_before_b: "Unexpected '{a}' before '{b}'.",
-        unexpected_at_top_level_a: "Expected '{a}' to be in a function.",
-        unexpected_char_a: "Unexpected character '{a}'.",
-        unexpected_comment: "Unexpected comment.",
-        unexpected_directive_a: (
-            "When using modules, don't use directive '/*{a}'."
-        ),
-        unexpected_expression_a: (
-            "Unexpected expression '{a}' in statement position."
-        ),
-        unexpected_label_a: "Unexpected label '{a}'.",
-        unexpected_parens: "Don't wrap function literals in parens.",
-        unexpected_space_a_b: "Unexpected space between '{a}' and '{b}'.",
-        unexpected_statement_a: (
-            "Unexpected statement '{a}' in expression position."
-        ),
-        unexpected_trailing_space: "Unexpected trailing space.",
-        unexpected_typeof_a: (
-            "Unexpected 'typeof'. Use '===' to compare directly with {a}."
-        ),
-        uninitialized_a: "Uninitialized '{a}'.",
-        unopened_enable: (
-            "Directive '/*jslint-enable*/' was not opened "
-            + "with '/*jslint-disable*/'."
-        ),
-        unreachable_a: "Unreachable '{a}'.",
-        unregistered_property_a: "Unregistered property name '{a}'.",
-        unused_a: "Unused '{a}'.",
-        use_double: "Use double quotes, not single quotes.",
-        use_open: (
-            "Wrap a ternary expression in parens, "
-            + "with a line break after the left paren."
-        ),
-        use_spaces: "Use spaces, not tabs.",
-        var_loop: "Don't declare variables in a loop.",
-        var_switch: "Don't declare variables in a switch.",
-        weird_condition_a: "Weird condition '{a}'.",
-        weird_expression_a: "Weird expression '{a}'.",
-        weird_loop: "Weird loop.",
-        weird_relation_a: "Weird relation '{a}'.",
-        wrap_condition: "Wrap the condition in parens.",
-        wrap_immediate: (
-            "Wrap an immediate function invocation in parentheses to assist "
-            + "the reader in understanding that the expression is the result "
-            + "of a function, and not the function itself."
-        ),
-        wrap_parameter: "Wrap the parameter in parens.",
-        wrap_regexp: "Wrap this regexp in parens to avoid confusion.",
-        wrap_unary: "Wrap the unary expression in parens."
-    };
+    and: "The '&&' subexpression should be wrapped in parens.",
+    bad_assignment_a: "Bad assignment to '{a}'.",
+    bad_directive_a: "Bad directive '{a}'.",
+    bad_get: "A get function takes no parameters.",
+    bad_module_name_a: "Bad module name '{a}'.",
+    bad_option_a: "Bad option '{a}'.",
+    bad_property_a: "Bad property name '{a}'.",
+    bad_set: "A set function takes one parameter.",
+    duplicate_a: "Duplicate '{a}'.",
+    empty_block: "Empty block.",
+    expected_a: "Expected '{a}'.",
+    expected_a_at_b_c: "Expected '{a}' at column {b}, not column {c}.",
+    expected_a_b: "Expected '{a}' and instead saw '{b}'.",
+    expected_a_b_from_c_d: (
+        "Expected '{a}' to match '{b}' from line {c} and instead saw '{d}'."
+    ),
+    expected_a_before_b: "Expected '{a}' before '{b}'.",
+    expected_digits_after_a: "Expected digits after '{a}'.",
+    expected_four_digits: "Expected four digits after '\\u'.",
+    expected_identifier_a: "Expected an identifier and instead saw '{a}'.",
+    expected_line_break_a_b: (
+        "Expected a line break between '{a}' and '{b}'."
+    ),
+    expected_regexp_factor_a: (
+        "Expected a regexp factor and instead saw '{a}'."
+    ),
+    expected_space_a_b: "Expected one space between '{a}' and '{b}'.",
+    expected_statements_a: "Expected statements before '{a}'.",
+    expected_string_a: "Expected a string and instead saw '{a}'.",
+    expected_type_string_a: "Expected a type string and instead saw '{a}'.",
+    freeze_exports: (
+        "Expected 'Object.freeze('. All export values should be frozen."
+    ),
+    function_in_loop: "Don't create functions within a loop.",
+    infix_in: (
+        "Unexpected 'in'. Compare with undefined, "
+        + "or use the hasOwnProperty method instead."
+    ),
+    label_a: "'{a}' is a statement label.",
+    misplaced_a: "Place '{a}' at the outermost level.",
+    misplaced_directive_a: (
+        "Place the '/*{a}*/' directive before the first statement."
+    ),
+    missing_await_statement: "Expected await statement in async function.",
+    missing_browser: "/*global*/ requires the Assume a browser option.",
+    missing_m: "Expected 'm' flag on a multiline regular expression.",
+    naked_block: "Naked block.",
+    nested_comment: "Nested comment.",
+    not_label_a: "'{a}' is not a label.",
+    number_isNaN: "Use Number.isNaN function to compare with NaN.",
+    out_of_scope_a: "'{a}' is out of scope.",
+    redefinition_a_b: "Redefinition of '{a}' from line {b}.",
+    required_a_optional_b: (
+        "Required parameter '{a}' after optional parameter '{b}'."
+    ),
+    reserved_a: "Reserved name '{a}'.",
+    subscript_a: "['{a}'] is better written in dot notation.",
+    todo_comment: "Unexpected TODO comment.",
+    too_long: "Line is longer than 80 characters.",
+    too_many_digits: "Too many digits.",
+    unclosed_comment: "Unclosed comment.",
+    unclosed_disable: (
+        "Directive '/*jslint-disable*/' was not closed "
+        + "with '/*jslint-enable*/'."
+    ),
+    unclosed_mega: "Unclosed mega literal.",
+    unclosed_string: "Unclosed string.",
+    undeclared_a: "Undeclared '{a}'.",
+    unexpected_a: "Unexpected '{a}'.",
+    unexpected_a_after_b: "Unexpected '{a}' after '{b}'.",
+    unexpected_a_before_b: "Unexpected '{a}' before '{b}'.",
+    unexpected_at_top_level_a: "Expected '{a}' to be in a function.",
+    unexpected_char_a: "Unexpected character '{a}'.",
+    unexpected_comment: "Unexpected comment.",
+    unexpected_directive_a: (
+        "When using modules, don't use directive '/*{a}'."
+    ),
+    unexpected_expression_a: (
+        "Unexpected expression '{a}' in statement position."
+    ),
+    unexpected_label_a: "Unexpected label '{a}'.",
+    unexpected_parens: "Don't wrap function literals in parens.",
+    unexpected_space_a_b: "Unexpected space between '{a}' and '{b}'.",
+    unexpected_statement_a: (
+        "Unexpected statement '{a}' in expression position."
+    ),
+    unexpected_trailing_space: "Unexpected trailing space.",
+    unexpected_typeof_a: (
+        "Unexpected 'typeof'. Use '===' to compare directly with {a}."
+    ),
+    uninitialized_a: "Uninitialized '{a}'.",
+    unopened_enable: (
+        "Directive '/*jslint-enable*/' was not opened "
+        + "with '/*jslint-disable*/'."
+    ),
+    unreachable_a: "Unreachable '{a}'.",
+    unregistered_property_a: "Unregistered property name '{a}'.",
+    unused_a: "Unused '{a}'.",
+    use_double: "Use double quotes, not single quotes.",
+    use_open: (
+        "Wrap a ternary expression in parens, "
+        + "with a line break after the left paren."
+    ),
+    use_spaces: "Use spaces, not tabs.",
+    var_loop: "Don't declare variables in a loop.",
+    var_switch: "Don't declare variables in a switch.",
+    weird_condition_a: "Weird condition '{a}'.",
+    weird_expression_a: "Weird expression '{a}'.",
+    weird_loop: "Weird loop.",
+    weird_relation_a: "Weird relation '{a}'.",
+    wrap_condition: "Wrap the condition in parens.",
+    wrap_immediate: (
+        "Wrap an immediate function invocation in parentheses to assist "
+        + "the reader in understanding that the expression is the result "
+        + "of a function, and not the function itself."
+    ),
+    wrap_parameter: "Wrap the parameter in parens.",
+    wrap_regexp: "Wrap this regexp in parens to avoid confusion.",
+    wrap_unary: "Wrap the unary expression in parens."
+};
 
 // Regular expression literals:
 
-    function tag_regexp(strings) {
-        return new RegExp(strings.raw[0].replace(/\s/g, ""));
-    }
+function tag_regexp(strings) {
+    return new RegExp(strings.raw[0].replace(/\s/g, ""));
+}
 
 // supplant {variables}
-    const rx_supplant = /\{([^{}]*)\}/g;
+const rx_supplant = /\{([^{}]*)\}/g;
 // identifier
-    const rx_identifier = tag_regexp ` ^(
-        [ a-z A-Z _ $ ]
-        [ a-z A-Z 0-9 _ $ ]*
-    )$`;
-    const rx_module = tag_regexp ` ^ [ a-z A-Z 0-9 _ $ : . @ \- \/ ]+ $ `;
+const rx_identifier = tag_regexp ` ^(
+    [ a-z A-Z _ $ ]
+    [ a-z A-Z 0-9 _ $ ]*
+)$`;
+const rx_module = tag_regexp ` ^ [ a-z A-Z 0-9 _ $ : . @ \- \/ ]+ $ `;
 // star slash
-    const rx_star_slash = tag_regexp ` \* \/ `;
+const rx_star_slash = tag_regexp ` \* \/ `;
 // slash star
-    const rx_slash_star = tag_regexp ` \/ \* `;
+const rx_slash_star = tag_regexp ` \/ \* `;
 // slash star or ending slash
-    const rx_slash_star_or_slash = tag_regexp ` \/ \* | \/ $ `;
+const rx_slash_star_or_slash = tag_regexp ` \/ \* | \/ $ `;
 // uncompleted work comment
-    const rx_todo = tag_regexp ` \b (?:
-        todo
-      | TO \s? DO
-      | HACK
-    ) \b `;
+const rx_todo = tag_regexp ` \b (?:
+    todo
+  | TO \s? DO
+  | HACK
+) \b `;
 // tab
-    const rx_tab = /\t/g;
+const rx_tab = /\t/g;
 // directive
-    const rx_directive = tag_regexp ` ^ (
-        jslint
-      | property
-      | global
-    ) \s+ ( .* ) $ `;
-    const rx_directive_part = tag_regexp ` ^ (
-        [ a-z A-Z $ _ ] [ a-z A-Z 0-9 $ _ ]*
-    ) (?:
-        : \s* ( true | false )
-    )? ,? \s* ( .* ) $ `;
+const rx_directive = tag_regexp ` ^ (
+    jslint
+  | property
+  | global
+) \s+ ( .* ) $ `;
+const rx_directive_part = tag_regexp ` ^ (
+    [ a-z A-Z $ _ ] [ a-z A-Z 0-9 $ _ ]*
+) (?:
+    : \s* ( true | false )
+)? ,? \s* ( .* ) $ `;
 // token
-    const rx_token = tag_regexp ` ^ (
-        (\s+)
-      | (
-          [ a-z A-Z _ $ ]
-          [ a-z A-Z 0-9 _ $ ]*
-        )
-      | [
-          ( ) { } \[ \] , : ; ' " ~ \`
-      ]
-      | \? [ ? . ]?
-      | = (?:
-            = =?
-          | >
-        )?
-      | \.+
-      | \* [ * \/ = ]?
-      | \/ [ * \/ ]?
-      | \+ [ = + ]?
-      | - [ = \- ]?
-      | [ \^ % ] =?
-      | & [ & = ]?
-      | \| [ | = ]?
-      | >{1,3} =?
-      | < <? =?
-      | ! (?:
-            !
-          | = =?
-        )?
-      | (
-            0
-          | [ 1-9 ] [ 0-9 ]*
-        )
-    ) ( .* ) $ `;
-    const rx_digits = /^[0-9]*/;
-    const rx_hexs = /^[0-9A-F]*/i;
-    const rx_octals = /^[0-7]*/;
-    const rx_bits = /^[01]*/;
+const rx_token = tag_regexp ` ^ (
+    (\s+)
+  | (
+      [ a-z A-Z _ $ ]
+      [ a-z A-Z 0-9 _ $ ]*
+    )
+  | [
+      ( ) { } \[ \] , : ; ' " ~ \`
+  ]
+  | \? [ ? . ]?
+  | = (?:
+        = =?
+      | >
+    )?
+  | \.+
+  | \* [ * \/ = ]?
+  | \/ [ * \/ ]?
+  | \+ [ = + ]?
+  | - [ = \- ]?
+  | [ \^ % ] =?
+  | & [ & = ]?
+  | \| [ | = ]?
+  | >{1,3} =?
+  | < <? =?
+  | ! (?:
+        !
+      | = =?
+    )?
+  | (
+        0
+      | [ 1-9 ] [ 0-9 ]*
+    )
+) ( .* ) $ `;
+const rx_digits = /^[0-9]*/;
+const rx_hexs = /^[0-9A-F]*/i;
+const rx_octals = /^[0-7]*/;
+const rx_bits = /^[01]*/;
 // mega
-    const rx_mega = /[`\\]|\$\{/;
+const rx_mega = /[`\\]|\$\{/;
 // JSON number
-    const rx_JSON_number = tag_regexp ` ^
-        -?
-        (?: 0 | [ 1-9 ] \d* )
-        (?: \. \d* )?
-        (?: [ e E ] [ \- + ]? \d+ )?
-    $ `;
+const rx_JSON_number = tag_regexp ` ^
+    -?
+    (?: 0 | [ 1-9 ] \d* )
+    (?: \. \d* )?
+    (?: [ e E ] [ \- + ]? \d+ )?
+$ `;
 // initial cap
-    const rx_cap = /^[A-Z]/;
-
+const rx_cap = /^[A-Z]/;
 
 // The directive comments.
-    const directives = [];
+let directives;
 // The exported names and values.
-    const export_object = empty();
+let export_dict;
 // The array containing all of the functions.
-    const function_array = [];
+let function_list;
 // The global object; the outermost context.
-    const global = {
-        async: 0,
-        body: true,
-        context: empty(),
-        finally: 0,
-        from: 0,
-        id: "(global)",
-        level: 0,
-        line: 1,
-        live: [],
-        loop: 0,
-        switch: 0,
-        thru: 0,
-        try: 0
-    };
+let token_global;
 // The array collecting all import-from strings.
-    const import_array = [];
+let import_list;
 // Fudge starting line and starting column to 1.
-    const line_fudge = 1;
+let line_fudge;
 // The object containing the tallied property names.
-    const property = empty();
+let property;
 // The object containing the parser.
-    const syntax_object = empty();
+let syntax_dict;
 // The array of tokens.
-    const token_array = [];
+let token_list;
 // The array collecting all generated warnings.
-    const warning_array = [];
+let warning_list;
 // The stack of functions.
-    let function_stack = [];
+let function_stack;
 // The array containing source lines.
-    let line_array;
+let line_list;
 // true if parsing JSON.
-    let mode_json = false;
+let mode_json;
 // true if currently parsing a megastring literal.
-    let mode_mega = false;
+let mode_mega;
 // true if import or export was used.
-    let mode_module = false;
+let mode_module;
 // true if a #! was seen on the first line.
-    let mode_shebang = false;
-// true if JSLint cannot finish.
-    let mode_stop = true;
+let mode_shebang;
 // "var" if using var; "let" if using let.
-    let mode_var;
+let mode_var;
 // The predefined property registry.
-    let tenure;
-// The next token to be examined in <token_array>.
-    let token_nxt = global;
+let tenure;
+// The next token to be examined in <token_list>.
+let token_nxt;
 // The abstract parse tree.
-    let token_tree;
+let token_tree;
+
+let source;
+let option_dict;
+let global_list;
 
 // Error reportage functions:
 
-    function artifact(the_token) {
+function artifact(the_token) {
 
 // Return a string representing an artifact.
 
-        if (the_token === undefined) {
-            the_token = token_nxt;
-        }
-        return (
-            (the_token.id === "(string)" || the_token.id === "(number)")
-            ? String(the_token.value)
-            : the_token.id
-        );
+    if (the_token === undefined) {
+        the_token = token_nxt;
     }
+    return (
+        (the_token.id === "(string)" || the_token.id === "(number)")
+        ? String(the_token.value)
+        : the_token.id
+    );
+}
 
-    function warn_at(code, line, column, a, b, c, d) {
+function warn_at(code, line, column, a, b, c, d) {
 
 // Report an error at some line and column of the program. The warning object
 // resembles an exception.
 
-        const warning = Object.assign({
-            a,
-            b,
-            c,
-            code,
+    const warning = Object.assign({
+        a,
+        b,
+        c,
+        code,
 
 // Fudge column numbers in warning message.
 
-            column: column || line_fudge,
-            d,
-            line,
-            line_source: "",
-            name: "JSLintError"
-        }, line_array[line]);
-        warning.message = bundle[code].replace(rx_supplant, function (
-            ignore,
-            filling
-        ) {
-            assert_or_throw(
-                warning[filling] !== undefined,
-                "Expected warning[filling] !== undefined."
-            );
+        column: column || line_fudge,
+        d,
+        line,
+        line_source: "",
+        name: "JSLintError"
+    }, line_list[line]);
+    warning.message = bundle[code].replace(rx_supplant, function (
+        ignore,
+        filling
+    ) {
+        assert_or_throw(
+            warning[filling] !== undefined,
+            "Expected warning[filling] !== undefined."
+        );
 //      Probably deadcode.
 //      return (
 //          replacement !== undefined
 //          ? replacement
 //          : found
 //      );
-            return warning[filling];
-        });
+        return warning[filling];
+    });
 
 // Include stack_trace for jslint to debug itself for errors.
 
-        if (option_object.debug) {
-            warning.stack_trace = new Error().stack;
-        }
-        if (warning.directive_quiet) {
+    if (option_dict.debug) {
+        warning.stack_trace = new Error().stack;
+    }
+    if (warning.directive_quiet) {
 
 // cause: "0 //jslint-quiet"
 
-            return warning;
-        }
-        warning_array.push(warning);
         return warning;
     }
+    warning_list.push(warning);
+    return warning;
+}
 
-    function stop_at(code, line, column, a, b, c, d) {
+function stop_at(code, line, column, a, b, c, d) {
 
 // Same as warn_at, except that it stops the analysis.
 
-        throw warn_at(code, line, column, a, b, c, d);
-    }
+    throw warn_at(code, line, column, a, b, c, d);
+}
 
-    function warn(code, the_token, a, b, c, d) {
+function warn(code, the_token, a, b, c, d) {
 
 // Same as warn_at, except the warning will be associated with a specific token.
 // If there is already a warning on this token, suppress the new one. It is
 // likely that the first warning will be the most meaningful.
 
-        if (the_token === undefined) {
-            the_token = token_nxt;
-        }
-        if (the_token.warning === undefined) {
-            the_token.warning = warn_at(
-                code,
-                the_token.line,
-                (the_token.from || 0) + line_fudge,
-                a || artifact(the_token),
-                b,
-                c,
-                d
-            );
-            return the_token.warning;
-        }
+    if (the_token === undefined) {
+        the_token = token_nxt;
     }
+    if (the_token.warning === undefined) {
+        the_token.warning = warn_at(
+            code,
+            the_token.line,
+            (the_token.from || 0) + line_fudge,
+            a || artifact(the_token),
+            b,
+            c,
+            d
+        );
+        return the_token.warning;
+    }
+}
 
-    function stop(code, the_token, a, b, c, d) {
+function stop(code, the_token, a, b, c, d) {
 
 // Similar to warn and stop_at. If the token already had a warning, that
 // warning will be replaced with this new one. It is likely that the stopping
 // warning will be the more meaningful.
 
-        if (the_token === undefined) {
-            the_token = token_nxt;
-        }
-        delete the_token.warning;
-        throw warn(code, the_token, a, b, c, d);
+    if (the_token === undefined) {
+        the_token = token_nxt;
     }
+    delete the_token.warning;
+    throw warn(code, the_token, a, b, c, d);
+}
 
-    function is_weird(thing) {
-        return (
-            thing.id === "(regexp)"
-            || thing.id === "{"
-            || thing.id === "=>"
-            || thing.id === "function"
-            || (thing.id === "[" && thing.arity === "unary")
-        );
-    }
+function is_weird(thing) {
+    return (
+        thing.id === "(regexp)"
+        || thing.id === "{"
+        || thing.id === "=>"
+        || thing.id === "function"
+        || (thing.id === "[" && thing.arity === "unary")
+    );
+}
 
-    function are_similar(a, b) {
-        let a_string;
-        let b_string;
+function are_similar(a, b) {
+    let a_string;
+    let b_string;
 
 // cause: "0&&0"
 
-        assert_or_throw(!(a === b), `Expected !(a === b).`);
+    assert_or_throw(!(a === b), `Expected !(a === b).`);
 //  Probably deadcode.
 //  if (a === b) {
 //      return true;
 //  }
-        if (Array.isArray(a)) {
-            return (
-                Array.isArray(b)
-                && a.length === b.length
-                && a.every(function (value, index) {
+    if (Array.isArray(a)) {
+        return (
+            Array.isArray(b)
+            && a.length === b.length
+            && a.every(function (value, index) {
 
 // cause: "`${0}`&&`${0}`"
 
-                    return are_similar(value, b[index]);
-                })
-            );
-        }
-        assert_or_throw(!Array.isArray(b), `Expected !Array.isArray(b).`);
+                return are_similar(value, b[index]);
+            })
+        );
+    }
+    assert_or_throw(!Array.isArray(b), `Expected !Array.isArray(b).`);
 //  Probably deadcode.
 //  if (Array.isArray(b)) {
 //      return false;
 //  }
-        if (a.id === "(number)" && b.id === "(number)") {
-            return a.value === b.value;
-        }
-        if (a.id === "(string)") {
-            a_string = a.value;
-        } else if (a.id === "`" && a.constant) {
-            a_string = a.value[0];
-        }
-        if (b.id === "(string)") {
-            b_string = b.value;
-        } else if (b.id === "`" && b.constant) {
-            b_string = b.value[0];
-        }
-        if (typeof a_string === "string") {
-            return a_string === b_string;
-        }
-        if (is_weird(a) || is_weird(b)) {
-            return false;
-        }
-        if (a.arity === b.arity && a.id === b.id) {
+    if (a.id === "(number)" && b.id === "(number)") {
+        return a.value === b.value;
+    }
+    if (a.id === "(string)") {
+        a_string = a.value;
+    } else if (a.id === "`" && a.constant) {
+        a_string = a.value[0];
+    }
+    if (b.id === "(string)") {
+        b_string = b.value;
+    } else if (b.id === "`" && b.constant) {
+        b_string = b.value[0];
+    }
+    if (typeof a_string === "string") {
+        return a_string === b_string;
+    }
+    if (is_weird(a) || is_weird(b)) {
+        return false;
+    }
+    if (a.arity === b.arity && a.id === b.id) {
 
 // cause: "aa.bb&&aa.bb"
 
-            if (a.id === ".") {
-                return (
-                    are_similar(a.expression, b.expression)
-                    && are_similar(a.name, b.name)
-                );
-            }
+        if (a.id === ".") {
+            return (
+                are_similar(a.expression, b.expression)
+                && are_similar(a.name, b.name)
+            );
+        }
 
 // cause: "+0&&+0"
 
-            if (a.arity === "unary") {
-                return are_similar(a.expression, b.expression);
-            }
-            if (a.arity === "binary") {
+        if (a.arity === "unary") {
+            return are_similar(a.expression, b.expression);
+        }
+        if (a.arity === "binary") {
 
 // cause: "aa[0]&&aa[0]"
 
-                return (
-                    a.id !== "("
-                    && are_similar(a.expression[0], b.expression[0])
-                    && are_similar(a.expression[1], b.expression[1])
-                );
-            }
-            if (a.arity === "ternary") {
+            return (
+                a.id !== "("
+                && are_similar(a.expression[0], b.expression[0])
+                && are_similar(a.expression[1], b.expression[1])
+            );
+        }
+        if (a.arity === "ternary") {
 
 // cause: "aa=(``?``:``)&&(``?``:``)"
 
-                return (
-                    are_similar(a.expression[0], b.expression[0])
-                    && are_similar(a.expression[1], b.expression[1])
-                    && are_similar(a.expression[2], b.expression[2])
-                );
-            }
-            assert_or_throw(
-                !(a.arity === "function" || a.arity === "regexp"),
-                `Expected !(a.arity === "function" || a.arity === "regexp").`
+            return (
+                are_similar(a.expression[0], b.expression[0])
+                && are_similar(a.expression[1], b.expression[1])
+                && are_similar(a.expression[2], b.expression[2])
             );
+        }
+        assert_or_throw(
+            !(a.arity === "function" || a.arity === "regexp"),
+            `Expected !(a.arity === "function" || a.arity === "regexp").`
+        );
 //      Probably deadcode.
 //      if (a.arity === "function" || a.arity === "regexp") {
 //          return false;
@@ -751,148 +730,148 @@ function jslint(
 
 // cause: "undefined&&undefined"
 
-            return true;
-        }
+        return true;
+    }
 
 // cause: "null&&undefined"
 
-        return false;
-    }
+    return false;
+}
 
 
-    function phase1_split() {
+function phase1_split() {
 
-// PHASE 1. Split <source> by newlines into <line_array>.
+// PHASE 1. Split <source> by newlines into <line_list>.
 
-        line_array = String("\n" + source).split(
-            // rx_crlf
-            /\n|\r\n?/
-        ).map(function (line_source) {
-            return {
-                line_source
-            };
-        });
-    }
+    line_list = String("\n" + source).split(
+        // rx_crlf
+        /\n|\r\n?/
+    ).map(function (line_source) {
+        return {
+            line_source
+        };
+    });
+}
 
 
-    function phase2_lex() {
+function phase2_lex() {
 
-// PHASE 2. Lex <line_array> into <token_array>.
+// PHASE 2. Lex <line_list> into <token_list>.
 
 // A popular character.
-        let char;
+    let char;
 // The column number of the next character.
-        let column = 0;
+    let column = 0;
 // The starting column number of the token.
-        let from;
+    let from;
 // The starting column of megastring.
-        let from_mega;
+    let from_mega;
 // The line number of the next character.
-        let line = 0;
+    let line = 0;
 // The starting line of "/*jslint-disable*/".
-        let line_disable;
+    let line_disable;
 // The starting line of megastring.
-        let line_mega;
+    let line_mega;
 // The remaining line source string.
-        let line_source = "";
+    let line_source = "";
 // The whole line source string.
-        let line_whole = "";
+    let line_whole = "";
 // true if directives are still allowed.
-        let mode_directive = true;
+    let mode_directive = true;
 // true if regular expression literal seen on this line.
-        let mode_regexp;
+    let mode_regexp;
 // A piece of string.
-        let snippet = "";
+    let snippet = "";
 // The first token.
-        let token_1;
+    let token_1;
 // The previous token excluding comments.
-        let token_before_slash = global;
+    let token_before_slash = token_global;
 // The previous token including comments.
-        let token_prv = global;
+    let token_prv = token_global;
 
-        function line_next() {
+    function line_next() {
 
 // Put the next line of source in line_source. If the line contains tabs,
 // replace them with spaces and give a warning. Also warn if the line contains
 // unsafe characters or is too damn long.
 
-            let at;
-            if (
-                !option_object.long
-                && line_whole.length > 80
-                && line_disable === undefined
-                && !mode_json
-                && token_1
-                && !mode_regexp
-            ) {
+        let at;
+        if (
+            !option_dict.long
+            && line_whole.length > 80
+            && line_disable === undefined
+            && !mode_json
+            && token_1
+            && !mode_regexp
+        ) {
 
 // cause: "too_long"
 
-                warn_at("too_long", line);
-            }
-            column = 0;
-            line += 1;
-            mode_regexp = false;
-            line_source = undefined;
-            line_whole = "";
-            if (line_array[line] === undefined) {
-                return line_source;
-            }
-            line_source = line_array[line].line_source;
-            line_whole = line_source;
+            warn_at("too_long", line);
+        }
+        column = 0;
+        line += 1;
+        mode_regexp = false;
+        line_source = undefined;
+        line_whole = "";
+        if (line_list[line] === undefined) {
+            return line_source;
+        }
+        line_source = line_list[line].line_source;
+        line_whole = line_source;
 
 // Scan each line for following ignore-directives:
 // "/*jslint-disable*/"
 // "/*jslint-enable*/"
 // "//jslint-quiet"
 
-            if (line_source === "/*jslint-disable*/") {
+        if (line_source === "/*jslint-disable*/") {
 
 // cause: "/*jslint-disable*/"
 
-                line_disable = line;
-            } else if (line_source === "/*jslint-enable*/") {
-                if (line_disable === undefined) {
+            line_disable = line;
+        } else if (line_source === "/*jslint-enable*/") {
+            if (line_disable === undefined) {
 
 // cause: "/*jslint-enable*/"
 
-                    stop_at("unopened_enable", line);
-                }
-                line_disable = undefined;
-            } else if (line_source.endsWith(" //jslint-quiet")) {
+                stop_at("unopened_enable", line);
+            }
+            line_disable = undefined;
+        } else if (line_source.endsWith(" //jslint-quiet")) {
 
 // cause: "0 //jslint-quiet"
 
-                line_array[line].directive_quiet = true;
-            }
-            if (line_disable !== undefined) {
+            line_list[line].directive_quiet = true;
+        }
+        if (line_disable !== undefined) {
 
 // cause: "/*jslint-disable*/\n0"
 
-                line_source = "";
-            }
-            at = line_source.search(rx_tab);
-            if (at >= 0) {
-                if (!option_object.white) {
+            line_source = "";
+        }
+        at = line_source.search(rx_tab);
+        if (at >= 0) {
+            if (!option_dict.white) {
 
 // cause: "\t"
 
-                    warn_at("use_spaces", line, at);
-                }
-                line_source = line_source.replace(rx_tab, " ");
+                warn_at("use_spaces", line, at);
             }
-            if (!option_object.white && line_source.endsWith(" ")) {
+            line_source = line_source.replace(rx_tab, " ");
+        }
+        if (!option_dict.white && line_source.endsWith(" ")) {
 
 // cause: " "
 
-                warn_at(
-                    "unexpected_trailing_space",
-                    line,
-                    line_source.length - 1
-                );
-            }
-            return line_source;
+            warn_at(
+                "unexpected_trailing_space",
+                line,
+                line_source.length - 1
+            );
         }
+        return line_source;
+    }
 
 // Most tokens, including the identifiers, operators, and punctuators, can be
 // found with a regular expression. Regular expressions cannot correctly match
@@ -901,471 +880,452 @@ function jslint(
 // don't provide good warnings. The functions char_after, char_before,
 // read_some_digits, and char_after_escape help in the parsing of literals.
 
-        function char_after(match) {
+    function char_after(match) {
 
 // Get the next character from the source line. Remove it from the line_source,
 // and append it to the snippet. Optionally check that the previous character
 // matched an expected value.
 
-            if (match !== undefined && char !== match) {
-                return (
-                    char === ""
+        if (match !== undefined && char !== match) {
+            return (
+                char === ""
 
 // cause: "aa=/[/"
 
-                    ? stop_at("expected_a", line, column - 1, match, char)
+                ? stop_at("expected_a", line, column - 1, match, char)
 
 // cause: "aa=/aa{/"
 
-                    : stop_at("expected_a_b", line, column, match, char)
-                );
-            }
-            char = line_source.slice(0, 1);
-            line_source = line_source.slice(1);
-            snippet += char || " ";
-            column += 1;
-            return char;
+                : stop_at("expected_a_b", line, column, match, char)
+            );
         }
+        char = line_source.slice(0, 1);
+        line_source = line_source.slice(1);
+        snippet += char || " ";
+        column += 1;
+        return char;
+    }
 
-        function char_before() {
+    function char_before() {
 
 // Back up one character by moving a character from the end of the snippet to
 // the front of the line_source.
 
-            char = snippet.slice(-1);
-            line_source = char + line_source;
-            column -= char.length;
+        char = snippet.slice(-1);
+        line_source = char + line_source;
+        column -= char.length;
 
 // Remove last character from snippet.
 
-            snippet = snippet.slice(0, -1);
-            return char;
-        }
+        snippet = snippet.slice(0, -1);
+        return char;
+    }
 
-        function read_some_digits(rx, quiet) {
-            const digits = line_source.match(rx)[0];
-            const length = digits.length;
-            if (!quiet && length === 0) {
+    function read_some_digits(rx, quiet) {
+        const digits = line_source.match(rx)[0];
+        const length = digits.length;
+        if (!quiet && length === 0) {
 
 // cause: "0x"
 
-                warn_at("expected_digits_after_a", line, column, snippet);
-            }
-            column += length;
-            line_source = line_source.slice(length);
-            snippet += digits;
-            char_after();
-            return length;
+            warn_at("expected_digits_after_a", line, column, snippet);
         }
+        column += length;
+        line_source = line_source.slice(length);
+        snippet += digits;
+        char_after();
+        return length;
+    }
 
-        function char_after_escape(extra) {
+    function char_after_escape(extra) {
 
 // Validate char after escape "\\".
 
-            char_after("\\");
-            switch (char) {
-            case "":
+        char_after("\\");
+        switch (char) {
+        case "":
 
 // cause: "\"\\"
 
-                return stop_at("unclosed_string", line, column);
-            case "/":
-            case "\\":
-            case "`":
-            case "b":
-            case "f":
-            case "n":
-            case "r":
-            case "t":
-                return char_after();
-            case "u":
-                if (char_after("u") === "{") {
-                    if (mode_json) {
+            return stop_at("unclosed_string", line, column);
+        case "/":
+        case "\\":
+        case "`":
+        case "b":
+        case "f":
+        case "n":
+        case "r":
+        case "t":
+            return char_after();
+        case "u":
+            if (char_after("u") === "{") {
+                if (mode_json) {
 
 // cause: "[\"\\u{12345}\"]"
 
-                        warn_at("unexpected_a", line, column, char);
-                    }
-                    if (read_some_digits(rx_hexs) > 5) {
+                    warn_at("unexpected_a", line, column, char);
+                }
+                if (read_some_digits(rx_hexs) > 5) {
 
 // cause: "\"\\u{123456}\""
 
-                        warn_at("too_many_digits", line, column);
-                    }
-                    if (char !== "}") {
+                    warn_at("too_many_digits", line, column);
+                }
+                if (char !== "}") {
 
 // cause: "\"\\u{12345\""
 
-                        stop_at("expected_a_before_b", line, column, "}", char);
-                    }
-                    return char_after();
+                    stop_at("expected_a_before_b", line, column, "}", char);
                 }
-                char_before();
-                if (read_some_digits(rx_hexs, true) < 4) {
+                return char_after();
+            }
+            char_before();
+            if (read_some_digits(rx_hexs, true) < 4) {
 
 // cause: "\"\\u0\""
 
-                    warn_at("expected_four_digits", line, column);
-                }
-                return;
-            default:
-                if (extra && extra.indexOf(char) >= 0) {
-                    return char_after();
-                }
+                warn_at("expected_four_digits", line, column);
+            }
+            return;
+        default:
+            if (extra && extra.indexOf(char) >= 0) {
+                return char_after();
+            }
 
 // cause: "\"\\0\""
 
-                warn_at("unexpected_a_before_b", line, column, "\\", char);
-            }
+            warn_at("unexpected_a_before_b", line, column, "\\", char);
         }
+    }
 
-        function token_create(id, value, identifier) {
+    function token_create(id, value, identifier) {
 
-// Create the token object and append it to token_array.
+// Create the token object and append it to token_list.
 
-            const the_token = {
-                from,
-                id,
-                identifier: Boolean(identifier),
-                line,
-                nr: token_array.length,
-                thru: column
-            };
-            token_array.push(the_token);
+        const the_token = {
+            from,
+            id,
+            identifier: Boolean(identifier),
+            line,
+            nr: token_list.length,
+            thru: column
+        };
+        token_list.push(the_token);
 
 // Directives must appear before the first statement.
 
-            if (id !== "(comment)" && id !== ";") {
-                mode_directive = false;
-            }
+        if (id !== "(comment)" && id !== ";") {
+            mode_directive = false;
+        }
 
 // If the token is to have a value, give it one.
 
-            if (value !== undefined) {
-                the_token.value = value;
-            }
+        if (value !== undefined) {
+            the_token.value = value;
+        }
 
 // If this token is an identifier that touches a preceding number, or
 // a "/", comment, or regular expression literal that touches a preceding
 // comment or regular expression literal, then give a missing space warning.
-// This warning is not suppressed by option_object.white.
+// This warning is not suppressed by option_dict.white.
 
-            if (
-                token_prv.line === line
-                && token_prv.thru === from
-                && (id === "(comment)" || id === "(regexp)" || id === "/")
-                && (token_prv.id === "(comment)" || token_prv.id === "(regexp)")
-            ) {
+        if (
+            token_prv.line === line
+            && token_prv.thru === from
+            && (id === "(comment)" || id === "(regexp)" || id === "/")
+            && (token_prv.id === "(comment)" || token_prv.id === "(regexp)")
+        ) {
 
 // cause: "/**//**/"
 
-                warn(
-                    "expected_space_a_b",
-                    the_token,
-                    artifact(token_prv),
-                    artifact(the_token)
-                );
-            }
-            if (token_prv.id === "." && id === "(number)") {
+            warn(
+                "expected_space_a_b",
+                the_token,
+                artifact(token_prv),
+                artifact(the_token)
+            );
+        }
+        if (token_prv.id === "." && id === "(number)") {
 
 // cause: ".0"
 
-                warn("expected_a_before_b", token_prv, "0", ".");
-            }
-            if (token_before_slash.id === "." && the_token.identifier) {
-                the_token.dot = true;
-            }
+            warn("expected_a_before_b", token_prv, "0", ".");
+        }
+        if (token_before_slash.id === "." && the_token.identifier) {
+            the_token.dot = true;
+        }
 
 // The previous token is used to detect adjacency problems.
 
-            token_prv = the_token;
+        token_prv = the_token;
 
 // The token_before_slash token is a previous token that was not a comment.
 // The token_before_slash token
 // is used to disambiguate "/", which can mean division or regular expression
 // literal.
 
-            if (token_prv.id !== "(comment)") {
-                token_before_slash = token_prv;
-            }
-            return the_token;
+        if (token_prv.id !== "(comment)") {
+            token_before_slash = token_prv;
         }
+        return the_token;
+    }
 
-        function parse_directive(the_comment, body) {
+    function parse_directive(the_comment, body) {
 
 // JSLint recognizes three directives that can be encoded in comments. This
 // function processes one item, and calls itself recursively to process the
 // next one.
 
-            const result = body.match(rx_directive_part);
-            if (result) {
-                let allowed;
-                const name = result[1];
-                const value = result[2];
-                if (the_comment.directive === "jslint") {
-                    allowed = allowed_option[name];
-                    if (
-                        typeof allowed === "boolean"
-                        || typeof allowed === "object"
-                    ) {
-                        if (value === "true" || value === undefined) {
-                            option_object[name] = true;
-                            if (Array.isArray(allowed)) {
-                                populate(allowed, global_array, false);
-                            }
-                        } else {
-                            assert_or_throw(
-                                value === "false",
-                                `Expected value === "false".`
-                            );
-                            option_object[name] = false;
-//                  Probably deadcode.
-//                  } else if (value === "false") {
-//                      option_object[name] = false;
-//                  } else {
-//                      warn("bad_option_a", the_comment, name + ":" + value);
+        const result = body.match(rx_directive_part);
+        if (result) {
+            let allowed;
+            const name = result[1];
+            const value = result[2];
+            if (the_comment.directive === "jslint") {
+                allowed = allowed_option[name];
+                if (
+                    typeof allowed === "boolean"
+                    || typeof allowed === "object"
+                ) {
+                    if (value === "true" || value === undefined) {
+                        option_dict[name] = true;
+                        if (Array.isArray(allowed)) {
+                            populate(allowed, global_list, false);
                         }
                     } else {
+                        assert_or_throw(
+                            value === "false",
+                            `Expected value === "false".`
+                        );
+                        option_dict[name] = false;
+//                  Probably deadcode.
+//                  } else if (value === "false") {
+//                      option_dict[name] = false;
+//                  } else {
+//                      warn("bad_option_a", the_comment, name + ":" + value);
+                    }
+                } else {
 
 // cause: "/*jslint undefined*/"
 
-                        warn("bad_option_a", the_comment, name);
-                    }
-                } else if (the_comment.directive === "property") {
-                    if (tenure === undefined) {
-                        tenure = empty();
-                    }
-                    tenure[name] = true;
-                } else if (the_comment.directive === "global") {
-                    if (value) {
+                    warn("bad_option_a", the_comment, name);
+                }
+            } else if (the_comment.directive === "property") {
+                if (tenure === undefined) {
+                    tenure = empty();
+                }
+                tenure[name] = true;
+            } else if (the_comment.directive === "global") {
+                if (value) {
 
 // cause: "/*global aa:false*/"
 
-                        warn("bad_option_a", the_comment, name + ":" + value);
-                    }
-                    global_array[name] = false;
-                    mode_module = the_comment;
+                    warn("bad_option_a", the_comment, name + ":" + value);
                 }
-                return parse_directive(the_comment, result[3]);
+                global_list[name] = false;
+                mode_module = the_comment;
             }
-            if (body) {
+            return parse_directive(the_comment, result[3]);
+        }
+        if (body) {
 
 // cause: "/*jslint !*/"
 
-                return stop("bad_directive_a", the_comment, body);
-            }
+            return stop("bad_directive_a", the_comment, body);
         }
+    }
 
-        function comment(snippet) {
+    function comment(snippet) {
 
 // Create a comment object. Comments are not allowed in JSON text. Comments can
 // include directives and notices of incompletion.
 
-            const the_comment = token_create("(comment)", snippet);
-            let result;
-            if (Array.isArray(snippet)) {
-                snippet = snippet.join(" ");
-            }
-            if (!option_object.devel && rx_todo.test(snippet)) {
+        const the_comment = token_create("(comment)", snippet);
+        let result;
+        if (Array.isArray(snippet)) {
+            snippet = snippet.join(" ");
+        }
+        if (!option_dict.devel && rx_todo.test(snippet)) {
 
 // cause: "//\u0074odo"
 
-                warn("todo_comment", the_comment);
-            }
-            result = snippet.match(rx_directive);
-            if (result) {
-                if (!mode_directive) {
+            warn("todo_comment", the_comment);
+        }
+        result = snippet.match(rx_directive);
+        if (result) {
+            if (!mode_directive) {
 
 // cause: "0\n/*global aa*/"
 
-                    warn_at("misplaced_directive_a", line, from, result[1]);
-                } else {
-                    the_comment.directive = result[1];
-                    parse_directive(the_comment, result[2]);
-                }
-                directives.push(the_comment);
+                warn_at("misplaced_directive_a", line, from, result[1]);
+            } else {
+                the_comment.directive = result[1];
+                parse_directive(the_comment, result[2]);
             }
-            return the_comment;
+            directives.push(the_comment);
         }
+        return the_comment;
+    }
 
-        function regexp() {
+    function regexp() {
 
 // Regexp
 // Parse a regular expression literal.
 
-            let flag;
-            let mode_multi = false;
-            let result;
-            let value;
-            mode_regexp = true;
+        let flag;
+        let mode_multi = false;
+        let result;
+        let value;
+        mode_regexp = true;
 
-            function regexp_subklass() {
+        function regexp_subklass() {
 
 // RegExp
 // Match a character in a character class.
 
-                switch (char) {
-                case "\\":
-                    char_after_escape("BbDdSsWw-[]^");
-                    return true;
-                case "":
-                case "[":
-                case "]":
-                case "/":
-                case "^":
-                case "-":
-                    return false;
-                case " ":
+            switch (char) {
+            case "\\":
+                char_after_escape("BbDdSsWw-[]^");
+                return true;
+            case "":
+            case "[":
+            case "]":
+            case "/":
+            case "^":
+            case "-":
+                return false;
+            case " ":
 
 // cause: "aa=/[ ]/"
 
-                    warn_at("expected_a_b", line, column, "\\u0020", " ");
-                    char_after();
-                    return true;
-                case "`":
-                    if (mode_mega) {
+                warn_at("expected_a_b", line, column, "\\u0020", " ");
+                char_after();
+                return true;
+            case "`":
+                if (mode_mega) {
 
 // cause: "`${/[`]/}`"
 
-                        warn_at("unexpected_a", line, column, "`");
-                    }
-                    char_after();
-                    return true;
-                default:
-                    char_after();
-                    return true;
+                    warn_at("unexpected_a", line, column, "`");
                 }
+                char_after();
+                return true;
+            default:
+                char_after();
+                return true;
             }
+        }
 
-            function regexp_choice() {
-                let follow;
+        function regexp_choice() {
+            let follow;
 
 // RegExp
 // Parse sequence of characters in regexp.
 
-                while (true) {
-                    switch (char) {
-                    case "":
-                    case "/":
-                    case "]":
-                    case ")":
+            while (true) {
+                switch (char) {
+                case "":
+                case "/":
+                case "]":
+                case ")":
 
 // RegExp
 // Break while-loop in regexp_choice().
 
-                        if (!follow) {
+                    if (!follow) {
 
 // cause: "/ /"
 
-                            warn_at(
-                                "expected_regexp_factor_a",
-                                line,
-                                column,
-                                char
-                            );
-                        }
+                        warn_at(
+                            "expected_regexp_factor_a",
+                            line,
+                            column,
+                            char
+                        );
+                    }
 
 // RegExp
 // Match a choice (a sequence that can be followed by | and another choice).
 
-                        assert_or_throw(
-                            !(char === "|"),
-                            `Expected !(char === "|").`
-                        );
+                    assert_or_throw(
+                        !(char === "|"),
+                        `Expected !(char === "|").`
+                    );
 //                  Probably deadcode.
 //                  if (char === "|") {
 //                      char_after("|");
 //                      return regexp_choice();
 //                  }
-                        return;
-                    case "(":
+                    return;
+                case "(":
 
 // RegExp
 // Match a group that starts with left paren.
 
-                        char_after("(");
-                        if (char === "?") {
-                            char_after("?");
-                            if (char === "=" || char === "!") {
-                                char_after();
-                            } else {
-                                char_after(":");
-                            }
-                        } else if (char === ":") {
+                    char_after("(");
+                    if (char === "?") {
+                        char_after("?");
+                        if (char === "=" || char === "!") {
+                            char_after();
+                        } else {
+                            char_after(":");
+                        }
+                    } else if (char === ":") {
 
 // cause: "aa=/(:)/"
 // cause: "aa=/?/"
 
-                            warn_at(
-                                "expected_a_before_b",
-                                line,
-                                column,
-                                "?",
-                                ":"
-                            );
-                        }
+                        warn_at(
+                            "expected_a_before_b",
+                            line,
+                            column,
+                            "?",
+                            ":"
+                        );
+                    }
 
 // RegExp
 // Recurse regexp_choice().
 
-                        regexp_choice();
-                        char_after(")");
-                        break;
-                    case "[":
+                    regexp_choice();
+                    char_after(")");
+                    break;
+                case "[":
 
 // RegExp
 // Match a class.
 
-                        char_after("[");
-                        if (char === "^") {
-                            char_after("^");
-                        }
-                        while (true) {
+                    char_after("[");
+                    if (char === "^") {
+                        char_after("^");
+                    }
+                    while (true) {
 
 // RegExp
 // Match a range of subclasses.
 
-                            while (regexp_subklass()) {
-                                if (char === "-") {
-                                    char_after("-");
-                                    if (!regexp_subklass()) {
+                        while (regexp_subklass()) {
+                            if (char === "-") {
+                                char_after("-");
+                                if (!regexp_subklass()) {
 
 // cause: "aa=/[0-]/"
 
-                                        return stop_at(
-                                            "unexpected_a",
-                                            line,
-                                            column - 1,
-                                            "-"
-                                        );
-                                    }
+                                    return stop_at(
+                                        "unexpected_a",
+                                        line,
+                                        column - 1,
+                                        "-"
+                                    );
                                 }
                             }
-                            if (char === "]" || char === "") {
-                                break;
-                            }
+                        }
+                        if (char === "]" || char === "") {
+                            break;
+                        }
 
 // cause: "aa=/[/"
 
-                            warn_at(
-                                "expected_a_before_b",
-                                line,
-                                column,
-                                "\\",
-                                char
-                            );
-                            char_after();
-                        }
-                        char_after("]");
-                        break;
-                    case "\\":
-                        char_after_escape("BbDdSsWw^${}[]():=!.|*+?");
-                        break;
-                    case "?":
-                    case "+":
-                    case "*":
-                    case "}":
-                    case "{":
                         warn_at(
                             "expected_a_before_b",
                             line,
@@ -1374,264 +1334,283 @@ function jslint(
                             char
                         );
                         char_after();
-                        break;
-                    case "`":
-                        if (mode_mega) {
+                    }
+                    char_after("]");
+                    break;
+                case "\\":
+                    char_after_escape("BbDdSsWw^${}[]():=!.|*+?");
+                    break;
+                case "?":
+                case "+":
+                case "*":
+                case "}":
+                case "{":
+                    warn_at(
+                        "expected_a_before_b",
+                        line,
+                        column,
+                        "\\",
+                        char
+                    );
+                    char_after();
+                    break;
+                case "`":
+                    if (mode_mega) {
 
 // cause: "`${/`/}`"
 
-                            warn_at("unexpected_a", line, column, "`");
-                        }
-                        char_after();
-                        break;
-                    case " ":
+                        warn_at("unexpected_a", line, column, "`");
+                    }
+                    char_after();
+                    break;
+                case " ":
 
 // cause: "aa=/ /"
 
-                        warn_at("expected_a_b", line, column, "\\s", " ");
-                        char_after();
-                        break;
-                    case "$":
-                        if (line_source[0] !== "/") {
-                            mode_multi = true;
-                        }
-                        char_after();
-                        break;
-                    case "^":
-                        if (snippet !== "^") {
-                            mode_multi = true;
-                        }
-                        char_after();
-                        break;
-                    default:
-                        char_after();
+                    warn_at("expected_a_b", line, column, "\\s", " ");
+                    char_after();
+                    break;
+                case "$":
+                    if (line_source[0] !== "/") {
+                        mode_multi = true;
                     }
+                    char_after();
+                    break;
+                case "^":
+                    if (snippet !== "^") {
+                        mode_multi = true;
+                    }
+                    char_after();
+                    break;
+                default:
+                    char_after();
+                }
 
 // RegExp
 // Match an optional quantifier.
 
-                    switch (char) {
-                    case "?":
-                    case "*":
-                    case "+":
-                        if (char_after() === "?") {
-                            char_after("?");
-                        }
-                        break;
-                    case "{":
-                        if (read_some_digits(rx_digits, true) === 0) {
+                switch (char) {
+                case "?":
+                case "*":
+                case "+":
+                    if (char_after() === "?") {
+                        char_after("?");
+                    }
+                    break;
+                case "{":
+                    if (read_some_digits(rx_digits, true) === 0) {
 
 // cause: "aa=/aa{/"
 
-                            warn_at(
-                                "expected_a_before_b",
-                                line,
-                                column,
-                                "0",
-                                ","
-                            );
-                        }
-                        if (char === ",") {
+                        warn_at(
+                            "expected_a_before_b",
+                            line,
+                            column,
+                            "0",
+                            ","
+                        );
+                    }
+                    if (char === ",") {
 
 // cause: "aa=/.{,/"
 
-                            read_some_digits(rx_digits, true);
-                        }
-                        if (char_after("}") === "?") {
+                        read_some_digits(rx_digits, true);
+                    }
+                    if (char_after("}") === "?") {
 
 // cause: "aa=/.{0}?/"
 
-                            warn_at("unexpected_a", line, column, char);
-                            char_after("?");
-                        }
-                        break;
+                        warn_at("unexpected_a", line, column, char);
+                        char_after("?");
                     }
-                    follow = true;
+                    break;
                 }
+                follow = true;
             }
+        }
 
 // RegExp
 // Scan the regexp literal. Give a warning if the first character is = because
 // /= looks like a division assignment operator.
 
-            snippet = "";
-            char_after();
-            if (char === "=") {
+        snippet = "";
+        char_after();
+        if (char === "=") {
 
 // cause: "aa=/=/"
 
-                warn_at("expected_a_before_b", line, column, "\\", "=");
-            }
-            regexp_choice();
+            warn_at("expected_a_before_b", line, column, "\\", "=");
+        }
+        regexp_choice();
 
 // RegExp
 // Remove last character from snippet.
 
-            snippet = snippet.slice(0, -1);
+        snippet = snippet.slice(0, -1);
 
 // RegExp
 // Make sure there is a closing slash.
 
-            value = snippet;
-            char_after("/");
+        value = snippet;
+        char_after("/");
 
 // RegExp
 // Create flag.
 
-            flag = empty();
-            while (
+        flag = empty();
+        while (
 
 // Regexp
 // char is a letter.
 
-                (char >= "a" && char <= "z\uffff")
-                || (char >= "A" && char <= "Z\uffff")
-            ) {
+            (char >= "a" && char <= "z\uffff")
+            || (char >= "A" && char <= "Z\uffff")
+        ) {
 
 // RegExp
 // Process dangling flag letters.
 
-                switch (!flag[char] && char) {
-                case "g":
-                case "i":
-                case "m":
-                case "u":
-                case "y":
+            switch (!flag[char] && char) {
+            case "g":
+            case "i":
+            case "m":
+            case "u":
+            case "y":
 
 // cause: "aa=/./gimuy"
 
-                    break;
-                default:
+                break;
+            default:
 
 // cause: "aa=/./gg"
 // cause: "aa=/./z"
 
-                    warn_at("unexpected_a", line, column, char);
-                }
-                flag[char] = true;
-                char_after();
+                warn_at("unexpected_a", line, column, char);
             }
-            char_before();
-            if (char === "/" || char === "*") {
+            flag[char] = true;
+            char_after();
+        }
+        char_before();
+        if (char === "/" || char === "*") {
 
 // cause: "aa=/.//"
 
-                return stop_at("unexpected_a", line, from, char);
-            }
-            result = token_create("(regexp)", char);
-            result.flag = flag;
-            result.value = value;
-            if (mode_multi && !flag.m) {
+            return stop_at("unexpected_a", line, from, char);
+        }
+        result = token_create("(regexp)", char);
+        result.flag = flag;
+        result.value = value;
+        if (mode_multi && !flag.m) {
 
 // cause: "aa=/$^/"
 
-                warn_at("missing_m", line, column);
-            }
-            return result;
+            warn_at("missing_m", line, column);
         }
+        return result;
+    }
 
-        function string(quote) {
+    function string(quote) {
 
 // Create a string token.
 
-            let the_token;
-            snippet = "";
-            char_after();
+        let the_token;
+        snippet = "";
+        char_after();
 
 // Parse/loop through each character in "...".
 
-            while (true) {
-                switch (char) {
-                case quote:
+        while (true) {
+            switch (char) {
+            case quote:
 
 // Remove last character from snippet.
 
-                    snippet = snippet.slice(0, -1);
-                    the_token = token_create("(string)", snippet);
-                    the_token.quote = quote;
-                    return the_token;
-                case "":
+                snippet = snippet.slice(0, -1);
+                the_token = token_create("(string)", snippet);
+                the_token.quote = quote;
+                return the_token;
+            case "":
 
 // cause: "\""
 
-                    return stop_at("unclosed_string", line, column);
-                case "\\":
-                    char_after_escape(quote);
-                    break;
-                case "`":
-                    if (mode_mega) {
+                return stop_at("unclosed_string", line, column);
+            case "\\":
+                char_after_escape(quote);
+                break;
+            case "`":
+                if (mode_mega) {
 
 // cause: "`${\"`\"}`"
 
-                        warn_at("unexpected_a", line, column, "`");
-                    }
-                    char_after("`");
-                    break;
-                default:
-                    char_after();
+                    warn_at("unexpected_a", line, column, "`");
                 }
+                char_after("`");
+                break;
+            default:
+                char_after();
             }
         }
+    }
 
-        function frack() {
+    function frack() {
+        if (char === ".") {
+            read_some_digits(rx_digits);
+        }
+        if (char === "E" || char === "e") {
+            char_after();
+            if (char !== "+" && char !== "-") {
+                char_before();
+            }
+            read_some_digits(rx_digits);
+        }
+    }
+
+    function number() {
+        if (snippet === "0") {
+            char_after();
             if (char === ".") {
-                read_some_digits(rx_digits);
-            }
-            if (char === "E" || char === "e") {
-                char_after();
-                if (char !== "+" && char !== "-") {
-                    char_before();
-                }
-                read_some_digits(rx_digits);
-            }
-        }
-
-        function number() {
-            if (snippet === "0") {
-                char_after();
-                if (char === ".") {
-                    frack();
-                } else if (char === "b") {
-                    read_some_digits(rx_bits);
-                } else if (char === "o") {
-                    read_some_digits(rx_octals);
-                } else if (char === "x") {
-                    read_some_digits(rx_hexs);
-                }
-            } else {
-                char_after();
                 frack();
+            } else if (char === "b") {
+                read_some_digits(rx_bits);
+            } else if (char === "o") {
+                read_some_digits(rx_octals);
+            } else if (char === "x") {
+                read_some_digits(rx_hexs);
             }
+        } else {
+            char_after();
+            frack();
+        }
 
 // If the next character after a number is a digit or letter, then something
 // unexpected is going on.
 
-            if (
-                (char >= "0" && char <= "9")
-                || (char >= "a" && char <= "z")
-                || (char >= "A" && char <= "Z")
-            ) {
+        if (
+            (char >= "0" && char <= "9")
+            || (char >= "a" && char <= "z")
+            || (char >= "A" && char <= "Z")
+        ) {
 
 // cause: "0a"
 
-                return stop_at(
-                    "unexpected_a_after_b",
-                    line,
-                    column,
-                    snippet.slice(-1),
-                    snippet.slice(0, -1)
-                );
-            }
-            char_before();
-            return token_create("(number)", snippet);
+            return stop_at(
+                "unexpected_a_after_b",
+                line,
+                column,
+                snippet.slice(-1),
+                snippet.slice(0, -1)
+            );
         }
+        char_before();
+        return token_create("(number)", snippet);
+    }
 
-        function lex() {
-            let comment_array;
-            let i = 0;
-            let j = 0;
-            let result;
-            let the_token;
+    function lex() {
+        let comment_list;
+        let i = 0;
+        let j = 0;
+        let result;
+        let the_token;
 
 // This should properly be a tail recursive function, but sadly, conformant
 // implementations of ES6 are still rare. This is the ideal code:
@@ -1655,28 +1634,28 @@ function jslint(
 
 // Loop through blank lines.
 
-            while (!line_source) {
-                line_source = line_next();
-                from = 0;
-                if (line_source === undefined) {
-                    return (
-                        mode_mega
+        while (!line_source) {
+            line_source = line_next();
+            from = 0;
+            if (line_source === undefined) {
+                return (
+                    mode_mega
 
 // cause: "`${//}`"
 
-                        ? stop_at("unclosed_mega", line_mega, from_mega)
-                        : line_disable !== undefined
+                    ? stop_at("unclosed_mega", line_mega, from_mega)
+                    : line_disable !== undefined
 
 // cause: "/*jslint-disable*/"
 
-                        ? stop_at("unclosed_disable", line_disable)
-                        : token_create("(end)")
-                    );
-                }
+                    ? stop_at("unclosed_disable", line_disable)
+                    : token_create("(end)")
+                );
             }
+        }
 
-            from = column;
-            result = line_source.match(rx_token);
+        from = column;
+        result = line_source.match(rx_token);
 
 // result[1] token
 // result[2] whitespace
@@ -1684,210 +1663,210 @@ function jslint(
 // result[4] number
 // result[5] rest
 
-            if (!result) {
+        if (!result) {
 
 // cause: "#"
 
-                return stop_at(
-                    "unexpected_char_a",
-                    line,
-                    column,
-                    line_source[0]
-                );
-            }
+            return stop_at(
+                "unexpected_char_a",
+                line,
+                column,
+                line_source[0]
+            );
+        }
 
-            snippet = result[1];
-            column += snippet.length;
-            line_source = result[5];
+        snippet = result[1];
+        column += snippet.length;
+        line_source = result[5];
 
 // Whitespace was matched. Call lex again to get more.
 
-            if (result[2]) {
-                return lex();
-            }
+        if (result[2]) {
+            return lex();
+        }
 
 // The token is an identifier.
 
-            if (result[3]) {
-                return token_create(snippet, undefined, true);
-            }
+        if (result[3]) {
+            return token_create(snippet, undefined, true);
+        }
 
 // Create token from number.
 
-            if (result[4]) {
-                return number(snippet);
-            }
+        if (result[4]) {
+            return number(snippet);
+        }
 
 // Create token from string.
 
-            if (snippet === "\"") {
-                return string(snippet);
-            }
-            if (snippet === "'") {
-                if (!option_object.single) {
+        if (snippet === "\"") {
+            return string(snippet);
+        }
+        if (snippet === "'") {
+            if (!option_dict.single) {
 
 // cause: "''"
 
-                    warn_at("use_double", line, column);
-                }
-                return string(snippet);
+                warn_at("use_double", line, column);
             }
+            return string(snippet);
+        }
 
 // The token is a megastring. We don't allow any kind of mega nesting.
 
-            if (snippet === "`") {
-                if (mode_mega) {
+        if (snippet === "`") {
+            if (mode_mega) {
 
 // cause: "`${`"
 
-                    return stop_at("expected_a_b", line, column, "}", "`");
-                }
-                snippet = "";
-                from_mega = from;
-                line_mega = line;
-                mode_mega = true;
+                return stop_at("expected_a_b", line, column, "}", "`");
+            }
+            snippet = "";
+            from_mega = from;
+            line_mega = line;
+            mode_mega = true;
 
 // Parsing a mega literal is tricky. First create a ` token.
 
-                token_create("`");
-                from += 1;
+            token_create("`");
+            from += 1;
 
 // Then loop, building up a string, possibly from many lines, until seeing
 // the end of file, a closing `, or a ${ indicting an expression within the
 // string.
 
-                (function part() {
-                    const at = line_source.search(rx_mega);
+            (function part() {
+                const at = line_source.search(rx_mega);
 
 // If neither ` nor ${ is seen, then the whole line joins the snippet.
 
-                    if (at < 0) {
-                        snippet += line_source + "\n";
-                        return (
-                            line_next() === undefined
+                if (at < 0) {
+                    snippet += line_source + "\n";
+                    return (
+                        line_next() === undefined
 
 // cause: "`"
 
-                            ? stop_at("unclosed_mega", line_mega, from_mega)
-                            : part()
-                        );
-                    }
-                    snippet += line_source.slice(0, at);
-                    column += at;
-                    line_source = line_source.slice(at);
-                    if (line_source[0] === "\\") {
-                        snippet += line_source.slice(0, 2);
-                        line_source = line_source.slice(2);
-                        column += 2;
-                        return part();
-                    }
+                        ? stop_at("unclosed_mega", line_mega, from_mega)
+                        : part()
+                    );
+                }
+                snippet += line_source.slice(0, at);
+                column += at;
+                line_source = line_source.slice(at);
+                if (line_source[0] === "\\") {
+                    snippet += line_source.slice(0, 2);
+                    line_source = line_source.slice(2);
+                    column += 2;
+                    return part();
+                }
 
 // if either ` or ${ was found, then the preceding joins the snippet to become
 // a string token.
 
-                    token_create("(string)", snippet).quote = "`";
-                    snippet = "";
+                token_create("(string)", snippet).quote = "`";
+                snippet = "";
 
 // If ${, then create tokens that will become part of an expression until
 // a } token is made.
 
-                    if (line_source[0] === "$") {
-                        column += 2;
-                        token_create("${");
-                        line_source = line_source.slice(2);
-                        (function expr() {
-                            const id = lex().id;
-                            if (id === "{") {
+                if (line_source[0] === "$") {
+                    column += 2;
+                    token_create("${");
+                    line_source = line_source.slice(2);
+                    (function expr() {
+                        const id = lex().id;
+                        if (id === "{") {
 
 // cause: "`${{"
 
-                                return stop_at(
-                                    "expected_a_b",
-                                    line,
-                                    column,
-                                    "}",
-                                    "{"
-                                );
-                            }
-                            if (id !== "}") {
-                                return expr();
-                            }
-                        }());
-                        return part();
-                    }
-                }());
-                line_source = line_source.slice(1);
-                column += 1;
-                mode_mega = false;
-                return token_create("`");
-            }
+                            return stop_at(
+                                "expected_a_b",
+                                line,
+                                column,
+                                "}",
+                                "{"
+                            );
+                        }
+                        if (id !== "}") {
+                            return expr();
+                        }
+                    }());
+                    return part();
+                }
+            }());
+            line_source = line_source.slice(1);
+            column += 1;
+            mode_mega = false;
+            return token_create("`");
+        }
 
 // The token is a // comment.
 
-            if (snippet === "//") {
-                snippet = line_source;
-                line_source = "";
-                the_token = comment(snippet);
-                if (mode_mega) {
+        if (snippet === "//") {
+            snippet = line_source;
+            line_source = "";
+            the_token = comment(snippet);
+            if (mode_mega) {
 
 // cause: "`${//}`"
 
-                    warn("unexpected_comment", the_token, "`");
-                }
-                return the_token;
+                warn("unexpected_comment", the_token, "`");
             }
+            return the_token;
+        }
 
 // The token is a /* comment.
 
-            if (snippet === "/*") {
-                comment_array = [];
-                if (line_source[0] === "/") {
+        if (snippet === "/*") {
+            comment_list = [];
+            if (line_source[0] === "/") {
 
 // cause: "/*/"
 
-                    warn_at("unexpected_a", line, column + i, "/");
-                }
-                (function next() {
-                    if (line_source > "") {
-                        i = line_source.search(rx_star_slash);
-                        if (i >= 0) {
-                            return;
-                        }
-                        j = line_source.search(rx_slash_star);
-                        if (j >= 0) {
+                warn_at("unexpected_a", line, column + i, "/");
+            }
+            (function next() {
+                if (line_source > "") {
+                    i = line_source.search(rx_star_slash);
+                    if (i >= 0) {
+                        return;
+                    }
+                    j = line_source.search(rx_slash_star);
+                    if (j >= 0) {
 
 // cause: "/*/*"
 
-                            warn_at("nested_comment", line, column + j);
-                        }
+                        warn_at("nested_comment", line, column + j);
                     }
-                    comment_array.push(line_source);
-                    line_source = line_next();
-                    if (line_source === undefined) {
+                }
+                comment_list.push(line_source);
+                line_source = line_next();
+                if (line_source === undefined) {
 
 // cause: "/*"
 
-                        return stop_at("unclosed_comment", line, column);
-                    }
-                    return next();
-                }());
-                snippet = line_source.slice(0, i);
-                j = snippet.search(rx_slash_star_or_slash);
-                if (j >= 0) {
+                    return stop_at("unclosed_comment", line, column);
+                }
+                return next();
+            }());
+            snippet = line_source.slice(0, i);
+            j = snippet.search(rx_slash_star_or_slash);
+            if (j >= 0) {
 
 // cause: "/*/**/"
 
-                    warn_at("nested_comment", line, column + j);
-                }
-                comment_array.push(snippet);
-                column += i + 2;
-                line_source = line_source.slice(i + 2);
-                return comment(comment_array);
+                warn_at("nested_comment", line, column + j);
             }
+            comment_list.push(snippet);
+            column += i + 2;
+            line_source = line_source.slice(i + 2);
+            return comment(comment_list);
+        }
 
 // The token is a slash.
 
-            if (snippet === "/") {
+        if (snippet === "/") {
 
 // The / can be a division operator or the beginning of a regular expression
 // literal. It is not possible to know which without doing a complete parse.
@@ -1898,23 +1877,23 @@ function jslint(
 // object, so it is likely that we can get away with it. We avoided the worst
 // cases by eliminating automatic semicolon insertion.
 
-                if (token_before_slash.identifier) {
-                    if (!token_before_slash.dot) {
-                        if (token_before_slash.id === "return") {
-                            return regexp();
-                        }
-                        if (
-                            token_before_slash.id === "(begin)"
-                            || token_before_slash.id === "case"
-                            || token_before_slash.id === "delete"
-                            || token_before_slash.id === "in"
-                            || token_before_slash.id === "instanceof"
-                            || token_before_slash.id === "new"
-                            || token_before_slash.id === "typeof"
-                            || token_before_slash.id === "void"
-                            || token_before_slash.id === "yield"
-                        ) {
-                            the_token = regexp();
+            if (token_before_slash.identifier) {
+                if (!token_before_slash.dot) {
+                    if (token_before_slash.id === "return") {
+                        return regexp();
+                    }
+                    if (
+                        token_before_slash.id === "(begin)"
+                        || token_before_slash.id === "case"
+                        || token_before_slash.id === "delete"
+                        || token_before_slash.id === "in"
+                        || token_before_slash.id === "instanceof"
+                        || token_before_slash.id === "new"
+                        || token_before_slash.id === "typeof"
+                        || token_before_slash.id === "void"
+                        || token_before_slash.id === "yield"
+                    ) {
+                        the_token = regexp();
 
 // cause: "/./"
 // cause: "case /./"
@@ -1926,59 +1905,59 @@ function jslint(
 // cause: "void /./"
 // cause: "yield /./"
 
-                            return stop("unexpected_a", the_token);
-                        }
+                        return stop("unexpected_a", the_token);
                     }
-                } else {
-                    if ("(,=:?[".indexOf(
-                        token_before_slash.id.slice(-1)
-                    ) >= 0) {
-                        return regexp();
-                    }
-                    if ("!&|{};~+-*%/^<>".indexOf(
-                        token_before_slash.id.slice(-1)
-                    ) >= 0) {
-                        the_token = regexp();
+                }
+            } else {
+                if ("(,=:?[".indexOf(
+                    token_before_slash.id.slice(-1)
+                ) >= 0) {
+                    return regexp();
+                }
+                if ("!&|{};~+-*%/^<>".indexOf(
+                    token_before_slash.id.slice(-1)
+                ) >= 0) {
+                    the_token = regexp();
 
 // cause: "!/./"
 
-                        warn("wrap_regexp", the_token);
-                        return the_token;
-                    }
-                }
-                if (line_source[0] === "=") {
-                    column += 1;
-                    line_source = line_source.slice(1);
-                    snippet = "/=";
-                    warn_at("unexpected_a", line, column, "/=");
+                    warn("wrap_regexp", the_token);
+                    return the_token;
                 }
             }
-            return token_create(snippet);
+            if (line_source[0] === "=") {
+                column += 1;
+                line_source = line_source.slice(1);
+                snippet = "/=";
+                warn_at("unexpected_a", line, column, "/=");
+            }
         }
+        return token_create(snippet);
+    }
 
 // Scan first line for "#!" and ignore it.
 
-        if (line_array[line_fudge].line_source.startsWith("#!")) {
-            line += 1;
-            mode_shebang = true;
-        }
-        token_1 = lex();
-        mode_json = token_1.id === "{" || token_1.id === "[";
+    if (line_list[line_fudge].line_source.startsWith("#!")) {
+        line += 1;
+        mode_shebang = true;
+    }
+    token_1 = lex();
+    mode_json = token_1.id === "{" || token_1.id === "[";
 
 // This loop will be replaced with a recursive call to lex when ES6 has been
 // finished and widely deployed and adopted.
 
-        while (true) {
-            if (lex().id === "(end)") {
-                break;
-            }
+    while (true) {
+        if (lex().id === "(end)") {
+            break;
         }
     }
+}
 
 
-    function phase3_parse() {
+function phase3_parse() {
 
-// PHASE 3. Parse <token_array> into <token_tree> using Pratt parsing.
+// PHASE 3. Parse <token_list> into <token_tree> using Pratt parsing.
 
 // Parsing:
 
@@ -1995,175 +1974,175 @@ function jslint(
 // Specialized tokens may have additional properties.
 
 // The guessed name for anonymous functions.
-        let anon = "anonymous";
+    let anon = "anonymous";
 // The current function.
-        let functionage = global;
+    let functionage = token_global;
 // The number of the next token.
-        let token_array_ii = 0;
+    let token_list_ii = 0;
 // The current token being examined in the parse.
-        let token_now = global;
+    let token_now = token_global;
 
-        function advance(id, match) {
+    function advance(id, match) {
 
 // Produce the next token.
 
 // Attempt to give helpful names to anonymous functions.
 
-            if (token_now.identifier && token_now.id !== "function") {
-                anon = token_now.id;
-            } else if (
-                token_now.id === "(string)"
-                && rx_identifier.test(token_now.value)
-            ) {
-                anon = token_now.value;
-            }
+        if (token_now.identifier && token_now.id !== "function") {
+            anon = token_now.id;
+        } else if (
+            token_now.id === "(string)"
+            && rx_identifier.test(token_now.value)
+        ) {
+            anon = token_now.value;
+        }
 
 // Attempt to match token_nxt with an expected id.
 
-            if (id !== undefined && token_nxt.id !== id) {
-                return (
-                    match === undefined
+        if (id !== undefined && token_nxt.id !== id) {
+            return (
+                match === undefined
 
 // cause: "()"
 
-                    ? stop("expected_a_b", token_nxt, id, artifact())
+                ? stop("expected_a_b", token_nxt, id, artifact())
 
 // cause: "{\"aa\":0"
 
-                    : stop(
-                        "expected_a_b_from_c_d",
-                        token_nxt,
-                        id,
-                        artifact(match),
-                        match.line,
-                        artifact(token_nxt)
-                    )
-                );
-            }
+                : stop(
+                    "expected_a_b_from_c_d",
+                    token_nxt,
+                    id,
+                    artifact(match),
+                    match.line,
+                    artifact(token_nxt)
+                )
+            );
+        }
 
 // Promote the tokens, skipping comments.
 
-            token_now = token_nxt;
-            while (true) {
-                token_nxt = token_array[token_array_ii];
-                token_array_ii += 1;
-                if (token_nxt.id !== "(comment)") {
-                    if (token_nxt.id === "(end)") {
-                        token_array_ii -= 1;
-                    }
-                    break;
+        token_now = token_nxt;
+        while (true) {
+            token_nxt = token_list[token_list_ii];
+            token_list_ii += 1;
+            if (token_nxt.id !== "(comment)") {
+                if (token_nxt.id === "(end)") {
+                    token_list_ii -= 1;
                 }
-                if (mode_json) {
+                break;
+            }
+            if (mode_json) {
 
 // cause: "[//]"
 
-                    warn("unexpected_a", token_nxt);
-                }
+                warn("unexpected_a", token_nxt);
             }
         }
+    }
 
-        function lookahead() {
+    function lookahead() {
 
 // Look ahead one token without advancing, skipping comments.
 
-            let cadet;
-            let ii = token_array_ii;
-            while (true) {
-                cadet = token_array[ii];
-                if (cadet.id !== "(comment)") {
-                    return cadet;
-                }
-                ii += 1;
+        let cadet;
+        let ii = token_list_ii;
+        while (true) {
+            cadet = token_list[ii];
+            if (cadet.id !== "(comment)") {
+                return cadet;
             }
+            ii += 1;
         }
+    }
 
 // Now we parse JavaScript.
 
-        function enroll(name, role, readonly) {
+    function enroll(name, role, readonly) {
 
 // Enroll a name into the current function context. The role can be exception,
 // function, label, parameter, or variable. We look for variable redefinition
 // because it causes confusion.
 
-            const id = name.id;
+        const id = name.id;
 
 // Reserved words may not be enrolled.
 
-            if (syntax_object[id] !== undefined && id !== "ignore") {
+        if (syntax_dict[id] !== undefined && id !== "ignore") {
 
 // cause: "let undefined"
 
-                warn("reserved_a", name);
-            } else {
+            warn("reserved_a", name);
+        } else {
 
 // Has the name been enrolled in this context?
 
-                let earlier = functionage.context[id];
-                if (earlier) {
+            let earlier = functionage.context[id];
+            if (earlier) {
 
 // cause: "let aa;let aa"
 
-                    warn(
-                        "redefinition_a_b",
-                        name,
-                        name.id,
-                        earlier.line
-                    );
+                warn(
+                    "redefinition_a_b",
+                    name,
+                    name.id,
+                    earlier.line
+                );
 
 // Has the name been enrolled in an outer context?
 
-                } else {
-                    function_stack.forEach(function (value) {
-                        const item = value.context[id];
-                        if (item !== undefined) {
-                            earlier = item;
-                        }
-                    });
-                    if (earlier) {
-                        if (id === "ignore") {
-                            if (earlier.role === "variable") {
+            } else {
+                function_stack.forEach(function (value) {
+                    const item = value.context[id];
+                    if (item !== undefined) {
+                        earlier = item;
+                    }
+                });
+                if (earlier) {
+                    if (id === "ignore") {
+                        if (earlier.role === "variable") {
 
 // cause: "let ignore;function aa(ignore){}"
 
-                                warn("unexpected_a", name);
-                            }
-                        } else {
-                            if (
-                                (
-                                    role !== "exception"
-                                    || earlier.role !== "exception"
-                                )
-                                && role !== "parameter"
-                                && role !== "function"
-                            ) {
+                            warn("unexpected_a", name);
+                        }
+                    } else {
+                        if (
+                            (
+                                role !== "exception"
+                                || earlier.role !== "exception"
+                            )
+                            && role !== "parameter"
+                            && role !== "function"
+                        ) {
 
 // cause: "function aa(){try{aa();}catch(aa){aa();}}"
 // cause: "function aa(){var aa;}"
 
-                                warn(
-                                    "redefinition_a_b",
-                                    name,
-                                    name.id,
-                                    earlier.line
-                                );
-                            }
+                            warn(
+                                "redefinition_a_b",
+                                name,
+                                name.id,
+                                earlier.line
+                            );
                         }
                     }
+                }
 
 // Enroll it.
 
-                    functionage.context[id] = name;
-                    name.dead = true;
-                    name.parent = functionage;
-                    name.init = false;
-                    name.role = role;
-                    name.used = 0;
-                    name.writable = !readonly;
-                }
+                functionage.context[id] = name;
+                name.dead = true;
+                name.parent = functionage;
+                name.init = false;
+                name.role = role;
+                name.used = 0;
+                name.writable = !readonly;
             }
         }
+    }
 
-        function parse_expression(rbp, initial) {
+    function parse_expression(rbp, initial) {
 
 // This is the heart of the Pratt parser. I retained Pratt's nomenclature.
 // They are elements of the parsing method called Top Down Operator Precedence.
@@ -2177,93 +2156,93 @@ function jslint(
 // process leds (infix operators) until the bind powers cause it to stop. It
 // returns the expression's parse tree.
 
-            let left;
-            let the_symbol;
+        let left;
+        let the_symbol;
 
 // Statements will have already advanced, so advance now only if the token is
 // not the first of a statement,
 
-            if (!initial) {
-                advance();
-            }
-            the_symbol = syntax_object[token_now.id];
-            if (the_symbol !== undefined && the_symbol.nud !== undefined) {
+        if (!initial) {
+            advance();
+        }
+        the_symbol = syntax_dict[token_now.id];
+        if (the_symbol !== undefined && the_symbol.nud !== undefined) {
 
 // cause: "0"
 
-                left = the_symbol.nud();
-            } else if (token_now.identifier) {
+            left = the_symbol.nud();
+        } else if (token_now.identifier) {
 
 // cause: "aa"
 
-                left = token_now;
-                left.arity = "variable";
-            } else {
+            left = token_now;
+            left.arity = "variable";
+        } else {
 
 // cause: "!"
 // cause: "let aa=`${}`;"
 
-                return stop("unexpected_a", token_now);
-            }
+            return stop("unexpected_a", token_now);
+        }
 
 // Parse/loop through each symbol in expression.
 
-            while (true) {
-                the_symbol = syntax_object[token_nxt.id];
-                if (
-                    the_symbol === undefined
-                    || the_symbol.led === undefined
-                    || the_symbol.lbp <= rbp
-                ) {
-                    break;
-                }
-                advance();
-                left = the_symbol.led(left);
+        while (true) {
+            the_symbol = syntax_dict[token_nxt.id];
+            if (
+                the_symbol === undefined
+                || the_symbol.led === undefined
+                || the_symbol.lbp <= rbp
+            ) {
+                break;
             }
-            return left;
+            advance();
+            left = the_symbol.led(left);
         }
+        return left;
+    }
 
-        function condition() {
+    function condition() {
 
 // Parse the condition part of a do, if, while.
 
-            const the_paren = token_nxt;
-            let the_value;
+        const the_paren = token_nxt;
+        let the_value;
 
 // cause: "do{}while()"
 // cause: "if(){}"
 // cause: "while(){}"
 
-            the_paren.free = true;
-            advance("(");
-            the_value = parse_expression(0);
-            advance(")");
-            if (the_value.wrapped === true) {
+        the_paren.free = true;
+        advance("(");
+        the_value = parse_expression(0);
+        advance(")");
+        if (the_value.wrapped === true) {
 
 // cause: "while((0)){}"
 
-                warn("unexpected_a", the_paren);
-            }
+            warn("unexpected_a", the_paren);
+        }
 
 // Check for anticondition.
 
-            switch (the_value.id) {
-            case "%":
-            case "&":
-            case "(number)":
-            case "(string)":
-            case "*":
-            case "+":
-            case "-":
-            case "/":
-            case "<<":
-            case ">>":
-            case ">>>":
-            case "?":
-            case "^":
-            case "typeof":
-            case "|":
-            case "~":
+        switch (the_value.id) {
+        case "%":
+        case "&":
+        case "(number)":
+        case "(string)":
+        case "*":
+        case "+":
+        case "-":
+        case "/":
+        case "<<":
+        case ">>":
+        case ">>>":
+        case "?":
+        case "^":
+        case "typeof":
+        case "|":
+        case "~":
 
 // cause: "if(\"aa\"){}"
 // cause: "if(0%0){}"
@@ -2282,154 +2261,154 @@ function jslint(
 // cause: "if(typeof 0){}"
 // cause: "if(~0){}"
 
-                warn("unexpected_a", the_value);
-                break;
-            }
-            return the_value;
+            warn("unexpected_a", the_value);
+            break;
         }
+        return the_value;
+    }
 
-        function semicolon() {
+    function semicolon() {
 
 // Try to match a semicolon.
 
-            if (token_nxt.id === ";") {
-                advance(";");
-            } else {
+        if (token_nxt.id === ";") {
+            advance(";");
+        } else {
 
 // cause: "0"
 
-                warn_at(
-                    "expected_a_b",
-                    token_now.line,
-                    token_now.thru + 1,
-                    ";",
-                    artifact(token_nxt)
-                );
-            }
-            anon = "anonymous";
+            warn_at(
+                "expected_a_b",
+                token_now.line,
+                token_now.thru + 1,
+                ";",
+                artifact(token_nxt)
+            );
         }
+        anon = "anonymous";
+    }
 
-        function parse_statement() {
+    function parse_statement() {
 
 // Parse a statement. Any statement may have a label, but only four statements
 // have use for one. A statement can be one of the standard statements, or
 // an assignment expression, or an invocation expression.
 
-            let first;
-            let the_label;
-            let the_statement;
-            let the_symbol;
-            advance();
-            if (token_now.identifier && token_nxt.id === ":") {
-                the_label = token_now;
-                if (the_label.id === "ignore") {
+        let first;
+        let the_label;
+        let the_statement;
+        let the_symbol;
+        advance();
+        if (token_now.identifier && token_nxt.id === ":") {
+            the_label = token_now;
+            if (the_label.id === "ignore") {
 
 // cause: "ignore:"
 
-                    warn("unexpected_a", the_label);
-                }
-                advance(":");
-                if (
-                    token_nxt.id === "do"
-                    || token_nxt.id === "for"
-                    || token_nxt.id === "switch"
-                    || token_nxt.id === "while"
-                ) {
-                    enroll(the_label, "label", true);
-                    the_label.init = true;
-                    the_label.dead = false;
-                    the_statement = parse_statement();
-                    the_statement.label = the_label;
-                    the_statement.statement = true;
-                    return the_statement;
-                }
-                advance();
+                warn("unexpected_a", the_label);
+            }
+            advance(":");
+            if (
+                token_nxt.id === "do"
+                || token_nxt.id === "for"
+                || token_nxt.id === "switch"
+                || token_nxt.id === "while"
+            ) {
+                enroll(the_label, "label", true);
+                the_label.init = true;
+                the_label.dead = false;
+                the_statement = parse_statement();
+                the_statement.label = the_label;
+                the_statement.statement = true;
+                return the_statement;
+            }
+            advance();
 
 // cause: "aa:"
 
-                warn("unexpected_label_a", the_label);
-            }
+            warn("unexpected_label_a", the_label);
+        }
 
 // Parse the statement.
 
-            first = token_now;
-            first.statement = true;
-            the_symbol = syntax_object[first.id];
-            if (
-                the_symbol !== undefined
-                && the_symbol.fud !== undefined
+        first = token_now;
+        first.statement = true;
+        the_symbol = syntax_dict[first.id];
+        if (
+            the_symbol !== undefined
+            && the_symbol.fud !== undefined
 
 // Fixes issues #316, #317 - dynamic-import().
 
-                && !(the_symbol.id === "import" && token_nxt.id === "(")
-            ) {
-                the_symbol.disrupt = false;
-                the_symbol.statement = true;
-                the_statement = the_symbol.fud();
-            } else {
+            && !(the_symbol.id === "import" && token_nxt.id === "(")
+        ) {
+            the_symbol.disrupt = false;
+            the_symbol.statement = true;
+            the_statement = the_symbol.fud();
+        } else {
 
 // It is an expression statement.
 
-                the_statement = parse_expression(0, true);
-                if (the_statement.wrapped && the_statement.id !== "(") {
+            the_statement = parse_expression(0, true);
+            if (the_statement.wrapped && the_statement.id !== "(") {
 
 // cause: "(0)"
 
-                    warn("unexpected_a", first);
-                }
-                semicolon();
+                warn("unexpected_a", first);
             }
-            if (the_label !== undefined) {
-                the_label.dead = true;
-            }
-            return the_statement;
+            semicolon();
         }
+        if (the_label !== undefined) {
+            the_label.dead = true;
+        }
+        return the_statement;
+    }
 
-        function parse_statements() {
+    function parse_statements() {
 
 // Parse a list of statements. Give a warning if an unreachable statement
 // follows a disruptive statement.
 
-            const statement_array = [];
-            let a_statement;
-            let disrupt = false;
+        const statement_list = [];
+        let a_statement;
+        let disrupt = false;
 
 // Parse/loop each statement until a statement-terminator is reached.
 
-            while (true) {
-                switch (token_nxt.id) {
-                case "}":
-                case "case":
-                case "default":
-                case "else":
-                case "(end)":
-                    return statement_array;
-                }
-                a_statement = parse_statement();
-                statement_array.push(a_statement);
-                if (disrupt) {
+        while (true) {
+            switch (token_nxt.id) {
+            case "}":
+            case "case":
+            case "default":
+            case "else":
+            case "(end)":
+                return statement_list;
+            }
+            a_statement = parse_statement();
+            statement_list.push(a_statement);
+            if (disrupt) {
 
 // cause: "while(0){break;0;}"
 
-                    warn("unreachable_a", a_statement);
-                }
-                disrupt = a_statement.disrupt;
+                warn("unreachable_a", a_statement);
             }
+            disrupt = a_statement.disrupt;
         }
+    }
 
-        function not_top_level(thing) {
+    function not_top_level(thing) {
 
 // Some features should not be at the outermost level.
 
-            if (functionage === global) {
+        if (functionage === token_global) {
 
 // cause: "while(0){}"
 
-                warn("unexpected_at_top_level_a", thing);
-            }
+            warn("unexpected_at_top_level_a", thing);
         }
+    }
 
-        function block(special) {
+    function block(special) {
 
 // Parse a block, a sequence of statements wrapped in braces.
 //  special "body"      The block is a function body.
@@ -2437,44 +2416,44 @@ function jslint(
 //          "naked"     No advance.
 //          undefined   An ordinary block.
 
-            let stmts;
-            let the_block;
-            if (special !== "naked") {
-                advance("{");
-            }
-            the_block = token_now;
-            the_block.arity = "statement";
-            the_block.body = special === "body";
+        let stmts;
+        let the_block;
+        if (special !== "naked") {
+            advance("{");
+        }
+        the_block = token_now;
+        the_block.arity = "statement";
+        the_block.body = special === "body";
 
 // Top level function bodies may include the "use strict" pragma.
 
-            if (
-                special === "body"
-                && function_stack.length === 1
-                && token_nxt.value === "use strict"
-            ) {
-                token_nxt.statement = true;
-                advance("(string)");
-                advance(";");
-            }
-            stmts = parse_statements();
-            the_block.block = stmts;
-            if (stmts.length === 0) {
-                if (!option_object.devel && special !== "ignore") {
+        if (
+            special === "body"
+            && function_stack.length === 1
+            && token_nxt.value === "use strict"
+        ) {
+            token_nxt.statement = true;
+            advance("(string)");
+            advance(";");
+        }
+        stmts = parse_statements();
+        the_block.block = stmts;
+        if (stmts.length === 0) {
+            if (!option_dict.devel && special !== "ignore") {
 
 // cause: "function aa(){}"
 
-                    warn("empty_block", the_block);
-                }
-                the_block.disrupt = false;
-            } else {
-                the_block.disrupt = stmts[stmts.length - 1].disrupt;
+                warn("empty_block", the_block);
             }
-            advance("}");
-            return the_block;
+            the_block.disrupt = false;
+        } else {
+            the_block.disrupt = stmts[stmts.length - 1].disrupt;
         }
+        advance("}");
+        return the_block;
+    }
 
-        function mutation_check(the_thing) {
+    function mutation_check(the_thing) {
 
 // The only expressions that may be assigned to are
 //      e.b
@@ -2483,22 +2462,22 @@ function jslint(
 //      [destructure]
 //      {destructure}
 
-            if (
-                the_thing.arity !== "variable"
-                && the_thing.id !== "."
-                && the_thing.id !== "["
-                && the_thing.id !== "{"
-            ) {
+        if (
+            the_thing.arity !== "variable"
+            && the_thing.id !== "."
+            && the_thing.id !== "["
+            && the_thing.id !== "{"
+        ) {
 
 // cause: "0=0"
 
-                warn("bad_assignment_a", the_thing);
-                return false;
-            }
-            return true;
+            warn("bad_assignment_a", the_thing);
+            return false;
         }
+        return true;
+    }
 
-        function left_check(left, right) {
+    function left_check(left, right) {
 
 // Warn if the left is not one of these:
 //      ?.
@@ -2508,239 +2487,239 @@ function jslint(
 //      e[b]
 //      identifier
 
-            const id = left.id;
-            if (
-                !left.identifier
-                && (
-                    left.arity !== "ternary"
-                    || (
-                        !left_check(left.expression[1])
-                        && !left_check(left.expression[2])
-                    )
+        const id = left.id;
+        if (
+            !left.identifier
+            && (
+                left.arity !== "ternary"
+                || (
+                    !left_check(left.expression[1])
+                    && !left_check(left.expression[2])
                 )
-                && (
-                    left.arity !== "binary"
-                    || (id !== "." && id !== "?." && id !== "(" && id !== "[")
-                )
-            ) {
-                warn("unexpected_a", right);
-                return false;
-            }
-            return true;
+            )
+            && (
+                left.arity !== "binary"
+                || (id !== "." && id !== "?." && id !== "(" && id !== "[")
+            )
+        ) {
+            warn("unexpected_a", right);
+            return false;
         }
+        return true;
+    }
 
 // These functions are used to specify the grammar of our language:
 
-        function symbol(id, bp) {
+    function symbol(id, bp) {
 
 // Create a symbol if it does not already exist in the language's syntax.
 
-            let the_symbol = syntax_object[id];
-            if (the_symbol === undefined) {
-                the_symbol = empty();
-                the_symbol.id = id;
-                the_symbol.lbp = bp || 0;
-                syntax_object[id] = the_symbol;
-            }
-            return the_symbol;
+        let the_symbol = syntax_dict[id];
+        if (the_symbol === undefined) {
+            the_symbol = empty();
+            the_symbol.id = id;
+            the_symbol.lbp = bp || 0;
+            syntax_dict[id] = the_symbol;
         }
+        return the_symbol;
+    }
 
-        function assignment(id) {
+    function assignment(id) {
 
 // Create an assignment operator. The one true assignment is different because
 // its left side, when it is a variable, is not treated as an expression.
 // That case is special because that is when a variable gets initialized. The
 // other assignment operators can modify, but they cannot initialize.
 
-            const the_symbol = symbol(id, 20);
-            the_symbol.led = function (left) {
-                const the_token = token_now;
-                let right;
-                the_token.arity = "assignment";
-                right = parse_expression(20 - 1);
-                if (id === "=" && left.arity === "variable") {
-                    the_token.names = left;
-                    the_token.expression = right;
-                } else {
-                    the_token.expression = [left, right];
-                }
-                if (
-                    right.arity === "assignment"
-                    || right.arity === "pre"
-                    || right.arity === "post"
-                ) {
-                    warn("unexpected_a", right);
-                }
-                mutation_check(left);
-                return the_token;
-            };
-            return the_symbol;
-        }
+        const the_symbol = symbol(id, 20);
+        the_symbol.led = function (left) {
+            const the_token = token_now;
+            let right;
+            the_token.arity = "assignment";
+            right = parse_expression(20 - 1);
+            if (id === "=" && left.arity === "variable") {
+                the_token.names = left;
+                the_token.expression = right;
+            } else {
+                the_token.expression = [left, right];
+            }
+            if (
+                right.arity === "assignment"
+                || right.arity === "pre"
+                || right.arity === "post"
+            ) {
+                warn("unexpected_a", right);
+            }
+            mutation_check(left);
+            return the_token;
+        };
+        return the_symbol;
+    }
 
-        function constant(id, type, value) {
+    function constant(id, type, value) {
 
 // Create a constant symbol.
 
-            const the_symbol = symbol(id);
-            the_symbol.constant = true;
-            the_symbol.nud = (
-                typeof value === "function"
-                ? value
-                : function () {
-                    token_now.constant = true;
-                    if (value !== undefined) {
-                        token_now.value = value;
-                    }
-                    return token_now;
+        const the_symbol = symbol(id);
+        the_symbol.constant = true;
+        the_symbol.nud = (
+            typeof value === "function"
+            ? value
+            : function () {
+                token_now.constant = true;
+                if (value !== undefined) {
+                    token_now.value = value;
                 }
-            );
-            the_symbol.type = type;
-            the_symbol.value = value;
-            return the_symbol;
-        }
+                return token_now;
+            }
+        );
+        the_symbol.type = type;
+        the_symbol.value = value;
+        return the_symbol;
+    }
 
-        function infix(id, bp, f) {
+    function infix(id, bp, f) {
 
 // Create an infix operator.
 
-            const the_symbol = symbol(id, bp);
-            the_symbol.led = function (left) {
-                const the_token = token_now;
-                the_token.arity = "binary";
-                if (f !== undefined) {
-                    return f(left);
-                }
-                the_token.expression = [left, parse_expression(bp)];
-                return the_token;
-            };
-            return the_symbol;
-        }
+        const the_symbol = symbol(id, bp);
+        the_symbol.led = function (left) {
+            const the_token = token_now;
+            the_token.arity = "binary";
+            if (f !== undefined) {
+                return f(left);
+            }
+            the_token.expression = [left, parse_expression(bp)];
+            return the_token;
+        };
+        return the_symbol;
+    }
 
-        function infixr(id, bp) {
+    function infixr(id, bp) {
 
 // Create a right associative infix operator.
 
-            const the_symbol = symbol(id, bp);
-            the_symbol.led = function (left) {
+        const the_symbol = symbol(id, bp);
+        the_symbol.led = function (left) {
 
 // cause: "0**0"
 
-                const the_token = token_now;
-                the_token.arity = "binary";
-                the_token.expression = [left, parse_expression(bp - 1)];
-                return the_token;
-            };
-            return the_symbol;
-        }
+            const the_token = token_now;
+            the_token.arity = "binary";
+            the_token.expression = [left, parse_expression(bp - 1)];
+            return the_token;
+        };
+        return the_symbol;
+    }
 
-        function post(id) {
+    function post(id) {
 
 // Create one of the post operators.
 
-            const the_symbol = symbol(id, 150);
-            the_symbol.led = function (left) {
-                token_now.expression = left;
-                token_now.arity = "post";
-                mutation_check(token_now.expression);
-                return token_now;
-            };
-            return the_symbol;
-        }
+        const the_symbol = symbol(id, 150);
+        the_symbol.led = function (left) {
+            token_now.expression = left;
+            token_now.arity = "post";
+            mutation_check(token_now.expression);
+            return token_now;
+        };
+        return the_symbol;
+    }
 
-        function pre(id) {
+    function pre(id) {
 
 // Create one of the pre operators.
 
-            const the_symbol = symbol(id);
-            the_symbol.nud = function () {
-                const the_token = token_now;
-                the_token.arity = "pre";
-                the_token.expression = parse_expression(150);
-                mutation_check(the_token.expression);
-                return the_token;
-            };
-            return the_symbol;
-        }
+        const the_symbol = symbol(id);
+        the_symbol.nud = function () {
+            const the_token = token_now;
+            the_token.arity = "pre";
+            the_token.expression = parse_expression(150);
+            mutation_check(the_token.expression);
+            return the_token;
+        };
+        return the_symbol;
+    }
 
-        function prefix(id, f) {
+    function prefix(id, f) {
 
 // Create a prefix operator.
 
-            const the_symbol = symbol(id);
-            the_symbol.nud = function () {
-                const the_token = token_now;
-                the_token.arity = "unary";
-                if (typeof f === "function") {
-                    return f();
-                }
-                the_token.expression = parse_expression(150);
-                return the_token;
-            };
-            return the_symbol;
-        }
+        const the_symbol = symbol(id);
+        the_symbol.nud = function () {
+            const the_token = token_now;
+            the_token.arity = "unary";
+            if (typeof f === "function") {
+                return f();
+            }
+            the_token.expression = parse_expression(150);
+            return the_token;
+        };
+        return the_symbol;
+    }
 
-        function stmt(id, f) {
+    function stmt(id, f) {
 
 // Create a statement.
 
-            const the_symbol = symbol(id);
-            the_symbol.fud = function () {
-                token_now.arity = "statement";
-                return f();
-            };
-            return the_symbol;
-        }
+        const the_symbol = symbol(id);
+        the_symbol.fud = function () {
+            token_now.arity = "statement";
+            return f();
+        };
+        return the_symbol;
+    }
 
-        function survey(name) {
-            let id = name.id;
+    function survey(name) {
+        let id = name.id;
 
 // Tally the property name. If it is a string, only tally strings that conform
 // to the identifier rules.
 
-            if (id === "(string)") {
-                id = name.value;
+        if (id === "(string)") {
+            id = name.value;
+            if (!rx_identifier.test(id)) {
+                return id;
+            }
+        } else if (id === "`") {
+            if (name.value.length === 1) {
+                id = name.value[0].value;
                 if (!rx_identifier.test(id)) {
                     return id;
                 }
-            } else if (id === "`") {
-                if (name.value.length === 1) {
-                    id = name.value[0].value;
-                    if (!rx_identifier.test(id)) {
-                        return id;
-                    }
-                }
-            } else if (!name.identifier) {
+            }
+        } else if (!name.identifier) {
 
 // cause: "let aa={0:0}"
 
-                return stop("expected_identifier_a", name);
-            }
+            return stop("expected_identifier_a", name);
+        }
 
 // If we have seen this name before, increment its count.
 
-            if (typeof property[id] === "number") {
-                property[id] += 1;
+        if (typeof property[id] === "number") {
+            property[id] += 1;
 
 // If this is the first time seeing this property name, and if there is a
 // tenure list, then it must be on the list. Otherwise, it must conform to
 // the rules for good property names.
 
-            } else {
-                if (tenure !== undefined) {
-                    if (tenure[id] !== true) {
+        } else {
+            if (tenure !== undefined) {
+                if (tenure[id] !== true) {
 
 // cause: "/*property aa*/\naa.bb"
 
-                        warn("unregistered_property_a", name);
-                    }
-                } else if (
-                    !option_object.name
-                    && name.identifier
-                    && (
-                        // rx_bad_property
-                        /^_|\$|Sync$|_$/m
-                    ).test(id)
-                ) {
+                    warn("unregistered_property_a", name);
+                }
+            } else if (
+                !option_dict.name
+                && name.identifier
+                && (
+                    // rx_bad_property
+                    /^_|\$|Sync$|_$/m
+                ).test(id)
+            ) {
 
 // cause: "aa.$"
 // cause: "aa._"
@@ -2748,564 +2727,614 @@ function jslint(
 // cause: "aa.aaSync"
 // cause: "aa.aa_"
 
-                    warn("bad_property_a", name);
-                }
-                property[id] = 1;
+                warn("bad_property_a", name);
             }
-            return id;
+            property[id] = 1;
         }
+        return id;
+    }
 
-        function ternary(id1, id2) {
+    function ternary(id1, id2) {
 
 // Create a ternary operator.
 
-            const the_symbol = symbol(id1, 30);
-            the_symbol.led = function (left) {
-                const the_token = token_now;
-                const second = parse_expression(20);
-                advance(id2);
-                token_now.arity = "ternary";
-                the_token.arity = "ternary";
-                the_token.expression = [left, second, parse_expression(10)];
-                if (token_nxt.id !== ")") {
+        const the_symbol = symbol(id1, 30);
+        the_symbol.led = function (left) {
+            const the_token = token_now;
+            const second = parse_expression(20);
+            advance(id2);
+            token_now.arity = "ternary";
+            the_token.arity = "ternary";
+            the_token.expression = [left, second, parse_expression(10)];
+            if (token_nxt.id !== ")") {
 
 // cause: "0?0:0"
 
-                    warn("use_open", the_token);
-                }
-                return the_token;
-            };
-            return the_symbol;
-        }
+                warn("use_open", the_token);
+            }
+            return the_token;
+        };
+        return the_symbol;
+    }
 
 // Begin defining the language.
 
-        symbol("}");
-        symbol(")");
-        symbol("]");
-        symbol(",");
-        symbol(";");
-        symbol(":");
-        symbol("*/");
-        symbol("async");
-        symbol("await");
-        symbol("case");
-        symbol("catch");
-        symbol("class");
-        symbol("default");
-        symbol("else");
-        symbol("enum");
-        symbol("finally");
-        symbol("implements");
-        symbol("interface");
-        symbol("package");
-        symbol("private");
-        symbol("protected");
-        symbol("public");
-        symbol("static");
-        symbol("super");
-        symbol("void");
-        symbol("yield");
+    symbol("}");
+    symbol(")");
+    symbol("]");
+    symbol(",");
+    symbol(";");
+    symbol(":");
+    symbol("*/");
+    symbol("async");
+    symbol("await");
+    symbol("case");
+    symbol("catch");
+    symbol("class");
+    symbol("default");
+    symbol("else");
+    symbol("enum");
+    symbol("finally");
+    symbol("implements");
+    symbol("interface");
+    symbol("package");
+    symbol("private");
+    symbol("protected");
+    symbol("public");
+    symbol("static");
+    symbol("super");
+    symbol("void");
+    symbol("yield");
 
-        constant("(number)", "number");
-        constant("(regexp)", "regexp");
-        constant("(string)", "string");
-        constant("arguments", "object", function () {
+    constant("(number)", "number");
+    constant("(regexp)", "regexp");
+    constant("(string)", "string");
+    constant("arguments", "object", function () {
 
 // cause: "arguments"
 
-            warn("unexpected_a", token_now);
-            return token_now;
-        });
-        constant("eval", "function", function () {
-            if (!option_object.eval) {
+        warn("unexpected_a", token_now);
+        return token_now;
+    });
+    constant("eval", "function", function () {
+        if (!option_dict.eval) {
 
 // cause: "eval"
 
-                warn("unexpected_a", token_now);
-            } else if (token_nxt.id !== "(") {
+            warn("unexpected_a", token_now);
+        } else if (token_nxt.id !== "(") {
 
 // cause: "/*jslint eval*/\neval"
 
-                warn("expected_a_before_b", token_nxt, "(", artifact());
-            }
-            return token_now;
-        });
-        constant("false", "boolean", false);
-        constant("Function", "function", function () {
-            if (!option_object.eval) {
+            warn("expected_a_before_b", token_nxt, "(", artifact());
+        }
+        return token_now;
+    });
+    constant("false", "boolean", false);
+    constant("Function", "function", function () {
+        if (!option_dict.eval) {
 
 // cause: "Function()"
 
-                warn("unexpected_a", token_now);
-            } else if (token_nxt.id !== "(") {
+            warn("unexpected_a", token_now);
+        } else if (token_nxt.id !== "(") {
 
 // cause: "/*jslint eval*/\nFunction"
 
-                warn("expected_a_before_b", token_nxt, "(", artifact());
-            }
-            return token_now;
-        });
-        constant("ignore", "undefined", function () {
+            warn("expected_a_before_b", token_nxt, "(", artifact());
+        }
+        return token_now;
+    });
+    constant("ignore", "undefined", function () {
 
 // cause: "ignore"
 
-            warn("unexpected_a", token_now);
-            return token_now;
-        });
-        constant("Infinity", "number", Infinity);
-        constant("isFinite", "function", function () {
+        warn("unexpected_a", token_now);
+        return token_now;
+    });
+    constant("Infinity", "number", Infinity);
+    constant("isFinite", "function", function () {
 
 // cause: "isFinite"
 
-            warn("expected_a_b", token_now, "Number.isFinite", "isFinite");
-            return token_now;
-        });
-        constant("isNaN", "function", function () {
+        warn("expected_a_b", token_now, "Number.isFinite", "isFinite");
+        return token_now;
+    });
+    constant("isNaN", "function", function () {
 
 // cause: "isNaN(0)"
 
-            warn("number_isNaN", token_now);
-            return token_now;
-        });
-        constant("NaN", "number", NaN);
-        constant("null", "null", null);
-        constant("this", "object", function () {
-            if (!option_object.this) {
+        warn("number_isNaN", token_now);
+        return token_now;
+    });
+    constant("NaN", "number", NaN);
+    constant("null", "null", null);
+    constant("this", "object", function () {
+        if (!option_dict.this) {
 
 // cause: "this"
 
-                warn("unexpected_a", token_now);
-            }
-            return token_now;
-        });
-        constant("true", "boolean", true);
-        constant("undefined", "undefined");
+            warn("unexpected_a", token_now);
+        }
+        return token_now;
+    });
+    constant("true", "boolean", true);
+    constant("undefined", "undefined");
 
-        assignment("=");
-        assignment("+=");
-        assignment("-=");
-        assignment("*=");
-        assignment("/=");
-        assignment("%=");
-        assignment("&=");
-        assignment("|=");
-        assignment("^=");
-        assignment("<<=");
-        assignment(">>=");
-        assignment(">>>=");
+    assignment("=");
+    assignment("+=");
+    assignment("-=");
+    assignment("*=");
+    assignment("/=");
+    assignment("%=");
+    assignment("&=");
+    assignment("|=");
+    assignment("^=");
+    assignment("<<=");
+    assignment(">>=");
+    assignment(">>>=");
 
-        infix("??", 35);
-        infix("||", 40);
-        infix("&&", 50);
-        infix("|", 70);
-        infix("^", 80);
-        infix("&", 90);
-        infix("==", 100);
-        infix("===", 100);
-        infix("!=", 100);
-        infix("!==", 100);
-        infix("<", 110);
-        infix(">", 110);
-        infix("<=", 110);
-        infix(">=", 110);
-        infix("in", 110);
-        infix("instanceof", 110);
-        infix("<<", 120);
-        infix(">>", 120);
-        infix(">>>", 120);
-        infix("+", 130);
-        infix("-", 130);
-        infix("*", 140);
-        infix("/", 140);
-        infix("%", 140);
-        infixr("**", 150);
-        infix("(", 160, function (left) {
-            const the_paren = token_now;
-            let ellipsis;
-            let the_argument;
-            if (left.id !== "function") {
+    infix("??", 35);
+    infix("||", 40);
+    infix("&&", 50);
+    infix("|", 70);
+    infix("^", 80);
+    infix("&", 90);
+    infix("==", 100);
+    infix("===", 100);
+    infix("!=", 100);
+    infix("!==", 100);
+    infix("<", 110);
+    infix(">", 110);
+    infix("<=", 110);
+    infix(">=", 110);
+    infix("in", 110);
+    infix("instanceof", 110);
+    infix("<<", 120);
+    infix(">>", 120);
+    infix(">>>", 120);
+    infix("+", 130);
+    infix("-", 130);
+    infix("*", 140);
+    infix("/", 140);
+    infix("%", 140);
+    infixr("**", 150);
+    infix("(", 160, function (left) {
+        const the_paren = token_now;
+        let ellipsis;
+        let the_argument;
+        if (left.id !== "function") {
 
 // cause: "(0?0:0)()"
 // cause: "0()"
 
-                left_check(left, the_paren);
-            }
-            if (functionage.arity === "statement" && left.identifier) {
-                functionage.name.calls[left.id] = left;
-            }
-            the_paren.expression = [left];
-            if (token_nxt.id !== ")") {
+            left_check(left, the_paren);
+        }
+        if (functionage.arity === "statement" && left.identifier) {
+            functionage.name.calls[left.id] = left;
+        }
+        the_paren.expression = [left];
+        if (token_nxt.id !== ")") {
 
 // Parse/loop through each token in expression (...).
 
-                while (true) {
-                    if (token_nxt.id === "...") {
-                        ellipsis = true;
-                        advance("...");
-                    }
-                    the_argument = parse_expression(10);
-                    if (ellipsis) {
-                        the_argument.ellipsis = true;
-                    }
-                    the_paren.expression.push(the_argument);
-                    if (token_nxt.id !== ",") {
-                        break;
-                    }
-                    advance(",");
+            while (true) {
+                if (token_nxt.id === "...") {
+                    ellipsis = true;
+                    advance("...");
                 }
+                the_argument = parse_expression(10);
+                if (ellipsis) {
+                    the_argument.ellipsis = true;
+                }
+                the_paren.expression.push(the_argument);
+                if (token_nxt.id !== ",") {
+                    break;
+                }
+                advance(",");
             }
-            advance(")", the_paren);
-            if (the_paren.expression.length === 2) {
+        }
+        advance(")", the_paren);
+        if (the_paren.expression.length === 2) {
 
 // cause: "aa(0)"
 
-                the_paren.free = true;
-                if (the_argument.wrapped === true) {
+            the_paren.free = true;
+            if (the_argument.wrapped === true) {
 
 // cause: "aa((0))"
 
-                    warn("unexpected_a", the_paren);
-                }
-                if (the_argument.id === "(") {
-                    the_argument.wrapped = true;
-                }
-            } else {
+                warn("unexpected_a", the_paren);
+            }
+            if (the_argument.id === "(") {
+                the_argument.wrapped = true;
+            }
+        } else {
 
 // cause: "aa()"
 // cause: "aa(0,0)"
 
-                the_paren.free = false;
-            }
-            return the_paren;
-        });
-        infix(".", 170, function (left) {
-            const the_token = token_now;
-            const name = token_nxt;
-            if (
-                (
-                    left.id !== "(string)"
-                    || (name.id !== "indexOf" && name.id !== "repeat")
+            the_paren.free = false;
+        }
+        return the_paren;
+    });
+    infix(".", 170, function (left) {
+        const the_token = token_now;
+        const name = token_nxt;
+        if (
+            (
+                left.id !== "(string)"
+                || (name.id !== "indexOf" && name.id !== "repeat")
+            )
+            && (
+                left.id !== "["
+                || (
+                    name.id !== "concat"
+                    && name.id !== "forEach"
+                    && name.id !== "join"
+                    && name.id !== "map"
                 )
-                && (
-                    left.id !== "["
-                    || (
-                        name.id !== "concat"
-                        && name.id !== "forEach"
-                        && name.id !== "join"
-                        && name.id !== "map"
-                    )
-                )
-                && (left.id !== "+" || name.id !== "slice")
-                && (
-                    left.id !== "(regexp)"
-                    || (name.id !== "exec" && name.id !== "test")
-                )
-            ) {
+            )
+            && (left.id !== "+" || name.id !== "slice")
+            && (
+                left.id !== "(regexp)"
+                || (name.id !== "exec" && name.id !== "test")
+            )
+        ) {
 
 // cause: "\"\".aa"
 
-                left_check(left, the_token);
-            }
-            if (!name.identifier) {
+            left_check(left, the_token);
+        }
+        if (!name.identifier) {
 
 // cause: "aa.0"
 
-                stop("expected_identifier_a");
-            }
-            advance();
-            survey(name);
+            stop("expected_identifier_a");
+        }
+        advance();
+        survey(name);
 
 // The property name is not an expression.
 
-            the_token.name = name;
-            the_token.expression = left;
-            return the_token;
-        });
-        infix("?.", 170, function (left) {
-            const the_token = token_now;
-            const name = token_nxt;
-            if (
-                (
-                    left.id !== "(string)"
-                    || (name.id !== "indexOf" && name.id !== "repeat")
+        the_token.name = name;
+        the_token.expression = left;
+        return the_token;
+    });
+    infix("?.", 170, function (left) {
+        const the_token = token_now;
+        const name = token_nxt;
+        if (
+            (
+                left.id !== "(string)"
+                || (name.id !== "indexOf" && name.id !== "repeat")
+            )
+            && (
+                left.id !== "["
+                || (
+                    name.id !== "concat"
+                    && name.id !== "forEach"
+                    && name.id !== "join"
+                    && name.id !== "map"
                 )
-                && (
-                    left.id !== "["
-                    || (
-                        name.id !== "concat"
-                        && name.id !== "forEach"
-                        && name.id !== "join"
-                        && name.id !== "map"
-                    )
-                )
+            )
 
 // cause: "(0+0)?.0"
 
-                && (left.id !== "+" || name.id !== "slice")
-                && (
-                    left.id !== "(regexp)"
-                    || (name.id !== "exec" && name.id !== "test")
-                )
-            ) {
+            && (left.id !== "+" || name.id !== "slice")
+            && (
+                left.id !== "(regexp)"
+                || (name.id !== "exec" && name.id !== "test")
+            )
+        ) {
 
 // cause: "\"aa\"?.0"
 // cause: "(/./)?.0"
 // cause: "aa=[]?.aa"
 
-                left_check(left, the_token);
-            }
-            if (!name.identifier) {
+            left_check(left, the_token);
+        }
+        if (!name.identifier) {
 
 // cause: "aa?.0"
 
-                stop("expected_identifier_a");
-            }
-            advance();
-            survey(name);
+            stop("expected_identifier_a");
+        }
+        advance();
+        survey(name);
 
 // The property name is not an expression.
 
-            the_token.name = name;
-            the_token.expression = left;
-            return the_token;
-        });
-        infix("[", 170, function (left) {
-            const the_token = token_now;
-            const the_subscript = parse_expression(0);
-            if (the_subscript.id === "(string)" || the_subscript.id === "`") {
-                const name = survey(the_subscript);
-                if (rx_identifier.test(name)) {
+        the_token.name = name;
+        the_token.expression = left;
+        return the_token;
+    });
+    infix("[", 170, function (left) {
+        const the_token = token_now;
+        const the_subscript = parse_expression(0);
+        if (the_subscript.id === "(string)" || the_subscript.id === "`") {
+            const name = survey(the_subscript);
+            if (rx_identifier.test(name)) {
 
 // cause: "aa[`aa`]"
 
-                    warn("subscript_a", the_subscript, name);
-                }
+                warn("subscript_a", the_subscript, name);
             }
+        }
 
 // cause: "0[0]"
 
-            left_check(left, the_token);
-            the_token.expression = [left, the_subscript];
-            advance("]");
-            return the_token;
-        });
-        infix("=>", 170, function (left) {
+        left_check(left, the_token);
+        the_token.expression = [left, the_subscript];
+        advance("]");
+        return the_token;
+    });
+    infix("=>", 170, function (left) {
 
 // cause: "aa=>0"
 
-            return stop("wrap_parameter", left);
-        });
+        return stop("wrap_parameter", left);
+    });
 
-        function do_tick() {
-            const the_tick = token_now;
-            the_tick.value = [];
-            the_tick.expression = [];
-            if (token_nxt.id !== "`") {
+    function do_tick() {
+        const the_tick = token_now;
+        the_tick.value = [];
+        the_tick.expression = [];
+        if (token_nxt.id !== "`") {
 
 // Parse/loop through each token in `${...}`.
 
-                while (true) {
-                    advance("(string)");
-                    the_tick.value.push(token_now);
-                    if (token_nxt.id !== "${") {
-                        break;
-                    }
-                    advance("${");
+            while (true) {
+                advance("(string)");
+                the_tick.value.push(token_now);
+                if (token_nxt.id !== "${") {
+                    break;
+                }
+                advance("${");
 
 // cause: "let aa=`${}`;"
 
-                    the_tick.expression.push(parse_expression(0));
-                    advance("}");
-                }
+                the_tick.expression.push(parse_expression(0));
+                advance("}");
             }
-            advance("`");
-            return the_tick;
         }
+        advance("`");
+        return the_tick;
+    }
 
-        infix("`", 160, function (left) {
-            const the_tick = do_tick();
+    infix("`", 160, function (left) {
+        const the_tick = do_tick();
 
 // cause: "0``"
 
-            left_check(left, the_tick);
-            the_tick.expression = [left].concat(the_tick.expression);
-            return the_tick;
-        });
+        left_check(left, the_tick);
+        the_tick.expression = [left].concat(the_tick.expression);
+        return the_tick;
+    });
 
-        post("++");
-        post("--");
-        pre("++");
-        pre("--");
+    post("++");
+    post("--");
+    pre("++");
+    pre("--");
 
-        prefix("+");
-        prefix("-");
-        prefix("~");
-        prefix("!");
-        prefix("!!");
-        prefix("[", function () {
-            const the_token = token_now;
-            let element;
-            let ellipsis;
-            the_token.expression = [];
-            if (token_nxt.id !== "]") {
+    prefix("+");
+    prefix("-");
+    prefix("~");
+    prefix("!");
+    prefix("!!");
+    prefix("[", function () {
+        const the_token = token_now;
+        let element;
+        let ellipsis;
+        the_token.expression = [];
+        if (token_nxt.id !== "]") {
 
 // Parse/loop through each element in [...].
 
-                while (true) {
-                    ellipsis = false;
-                    if (token_nxt.id === "...") {
-                        ellipsis = true;
-                        advance("...");
-                    }
-                    element = parse_expression(10);
-                    if (ellipsis) {
-                        element.ellipsis = true;
-                    }
-                    the_token.expression.push(element);
-                    if (token_nxt.id !== ",") {
-                        break;
-                    }
-                    advance(",");
+            while (true) {
+                ellipsis = false;
+                if (token_nxt.id === "...") {
+                    ellipsis = true;
+                    advance("...");
                 }
+                element = parse_expression(10);
+                if (ellipsis) {
+                    element.ellipsis = true;
+                }
+                the_token.expression.push(element);
+                if (token_nxt.id !== ",") {
+                    break;
+                }
+                advance(",");
             }
-            advance("]");
-            return the_token;
-        });
-        prefix("/=", function () {
+        }
+        advance("]");
+        return the_token;
+    });
+    prefix("/=", function () {
 
 // cause: "/="
 
-            stop("expected_a_b", token_now, "/\\=", "/=");
-        });
-        prefix("=>", function () {
+        stop("expected_a_b", token_now, "/\\=", "/=");
+    });
+    prefix("=>", function () {
 
 // cause: "=>0"
 
-            return stop("expected_a_before_b", token_now, "()", "=>");
-        });
-        prefix("new", function () {
-            const the_new = token_now;
-            const right = parse_expression(160);
-            if (token_nxt.id !== "(") {
+        return stop("expected_a_before_b", token_now, "()", "=>");
+    });
+    prefix("new", function () {
+        const the_new = token_now;
+        const right = parse_expression(160);
+        if (token_nxt.id !== "(") {
 
 // cause: "new aa"
 
-                warn(
-                    "expected_a_before_b",
-                    token_nxt,
-                    "()",
-                    artifact(token_nxt)
-                );
-            }
-            the_new.expression = right;
-            return the_new;
-        });
-        prefix("typeof");
-        prefix("void", function () {
-            const the_void = token_now;
+            warn(
+                "expected_a_before_b",
+                token_nxt,
+                "()",
+                artifact(token_nxt)
+            );
+        }
+        the_new.expression = right;
+        return the_new;
+    });
+    prefix("typeof");
+    prefix("void", function () {
+        const the_void = token_now;
 
 // cause: "void"
 // cause: "void 0"
 
-            warn("unexpected_a", the_void);
-            the_void.expression = parse_expression(0);
-            return the_void;
-        });
+        warn("unexpected_a", the_void);
+        the_void.expression = parse_expression(0);
+        return the_void;
+    });
 
-        function parameter_list() {
-            const list = [];
-            const signature = ["("];
-            let optional;
-            if (token_nxt.id !== ")" && token_nxt.id !== "(end)") {
-                (function parameter() {
-                    let ellipsis = false;
-                    let param;
-                    if (token_nxt.id === "{") {
-                        let artifact_now;
-                        let artifact_nxt = "";
-                        if (optional !== undefined) {
+    function parameter_list() {
+        const list = [];
+        const signature = ["("];
+        let optional;
+        if (token_nxt.id !== ")" && token_nxt.id !== "(end)") {
+            (function parameter() {
+                let ellipsis = false;
+                let param;
+                if (token_nxt.id === "{") {
+                    let artifact_now;
+                    let artifact_nxt = "";
+                    if (optional !== undefined) {
 
 // cause: "function aa(aa=0,{}){}"
 
-                            warn(
-                                "required_a_optional_b",
-                                token_nxt,
-                                token_nxt.id,
-                                optional.id
-                            );
-                        }
-                        param = token_nxt;
-                        param.names = [];
-                        advance("{");
-                        signature.push("{");
-                        (function subparameter() {
-                            let subparam = token_nxt;
-                            if (!subparam.identifier) {
+                        warn(
+                            "required_a_optional_b",
+                            token_nxt,
+                            token_nxt.id,
+                            optional.id
+                        );
+                    }
+                    param = token_nxt;
+                    param.names = [];
+                    advance("{");
+                    signature.push("{");
+                    (function subparameter() {
+                        let subparam = token_nxt;
+                        if (!subparam.identifier) {
 
 // cause: "function aa(aa=0,{}){}"
 // cause: "function aa({0}){}"
 
-                                return stop("expected_identifier_a");
-                            }
-                            survey(subparam);
-                            artifact_now = artifact_nxt;
-                            artifact_nxt = artifact(subparam);
-                            if (
-                                !option_object.unordered
-                                && artifact_now > artifact_nxt
-                            ) {
+                            return stop("expected_identifier_a");
+                        }
+                        survey(subparam);
+                        artifact_now = artifact_nxt;
+                        artifact_nxt = artifact(subparam);
+                        if (
+                            !option_dict.unordered
+                            && artifact_now > artifact_nxt
+                        ) {
 
 // cause: "function aa({bb,aa}){}"
 
-                                warn(
-                                    "expected_a_before_b",
-                                    subparam,
-                                    artifact_nxt,
-                                    artifact_now
-                                );
-                            }
+                            warn(
+                                "expected_a_before_b",
+                                subparam,
+                                artifact_nxt,
+                                artifact_now
+                            );
+                        }
+                        advance();
+                        signature.push(subparam.id);
+                        if (token_nxt.id === ":") {
+                            advance(":");
                             advance();
-                            signature.push(subparam.id);
-                            if (token_nxt.id === ":") {
-                                advance(":");
-                                advance();
-                                token_now.label = subparam;
-                                subparam = token_now;
-                                if (!subparam.identifier) {
+                            token_now.label = subparam;
+                            subparam = token_now;
+                            if (!subparam.identifier) {
 
 // cause: "function aa({aa:0}){}"
 
-                                    return stop("expected_identifier_a");
-                                }
+                                return stop("expected_identifier_a");
                             }
+                        }
 
 // cause: "function aa({aa=aa},aa){}"
 
-                            if (token_nxt.id === "=") {
-                                advance("=");
-                                subparam.expression = parse_expression();
-                                param.open = true;
-                            }
-                            param.names.push(subparam);
-                            if (token_nxt.id === ",") {
-                                advance(",");
-                                signature.push(", ");
-                                return subparameter();
-                            }
-                        }());
-                        list.push(param);
-                        advance("}");
-                        signature.push("}");
+                        if (token_nxt.id === "=") {
+                            advance("=");
+                            subparam.expression = parse_expression();
+                            param.open = true;
+                        }
+                        param.names.push(subparam);
                         if (token_nxt.id === ",") {
                             advance(",");
                             signature.push(", ");
-                            return parameter();
+                            return subparameter();
                         }
-                    } else if (token_nxt.id === "[") {
-                        if (optional !== undefined) {
+                    }());
+                    list.push(param);
+                    advance("}");
+                    signature.push("}");
+                    if (token_nxt.id === ",") {
+                        advance(",");
+                        signature.push(", ");
+                        return parameter();
+                    }
+                } else if (token_nxt.id === "[") {
+                    if (optional !== undefined) {
 
 // cause: "function aa(aa=0,[]){}"
+
+                        warn(
+                            "required_a_optional_b",
+                            token_nxt,
+                            token_nxt.id,
+                            optional.id
+                        );
+                    }
+                    param = token_nxt;
+                    param.names = [];
+                    advance("[");
+                    signature.push("[]");
+                    (function subparameter() {
+                        const subparam = token_nxt;
+                        if (!subparam.identifier) {
+
+// cause: "function aa(aa=0,[]){}"
+
+                            return stop("expected_identifier_a");
+                        }
+                        advance();
+                        param.names.push(subparam);
+
+// cause: "function aa([aa=aa],aa){}"
+
+                        if (token_nxt.id === "=") {
+                            advance("=");
+                            subparam.expression = parse_expression();
+                            param.open = true;
+                        }
+                        if (token_nxt.id === ",") {
+                            advance(",");
+                            return subparameter();
+                        }
+                    }());
+                    list.push(param);
+                    advance("]");
+                    if (token_nxt.id === ",") {
+                        advance(",");
+                        signature.push(", ");
+                        return parameter();
+                    }
+                } else {
+                    if (token_nxt.id === "...") {
+                        ellipsis = true;
+                        signature.push("...");
+                        advance("...");
+                        if (optional !== undefined) {
+
+// cause: "function aa(aa=0,...){}"
 
                             warn(
                                 "required_a_optional_b",
@@ -3314,137 +3343,87 @@ function jslint(
                                 optional.id
                             );
                         }
-                        param = token_nxt;
-                        param.names = [];
-                        advance("[");
-                        signature.push("[]");
-                        (function subparameter() {
-                            const subparam = token_nxt;
-                            if (!subparam.identifier) {
+                    }
+                    if (!token_nxt.identifier) {
 
-// cause: "function aa(aa=0,[]){}"
+// cause: "function aa(0){}"
 
-                                return stop("expected_identifier_a");
+                        return stop("expected_identifier_a");
+                    }
+                    param = token_nxt;
+                    list.push(param);
+                    advance();
+                    signature.push(param.id);
+                    if (ellipsis) {
+                        param.ellipsis = true;
+                    } else {
+                        if (token_nxt.id === "=") {
+                            optional = param;
+                            advance("=");
+                            param.expression = parse_expression(0);
+                        } else {
+                            if (optional !== undefined) {
+
+// cause: "function aa(aa=0,bb){}"
+
+                                warn(
+                                    "required_a_optional_b",
+                                    param,
+                                    param.id,
+                                    optional.id
+                                );
                             }
-                            advance();
-                            param.names.push(subparam);
-
-// cause: "function aa([aa=aa],aa){}"
-
-                            if (token_nxt.id === "=") {
-                                advance("=");
-                                subparam.expression = parse_expression();
-                                param.open = true;
-                            }
-                            if (token_nxt.id === ",") {
-                                advance(",");
-                                return subparameter();
-                            }
-                        }());
-                        list.push(param);
-                        advance("]");
+                        }
                         if (token_nxt.id === ",") {
                             advance(",");
                             signature.push(", ");
                             return parameter();
                         }
-                    } else {
-                        if (token_nxt.id === "...") {
-                            ellipsis = true;
-                            signature.push("...");
-                            advance("...");
-                            if (optional !== undefined) {
-
-// cause: "function aa(aa=0,...){}"
-
-                                warn(
-                                    "required_a_optional_b",
-                                    token_nxt,
-                                    token_nxt.id,
-                                    optional.id
-                                );
-                            }
-                        }
-                        if (!token_nxt.identifier) {
-
-// cause: "function aa(0){}"
-
-                            return stop("expected_identifier_a");
-                        }
-                        param = token_nxt;
-                        list.push(param);
-                        advance();
-                        signature.push(param.id);
-                        if (ellipsis) {
-                            param.ellipsis = true;
-                        } else {
-                            if (token_nxt.id === "=") {
-                                optional = param;
-                                advance("=");
-                                param.expression = parse_expression(0);
-                            } else {
-                                if (optional !== undefined) {
-
-// cause: "function aa(aa=0,bb){}"
-
-                                    warn(
-                                        "required_a_optional_b",
-                                        param,
-                                        param.id,
-                                        optional.id
-                                    );
-                                }
-                            }
-                            if (token_nxt.id === ",") {
-                                advance(",");
-                                signature.push(", ");
-                                return parameter();
-                            }
-                        }
                     }
-                }());
-            }
-            advance(")");
-            signature.push(")");
-            return [list, signature.join("")];
+                }
+            }());
         }
+        advance(")");
+        signature.push(")");
+        return [list, signature.join("")];
+    }
 
-        function do_function(the_function) {
-            let name = the_function && the_function.name;
-            if (the_function === undefined) {
-                the_function = token_now;
+    function do_function(the_function) {
+        let name = the_function && the_function.name;
+        if (the_function === undefined) {
+            the_function = token_now;
 
 // A function statement must have a name that will be in the parent's scope.
 
-                if (the_function.arity === "statement") {
-                    if (!token_nxt.identifier) {
+            if (the_function.arity === "statement") {
+                if (!token_nxt.identifier) {
 
 // cause: "function(){}"
 // cause: "function*aa(){}"
 
-                        return stop("expected_identifier_a", token_nxt);
-                    }
-                    name = token_nxt;
-                    enroll(name, "variable", true);
-                    the_function.name = Object.assign(name, {
-                        calls: empty(),
-                        init: true
-                    });
-                    advance();
-                } else if (name === undefined) {
+                    return stop("expected_identifier_a", token_nxt);
+                }
+                name = token_nxt;
+                enroll(name, "variable", true);
+                the_function.name = Object.assign(name, {
+                    calls: empty(),
+                    init: true
+                });
+                advance();
+            } else if (name === undefined) {
 
 // A function expression may have an optional name.
 
-                    the_function.name = anon;
-                    if (token_nxt.identifier) {
-                        name = token_nxt;
-                        the_function.name = name;
-                        advance();
-                    }
+                the_function.name = anon;
+                if (token_nxt.identifier) {
+                    name = token_nxt;
+                    the_function.name = name;
+                    advance();
                 }
             }
-            the_function.level = functionage.level + 1;
-            assert_or_throw(!mode_mega, `Expected !mode_mega.`);
+        }
+        the_function.level = functionage.level + 1;
+        assert_or_throw(!mode_mega, `Expected !mode_mega.`);
 //  Probably deadcode.
 //  if (mode_mega) {
 //      warn("unexpected_a", the_function);
@@ -3453,264 +3432,498 @@ function jslint(
 // Don't create functions in loops. It is inefficient, and it can lead to
 // scoping errors.
 
-            if (functionage.loop > 0) {
+        if (functionage.loop > 0) {
 
 // cause: "while(0){aa.map(function(){});}"
 
-                warn("function_in_loop", the_function);
-            }
+            warn("function_in_loop", the_function);
+        }
 
 // Give the function properties for storing its names and for observing the
 // depth of loops and switches.
 
-            Object.assign(the_function, {
-                async: the_function.async || 0,
-                context: empty(),
-                finally: 0,
-                loop: 0,
-                switch: 0,
-                try: 0
-            });
+        Object.assign(the_function, {
+            async: the_function.async || 0,
+            context: empty(),
+            finally: 0,
+            loop: 0,
+            switch: 0,
+            try: 0
+        });
 
 // Push the current function context and establish a new one.
 
-            function_stack.push(functionage);
-            function_array.push(the_function);
-            functionage = the_function;
-            if (
-                the_function.arity !== "statement"
-                && typeof name === "object"
-            ) {
+        function_stack.push(functionage);
+        function_list.push(the_function);
+        functionage = the_function;
+        if (
+            the_function.arity !== "statement"
+            && typeof name === "object"
+        ) {
 
 // cause: "let aa=function bb(){return;};"
 
-                enroll(name, "function", true);
-                name.dead = false;
-                name.init = true;
-                name.used = 1;
-            }
+            enroll(name, "function", true);
+            name.dead = false;
+            name.init = true;
+            name.used = 1;
+        }
 
 // Parse the parameter list.
 
-            advance("(");
+        advance("(");
 
 // cause: "function(){}"
 
-            token_now.free = false;
-            token_now.arity = "function";
-            [functionage.parameters, functionage.signature] = parameter_list();
-            functionage.parameters.forEach(function enroll_parameter(name) {
-                if (name.identifier) {
-                    enroll(name, "parameter", false);
-                } else {
-                    name.names.forEach(enroll_parameter);
-                }
-            });
+        token_now.free = false;
+        token_now.arity = "function";
+        [functionage.parameters, functionage.signature] = parameter_list();
+        functionage.parameters.forEach(function enroll_parameter(name) {
+            if (name.identifier) {
+                enroll(name, "parameter", false);
+            } else {
+                name.names.forEach(enroll_parameter);
+            }
+        });
 
 // The function's body is a block.
 
-            the_function.block = block("body");
-            if (
-                the_function.arity === "statement"
-                && token_nxt.line === token_now.line
-            ) {
+        the_function.block = block("body");
+        if (
+            the_function.arity === "statement"
+            && token_nxt.line === token_now.line
+        ) {
 
 // cause: "function aa(){}0"
 
-                return stop("unexpected_a", token_nxt);
-            }
-            if (
-                token_nxt.id === "."
-                || token_nxt.id === "?."
-                || token_nxt.id === "["
-            ) {
+            return stop("unexpected_a", token_nxt);
+        }
+        if (
+            token_nxt.id === "."
+            || token_nxt.id === "?."
+            || token_nxt.id === "["
+        ) {
 
 // cause: "function aa(){}\n[]"
 
-                warn("unexpected_a");
-            }
+            warn("unexpected_a");
+        }
 
 // Restore the previous context.
 
-            functionage = function_stack.pop();
-            return the_function;
-        }
+        functionage = function_stack.pop();
+        return the_function;
+    }
 
-        function do_async() {
-            let the_async;
-            let the_function;
-            the_async = token_now;
-            advance("function");
-            the_function = Object.assign(token_now, {
-                arity: the_async.arity,
-                async: 1
-            });
-            do_function();
-            if (the_function.async === 1) {
+    function do_async() {
+        let the_async;
+        let the_function;
+        the_async = token_now;
+        advance("function");
+        the_function = Object.assign(token_now, {
+            arity: the_async.arity,
+            async: 1
+        });
+        do_function();
+        if (the_function.async === 1) {
 
 // cause: "async function aa(){}"
 
-                warn("missing_await_statement", the_function);
-            }
-            return the_function;
+            warn("missing_await_statement", the_function);
         }
+        return the_function;
+    }
 
-        function do_await() {
-            const the_await = token_now;
-            if (functionage.async === 0) {
+    function do_await() {
+        const the_await = token_now;
+        if (functionage.async === 0) {
 
 // cause: "await"
 // cause: "function aa(){aa=await 0;}"
 // cause: "function aa(){await 0;}"
 
-                warn("unexpected_a", the_await);
-            } else {
-                functionage.async += 1;
-            }
-            if (the_await.arity === "statement") {
-                the_await.block = parse_expression();
-                semicolon();
-            } else {
-                the_await.expression = parse_expression();
-            }
-            return the_await;
+            warn("unexpected_a", the_await);
+        } else {
+            functionage.async += 1;
         }
+        if (the_await.arity === "statement") {
+            the_await.block = parse_expression();
+            semicolon();
+        } else {
+            the_await.expression = parse_expression();
+        }
+        return the_await;
+    }
 
-        prefix("async", do_async);
-        prefix("await", do_await);
-        prefix("function", do_function);
+    prefix("async", do_async);
+    prefix("await", do_await);
+    prefix("function", do_function);
 
-        function fart(pl) {
-            let the_fart;
-            advance("=>");
-            the_fart = token_now;
-            the_fart.arity = "binary";
-            the_fart.name = "=>";
-            the_fart.level = functionage.level + 1;
-            function_array.push(the_fart);
-            if (functionage.loop > 0) {
+    function fart(pl) {
+        let the_fart;
+        advance("=>");
+        the_fart = token_now;
+        the_fart.arity = "binary";
+        the_fart.name = "=>";
+        the_fart.level = functionage.level + 1;
+        function_list.push(the_fart);
+        if (functionage.loop > 0) {
 
 // cause: "while(0){aa.map(()=>0);}"
 
-                warn("function_in_loop", the_fart);
-            }
+            warn("function_in_loop", the_fart);
+        }
 
 // Give the function properties storing its names and for observing the depth
 // of loops and switches.
 
-            the_fart.context = empty();
-            the_fart.finally = 0;
-            the_fart.loop = 0;
-            the_fart.switch = 0;
-            the_fart.try = 0;
+        the_fart.context = empty();
+        the_fart.finally = 0;
+        the_fart.loop = 0;
+        the_fart.switch = 0;
+        the_fart.try = 0;
 
 // Push the current function context and establish a new one.
 
-            function_stack.push(functionage);
-            functionage = the_fart;
-            the_fart.parameters = pl[0];
-            the_fart.signature = pl[1];
-            the_fart.parameters.forEach(function (name) {
+        function_stack.push(functionage);
+        functionage = the_fart;
+        the_fart.parameters = pl[0];
+        the_fart.signature = pl[1];
+        the_fart.parameters.forEach(function (name) {
 
 // cause: "(aa)=>{}"
 
-                enroll(name, "parameter", true);
-            });
-            if (token_nxt.id === "{") {
+            enroll(name, "parameter", true);
+        });
+        if (token_nxt.id === "{") {
 
 // cause: "()=>{}"
 
-                warn("expected_a_b", the_fart, "function", "=>");
-                the_fart.block = block("body");
-            } else {
-                the_fart.expression = parse_expression(0);
-            }
-            functionage = function_stack.pop();
-            return the_fart;
+            warn("expected_a_b", the_fart, "function", "=>");
+            the_fart.block = block("body");
+        } else {
+            the_fart.expression = parse_expression(0);
         }
+        functionage = function_stack.pop();
+        return the_fart;
+    }
 
-        prefix("(", function () {
-            const cadet = lookahead().id;
-            const the_paren = token_now;
-            let the_value;
+    prefix("(", function () {
+        const cadet = lookahead().id;
+        const the_paren = token_now;
+        let the_value;
 
 // We can distinguish between a parameter list for => and a wrapped expression
 // with one token of lookahead.
 
-            if (
-                token_nxt.id === ")"
-                || token_nxt.id === "..."
-                || (token_nxt.identifier && (cadet === "," || cadet === "="))
-            ) {
+        if (
+            token_nxt.id === ")"
+            || token_nxt.id === "..."
+            || (token_nxt.identifier && (cadet === "," || cadet === "="))
+        ) {
 
 // cause: "()=>0"
 
-                the_paren.free = false;
-                return fart(parameter_list());
-            }
+            the_paren.free = false;
+            return fart(parameter_list());
+        }
 
 // cause: "(0)"
 
-            the_paren.free = true;
-            the_value = parse_expression(0);
-            if (the_value.wrapped === true) {
+        the_paren.free = true;
+        the_value = parse_expression(0);
+        if (the_value.wrapped === true) {
 
 // cause: "((0))"
 
-                warn("unexpected_a", the_paren);
-            }
-            the_value.wrapped = true;
-            advance(")", the_paren);
-            if (token_nxt.id === "=>") {
-                if (the_value.arity !== "variable") {
-                    if (the_value.id === "{" || the_value.id === "[") {
+            warn("unexpected_a", the_paren);
+        }
+        the_value.wrapped = true;
+        advance(")", the_paren);
+        if (token_nxt.id === "=>") {
+            if (the_value.arity !== "variable") {
+                if (the_value.id === "{" || the_value.id === "[") {
 
 // cause: "([])=>0"
 // cause: "({})=>0"
 
-                        warn("expected_a_before_b", the_paren, "function", "(");
+                    warn("expected_a_before_b", the_paren, "function", "(");
 
 // cause: "([])=>0"
 // cause: "({})=>0"
 
-                        return stop("expected_a_b", token_nxt, "{", "=>");
-                    }
+                    return stop("expected_a_b", token_nxt, "{", "=>");
+                }
 
 // cause: "(0)=>0"
 
-                    return stop("expected_identifier_a", the_value);
-                }
-                the_paren.expression = [the_value];
-                return fart([the_paren.expression, "(" + the_value.id + ")"]);
+                return stop("expected_identifier_a", the_value);
             }
-            return the_value;
-        });
-        prefix("`", do_tick);
-        prefix("{", function () {
-            const seen = empty();
-            const the_brace = token_now;
-            the_brace.expression = [];
-            if (token_nxt.id !== "}") {
-                let artifact_now;
-                let artifact_nxt = "";
+            the_paren.expression = [the_value];
+            return fart([the_paren.expression, "(" + the_value.id + ")"]);
+        }
+        return the_value;
+    });
+    prefix("`", do_tick);
+    prefix("{", function () {
+        const seen = empty();
+        const the_brace = token_now;
+        the_brace.expression = [];
+        if (token_nxt.id !== "}") {
+            let artifact_now;
+            let artifact_nxt = "";
 
 // Parse/loop through each property in {...}.
 
-                while (true) {
-                    let extra;
-                    let full;
-                    let id;
-                    let name = token_nxt;
-                    let value;
+            while (true) {
+                let extra;
+                let full;
+                let id;
+                let name = token_nxt;
+                let value;
+                advance();
+                artifact_now = artifact_nxt;
+                artifact_nxt = artifact(name);
+                if (
+                    !option_dict.unordered
+                    && artifact_now > artifact_nxt
+                ) {
+
+// cause: "aa={bb,aa}"
+
+                    warn(
+                        "expected_a_before_b",
+                        name,
+                        artifact_nxt,
+                        artifact_now
+                    );
+                }
+                if (
+                    (name.id === "get" || name.id === "set")
+                    && token_nxt.identifier
+                ) {
+                    if (!option_dict.getset) {
+
+// cause: "aa={get aa(){}}"
+
+                        warn("unexpected_a", name);
+                    }
+                    extra = name.id;
+                    full = extra + " " + token_nxt.id;
+                    name = token_nxt;
                     advance();
+                    id = survey(name);
+                    if (seen[full] === true || seen[id] === true) {
+
+// cause: "aa={get aa(){},get aa(){}}"
+
+                        warn("duplicate_a", name);
+                    }
+                    seen[id] = false;
+                    seen[full] = true;
+                } else {
+                    id = survey(name);
+                    if (typeof seen[id] === "boolean") {
+
+// cause: "aa={aa,aa}"
+
+                        warn("duplicate_a", name);
+                    }
+                    seen[id] = true;
+                }
+                if (name.identifier) {
+                    if (token_nxt.id === "}" || token_nxt.id === ",") {
+                        if (typeof extra === "string") {
+
+// cause: "aa={get aa}"
+
+                            advance("(");
+                        }
+                        value = parse_expression(Infinity, true);
+                    } else if (token_nxt.id === "(") {
+                        value = do_function({
+                            arity: "unary",
+                            from: name.from,
+                            id: "function",
+                            line: name.line,
+                            name: (
+                                typeof extra === "string"
+
+// cause: "aa={get aa(){}}"
+
+                                ? extra
+
+// cause: "aa={aa()}"
+
+                                : id
+                            ),
+                            thru: name.from
+                        });
+                    } else {
+                        if (typeof extra === "string") {
+
+// cause: "aa={get aa.aa}"
+
+                            advance("(");
+                        }
+                        let the_colon = token_nxt;
+                        advance(":");
+                        value = parse_expression(0);
+                        if (
+                            value.id === name.id
+                            && value.id !== "function"
+                        ) {
+
+// cause: "aa={aa:aa}"
+
+                            warn("unexpected_a", the_colon, ": " + name.id);
+                        }
+                    }
+                    value.label = name;
+                    if (typeof extra === "string") {
+                        value.extra = extra;
+                    }
+                    the_brace.expression.push(value);
+                } else {
+
+// cause: aa={"aa":0}
+
+                    advance(":");
+                    value = parse_expression(0);
+                    value.label = name;
+                    the_brace.expression.push(value);
+                }
+                if (token_nxt.id !== ",") {
+                    break;
+                }
+
+// cause: aa={"aa":0,"bb":0}
+
+                advance(",");
+            }
+        }
+        advance("}");
+        return the_brace;
+    });
+
+    stmt(";", function () {
+
+// cause: ";"
+
+        warn("unexpected_a", token_now);
+        return token_now;
+    });
+    stmt("{", function () {
+
+// cause: ";{}"
+// cause: "class aa{}"
+
+        warn("naked_block", token_now);
+        return block("naked");
+    });
+    stmt("async", do_async);
+    stmt("await", do_await);
+    stmt("break", function () {
+        const the_break = token_now;
+        let the_label;
+        if (
+            (functionage.loop < 1 && functionage.switch < 1)
+            || functionage.finally > 0
+        ) {
+
+// cause: "break"
+
+            warn("unexpected_a", the_break);
+        }
+        the_break.disrupt = true;
+        if (token_nxt.identifier && token_now.line === token_nxt.line) {
+            the_label = functionage.context[token_nxt.id];
+            if (
+                the_label === undefined
+                || the_label.role !== "label"
+                || the_label.dead
+            ) {
+                if (the_label !== undefined && the_label.dead) {
+
+// cause: "aa:{function aa(aa){break aa;}}"
+
+                    warn("out_of_scope_a");
+                } else {
+
+// cause: "aa:{break aa;}"
+
+                    warn("not_label_a");
+                }
+            } else {
+                the_label.used += 1;
+            }
+            the_break.label = token_nxt;
+            advance();
+        }
+        advance(";");
+        return the_break;
+    });
+
+    function do_var() {
+        const the_statement = token_now;
+        const mode_const = the_statement.id === "const";
+        the_statement.names = [];
+
+// A program may use var or let, but not both.
+
+        if (!mode_const) {
+            if (mode_var === undefined) {
+                mode_var = the_statement.id;
+            } else if (the_statement.id !== mode_var) {
+
+// cause: "let aa;var aa"
+
+                warn(
+                    "expected_a_b",
+                    the_statement,
+                    mode_var,
+                    the_statement.id
+                );
+            }
+        }
+
+// We don't expect to see variables created in switch statements.
+
+        if (functionage.switch > 0) {
+
+// cause: "switch(0){case 0:var aa}"
+
+            warn("var_switch", the_statement);
+        }
+        if (functionage.loop > 0 && the_statement.id === "var") {
+
+// cause: "while(0){var aa;}"
+
+            warn("var_loop", the_statement);
+        }
+        (function next() {
+            if (token_nxt.id === "{" && the_statement.id !== "var") {
+                let artifact_now;
+                let artifact_nxt = "";
+                const the_brace = token_nxt;
+                advance("{");
+                (function pair() {
+                    if (!token_nxt.identifier) {
+
+// cause: "let {0}"
+
+                        return stop("expected_identifier_a", token_nxt);
+                    }
+                    const name = token_nxt;
+                    survey(name);
                     artifact_now = artifact_nxt;
                     artifact_nxt = artifact(name);
                     if (
-                        !option_object.unordered
+                        !option_dict.unordered
                         && artifact_now > artifact_nxt
                     ) {
 
-// cause: "aa={bb,aa}"
+// cause: "let{bb,aa}"
 
                         warn(
                             "expected_a_before_b",
@@ -3719,1276 +3932,1042 @@ function jslint(
                             artifact_now
                         );
                     }
-                    if (
-                        (name.id === "get" || name.id === "set")
-                        && token_nxt.identifier
-                    ) {
-                        if (!option_object.getset) {
-
-// cause: "aa={get aa(){}}"
-
-                            warn("unexpected_a", name);
-                        }
-                        extra = name.id;
-                        full = extra + " " + token_nxt.id;
-                        name = token_nxt;
-                        advance();
-                        id = survey(name);
-                        if (seen[full] === true || seen[id] === true) {
-
-// cause: "aa={get aa(){},get aa(){}}"
-
-                            warn("duplicate_a", name);
-                        }
-                        seen[id] = false;
-                        seen[full] = true;
-                    } else {
-                        id = survey(name);
-                        if (typeof seen[id] === "boolean") {
-
-// cause: "aa={aa,aa}"
-
-                            warn("duplicate_a", name);
-                        }
-                        seen[id] = true;
-                    }
-                    if (name.identifier) {
-                        if (token_nxt.id === "}" || token_nxt.id === ",") {
-                            if (typeof extra === "string") {
-
-// cause: "aa={get aa}"
-
-                                advance("(");
-                            }
-                            value = parse_expression(Infinity, true);
-                        } else if (token_nxt.id === "(") {
-                            value = do_function({
-                                arity: "unary",
-                                from: name.from,
-                                id: "function",
-                                line: name.line,
-                                name: (
-                                    typeof extra === "string"
-
-// cause: "aa={get aa(){}}"
-
-                                    ? extra
-
-// cause: "aa={aa()}"
-
-                                    : id
-                                ),
-                                thru: name.from
-                            });
-                        } else {
-                            if (typeof extra === "string") {
-
-// cause: "aa={get aa.aa}"
-
-                                advance("(");
-                            }
-                            let the_colon = token_nxt;
-                            advance(":");
-                            value = parse_expression(0);
-                            if (
-                                value.id === name.id
-                                && value.id !== "function"
-                            ) {
-
-// cause: "aa={aa:aa}"
-
-                                warn("unexpected_a", the_colon, ": " + name.id);
-                            }
-                        }
-                        value.label = name;
-                        if (typeof extra === "string") {
-                            value.extra = extra;
-                        }
-                        the_brace.expression.push(value);
-                    } else {
-
-// cause: aa={"aa":0}
-
+                    advance();
+                    if (token_nxt.id === ":") {
                         advance(":");
-                        value = parse_expression(0);
-                        value.label = name;
-                        the_brace.expression.push(value);
-                    }
-                    if (token_nxt.id !== ",") {
-                        break;
-                    }
-
-// cause: aa={"aa":0,"bb":0}
-
-                    advance(",");
-                }
-            }
-            advance("}");
-            return the_brace;
-        });
-
-        stmt(";", function () {
-
-// cause: ";"
-
-            warn("unexpected_a", token_now);
-            return token_now;
-        });
-        stmt("{", function () {
-
-// cause: ";{}"
-// cause: "class aa{}"
-
-            warn("naked_block", token_now);
-            return block("naked");
-        });
-        stmt("async", do_async);
-        stmt("await", do_await);
-        stmt("break", function () {
-            const the_break = token_now;
-            let the_label;
-            if (
-                (functionage.loop < 1 && functionage.switch < 1)
-                || functionage.finally > 0
-            ) {
-
-// cause: "break"
-
-                warn("unexpected_a", the_break);
-            }
-            the_break.disrupt = true;
-            if (token_nxt.identifier && token_now.line === token_nxt.line) {
-                the_label = functionage.context[token_nxt.id];
-                if (
-                    the_label === undefined
-                    || the_label.role !== "label"
-                    || the_label.dead
-                ) {
-                    if (the_label !== undefined && the_label.dead) {
-
-// cause: "aa:{function aa(aa){break aa;}}"
-
-                        warn("out_of_scope_a");
-                    } else {
-
-// cause: "aa:{break aa;}"
-
-                        warn("not_label_a");
-                    }
-                } else {
-                    the_label.used += 1;
-                }
-                the_break.label = token_nxt;
-                advance();
-            }
-            advance(";");
-            return the_break;
-        });
-
-        function do_var() {
-            const the_statement = token_now;
-            const mode_const = the_statement.id === "const";
-            the_statement.names = [];
-
-// A program may use var or let, but not both.
-
-            if (!mode_const) {
-                if (mode_var === undefined) {
-                    mode_var = the_statement.id;
-                } else if (the_statement.id !== mode_var) {
-
-// cause: "let aa;var aa"
-
-                    warn(
-                        "expected_a_b",
-                        the_statement,
-                        mode_var,
-                        the_statement.id
-                    );
-                }
-            }
-
-// We don't expect to see variables created in switch statements.
-
-            if (functionage.switch > 0) {
-
-// cause: "switch(0){case 0:var aa}"
-
-                warn("var_switch", the_statement);
-            }
-            if (functionage.loop > 0 && the_statement.id === "var") {
-
-// cause: "while(0){var aa;}"
-
-                warn("var_loop", the_statement);
-            }
-            (function next() {
-                if (token_nxt.id === "{" && the_statement.id !== "var") {
-                    let artifact_now;
-                    let artifact_nxt = "";
-                    const the_brace = token_nxt;
-                    advance("{");
-                    (function pair() {
                         if (!token_nxt.identifier) {
-
-// cause: "let {0}"
-
-                            return stop("expected_identifier_a", token_nxt);
-                        }
-                        const name = token_nxt;
-                        survey(name);
-                        artifact_now = artifact_nxt;
-                        artifact_nxt = artifact(name);
-                        if (
-                            !option_object.unordered
-                            && artifact_now > artifact_nxt
-                        ) {
-
-// cause: "let{bb,aa}"
-
-                            warn(
-                                "expected_a_before_b",
-                                name,
-                                artifact_nxt,
-                                artifact_now
-                            );
-                        }
-                        advance();
-                        if (token_nxt.id === ":") {
-                            advance(":");
-                            if (!token_nxt.identifier) {
 
 // cause: "let {aa:0}"
 // cause: "let {aa:{aa}}"
 
-                                return stop("expected_identifier_a", token_nxt);
-                            }
-                            token_nxt.label = name;
-                            the_statement.names.push(token_nxt);
-                            enroll(token_nxt, "variable", mode_const);
-                            advance();
-                            the_brace.open = true;
-                        } else {
-                            the_statement.names.push(name);
-                            enroll(name, "variable", mode_const);
+                            return stop("expected_identifier_a", token_nxt);
                         }
-                        name.dead = false;
-                        name.init = true;
-                        if (token_nxt.id === "=") {
+                        token_nxt.label = name;
+                        the_statement.names.push(token_nxt);
+                        enroll(token_nxt, "variable", mode_const);
+                        advance();
+                        the_brace.open = true;
+                    } else {
+                        the_statement.names.push(name);
+                        enroll(name, "variable", mode_const);
+                    }
+                    name.dead = false;
+                    name.init = true;
+                    if (token_nxt.id === "=") {
 
 // cause: "let {aa=0}"
 
-                            advance("=");
-                            name.expression = parse_expression();
-                            the_brace.open = true;
-                        }
-                        if (token_nxt.id === ",") {
-                            advance(",");
-                            return pair();
-                        }
-                    }());
-                    advance("}");
-                    advance("=");
-                    the_statement.expression = parse_expression(0);
-                } else if (token_nxt.id === "[" && the_statement.id !== "var") {
-                    const the_bracket = token_nxt;
-                    advance("[");
-                    (function element() {
-                        let ellipsis;
-                        if (token_nxt.id === "...") {
-                            ellipsis = true;
-                            advance("...");
-                        }
-                        if (!token_nxt.identifier) {
+                        advance("=");
+                        name.expression = parse_expression();
+                        the_brace.open = true;
+                    }
+                    if (token_nxt.id === ",") {
+                        advance(",");
+                        return pair();
+                    }
+                }());
+                advance("}");
+                advance("=");
+                the_statement.expression = parse_expression(0);
+            } else if (token_nxt.id === "[" && the_statement.id !== "var") {
+                const the_bracket = token_nxt;
+                advance("[");
+                (function element() {
+                    let ellipsis;
+                    if (token_nxt.id === "...") {
+                        ellipsis = true;
+                        advance("...");
+                    }
+                    if (!token_nxt.identifier) {
 
 // cause: "let[]"
 
-                            return stop("expected_identifier_a", token_nxt);
-                        }
-                        const name = token_nxt;
-                        advance();
-                        the_statement.names.push(name);
-                        enroll(name, "variable", mode_const);
-                        name.dead = false;
-                        name.init = true;
-                        if (ellipsis) {
-                            name.ellipsis = true;
-                        } else {
-                            if (token_nxt.id === "=") {
-                                advance("=");
-                                name.expression = parse_expression();
-                                the_bracket.open = true;
-                            }
-                            if (token_nxt.id === ",") {
-                                advance(",");
-                                return element();
-                            }
-                        }
-                    }());
-                    advance("]");
-                    advance("=");
-                    the_statement.expression = parse_expression(0);
-                } else if (token_nxt.identifier) {
+                        return stop("expected_identifier_a", token_nxt);
+                    }
                     const name = token_nxt;
                     advance();
-                    if (name.id === "ignore") {
+                    the_statement.names.push(name);
+                    enroll(name, "variable", mode_const);
+                    name.dead = false;
+                    name.init = true;
+                    if (ellipsis) {
+                        name.ellipsis = true;
+                    } else {
+                        if (token_nxt.id === "=") {
+                            advance("=");
+                            name.expression = parse_expression();
+                            the_bracket.open = true;
+                        }
+                        if (token_nxt.id === ",") {
+                            advance(",");
+                            return element();
+                        }
+                    }
+                }());
+                advance("]");
+                advance("=");
+                the_statement.expression = parse_expression(0);
+            } else if (token_nxt.identifier) {
+                const name = token_nxt;
+                advance();
+                if (name.id === "ignore") {
 
 // cause: "let ignore;function aa(ignore) {}"
 
-                        warn("unexpected_a", name);
-                    }
-                    enroll(name, "variable", mode_const);
-                    if (token_nxt.id === "=" || mode_const) {
-                        advance("=");
-                        name.dead = false;
-                        name.init = true;
-                        name.expression = parse_expression(0);
-                    }
-                    the_statement.names.push(name);
-                } else {
+                    warn("unexpected_a", name);
+                }
+                enroll(name, "variable", mode_const);
+                if (token_nxt.id === "=" || mode_const) {
+                    advance("=");
+                    name.dead = false;
+                    name.init = true;
+                    name.expression = parse_expression(0);
+                }
+                the_statement.names.push(name);
+            } else {
 
 // cause: "let 0"
 // cause: "var{aa:{aa}}"
 
-                    return stop("expected_identifier_a", token_nxt);
-                }
-            }());
-            semicolon();
-            return the_statement;
-        }
+                return stop("expected_identifier_a", token_nxt);
+            }
+        }());
+        semicolon();
+        return the_statement;
+    }
 
-        stmt("const", do_var);
-        stmt("continue", function () {
-            const the_continue = token_now;
-            if (functionage.loop < 1 || functionage.finally > 0) {
+    stmt("const", do_var);
+    stmt("continue", function () {
+        const the_continue = token_now;
+        if (functionage.loop < 1 || functionage.finally > 0) {
 
 // cause: "continue"
 // cause: "function aa(){while(0){try{}finally{continue}}}"
 
-                warn("unexpected_a", the_continue);
-            }
-            not_top_level(the_continue);
-            the_continue.disrupt = true;
             warn("unexpected_a", the_continue);
-            advance(";");
-            return the_continue;
-        });
-        stmt("debugger", function () {
-            const the_debug = token_now;
-            if (!option_object.devel) {
+        }
+        not_top_level(the_continue);
+        the_continue.disrupt = true;
+        warn("unexpected_a", the_continue);
+        advance(";");
+        return the_continue;
+    });
+    stmt("debugger", function () {
+        const the_debug = token_now;
+        if (!option_dict.devel) {
 
 // cause: "debugger"
 
-                warn("unexpected_a", the_debug);
-            }
-            semicolon();
-            return the_debug;
-        });
-        stmt("delete", function () {
-            const the_token = token_now;
-            const the_value = parse_expression(0);
-            if (
-                (the_value.id !== "." && the_value.id !== "[")
-                || the_value.arity !== "binary"
-            ) {
+            warn("unexpected_a", the_debug);
+        }
+        semicolon();
+        return the_debug;
+    });
+    stmt("delete", function () {
+        const the_token = token_now;
+        const the_value = parse_expression(0);
+        if (
+            (the_value.id !== "." && the_value.id !== "[")
+            || the_value.arity !== "binary"
+        ) {
 
 // cause: "delete 0"
 
-                stop("expected_a_b", the_value, ".", artifact(the_value));
-            }
-            the_token.expression = the_value;
-            semicolon();
-            return the_token;
-        });
-        stmt("do", function () {
-            const the_do = token_now;
-            not_top_level(the_do);
-            functionage.loop += 1;
-            the_do.block = block();
-            advance("while");
-            the_do.expression = condition();
-            semicolon();
-            if (the_do.block.disrupt === true) {
+            stop("expected_a_b", the_value, ".", artifact(the_value));
+        }
+        the_token.expression = the_value;
+        semicolon();
+        return the_token;
+    });
+    stmt("do", function () {
+        const the_do = token_now;
+        not_top_level(the_do);
+        functionage.loop += 1;
+        the_do.block = block();
+        advance("while");
+        the_do.expression = condition();
+        semicolon();
+        if (the_do.block.disrupt === true) {
 
 // cause: "function aa(){do{break;}while(0)}"
 
-                warn("weird_loop", the_do);
-            }
-            functionage.loop -= 1;
-            return the_do;
-        });
-        stmt("export", function () {
-            const the_export = token_now;
-            let the_id;
-            let the_name;
-            let the_thing;
+            warn("weird_loop", the_do);
+        }
+        functionage.loop -= 1;
+        return the_do;
+    });
+    stmt("export", function () {
+        const the_export = token_now;
+        let the_id;
+        let the_name;
+        let the_thing;
 
-            function export_id() {
-                if (!token_nxt.identifier) {
+        function export_id() {
+            if (!token_nxt.identifier) {
 
 // cause: "export {}"
 
-                    stop("expected_identifier_a");
-                }
-                the_id = token_nxt.id;
-                the_name = global.context[the_id];
-                if (the_name === undefined) {
+                stop("expected_identifier_a");
+            }
+            the_id = token_nxt.id;
+            the_name = token_global.context[the_id];
+            if (the_name === undefined) {
 
 // cause: "export {aa}"
 
-                    warn("unexpected_a");
-                } else {
-                    the_name.used += 1;
-                    if (export_object[the_id] !== undefined) {
+                warn("unexpected_a");
+            } else {
+                the_name.used += 1;
+                if (export_dict[the_id] !== undefined) {
 
 // cause: "let aa;export{aa,aa}"
 
-                        warn("duplicate_a");
-                    }
-                    export_object[the_id] = the_name;
+                    warn("duplicate_a");
                 }
-                advance();
-                the_export.expression.push(the_thing);
+                export_dict[the_id] = the_name;
             }
+            advance();
+            the_export.expression.push(the_thing);
+        }
 
-            the_export.expression = [];
-            if (token_nxt.id === "default") {
-                if (export_object.default !== undefined) {
+        the_export.expression = [];
+        if (token_nxt.id === "default") {
+            if (export_dict.default !== undefined) {
 
 // cause: "export default 0;export default 0"
 
-                    warn("duplicate_a");
-                }
-                advance("default");
-                the_thing = parse_expression(0);
-                if (
-                    the_thing.id !== "("
-                    || the_thing.expression[0].id !== "."
-                    || the_thing.expression[0].expression.id !== "Object"
-                    || the_thing.expression[0].name.id !== "freeze"
-                ) {
+                warn("duplicate_a");
+            }
+            advance("default");
+            the_thing = parse_expression(0);
+            if (
+                the_thing.id !== "("
+                || the_thing.expression[0].id !== "."
+                || the_thing.expression[0].expression.id !== "Object"
+                || the_thing.expression[0].name.id !== "freeze"
+            ) {
 
 // cause: "export default {}"
 
-                    warn("freeze_exports", the_thing);
+                warn("freeze_exports", the_thing);
 
 // Fixes issues #282 - optional-semicolon.
 
-                } else {
+            } else {
 
 // cause: "export default Object.freeze({})"
 
-                    semicolon();
-                }
-                export_object.default = the_thing;
-                the_export.expression.push(the_thing);
-            } else {
-                if (token_nxt.id === "function") {
+                semicolon();
+            }
+            export_dict.default = the_thing;
+            the_export.expression.push(the_thing);
+        } else {
+            if (token_nxt.id === "function") {
 
 // cause: "export function aa(){}"
 
-                    warn("freeze_exports");
-                    the_thing = parse_statement();
-                    the_name = the_thing.name;
-                    the_id = the_name.id;
-                    the_name.used += 1;
+                warn("freeze_exports");
+                the_thing = parse_statement();
+                the_name = the_thing.name;
+                the_id = the_name.id;
+                the_name.used += 1;
 
 // cause: "let aa;export{aa};export function aa(){}"
 
-                    if (export_object[the_id] !== undefined) {
-                        warn("duplicate_a", the_name);
-                    }
-                    export_object[the_id] = the_thing;
-                    the_export.expression.push(the_thing);
-                    the_thing.statement = false;
-                    the_thing.arity = "unary";
-                } else if (
-                    token_nxt.id === "var"
-                    || token_nxt.id === "let"
-                    || token_nxt.id === "const"
-                ) {
-
-// cause: "export const"
-// cause: "export let"
-// cause: "export var"
-
-                    warn("unexpected_a", token_nxt);
-                    parse_statement();
-                } else if (token_nxt.id === "{") {
-
-// cause: "export {}"
-
-                    advance("{");
-                    (function loop() {
-                        export_id();
-                        if (token_nxt.id === ",") {
-                            advance(",");
-                            return loop();
-                        }
-                    }());
-                    advance("}");
-                    semicolon();
-                } else {
-
-// cause: "export"
-
-                    stop("unexpected_a");
+                if (export_dict[the_id] !== undefined) {
+                    warn("duplicate_a", the_name);
                 }
-            }
-            mode_module = true;
-            return the_export;
-        });
-        stmt("for", function () {
-            const the_for = token_now;
-            let first;
-            if (!option_object.for) {
-
-// cause: "for"
-
-                warn("unexpected_a", the_for);
-            }
-            not_top_level(the_for);
-            functionage.loop += 1;
-            advance("(");
-
-// cause: "for(){}"
-
-            token_now.free = true;
-            if (token_nxt.id === ";") {
-
-// cause: "for(;;){}"
-
-                return stop("expected_a_b", the_for, "while (", "for (;");
-            }
-            if (
+                export_dict[the_id] = the_thing;
+                the_export.expression.push(the_thing);
+                the_thing.statement = false;
+                the_thing.arity = "unary";
+            } else if (
                 token_nxt.id === "var"
                 || token_nxt.id === "let"
                 || token_nxt.id === "const"
             ) {
 
+// cause: "export const"
+// cause: "export let"
+// cause: "export var"
+
+                warn("unexpected_a", token_nxt);
+                parse_statement();
+            } else if (token_nxt.id === "{") {
+
+// cause: "export {}"
+
+                advance("{");
+                (function loop() {
+                    export_id();
+                    if (token_nxt.id === ",") {
+                        advance(",");
+                        return loop();
+                    }
+                }());
+                advance("}");
+                semicolon();
+            } else {
+
+// cause: "export"
+
+                stop("unexpected_a");
+            }
+        }
+        mode_module = true;
+        return the_export;
+    });
+    stmt("for", function () {
+        const the_for = token_now;
+        let first;
+        if (!option_dict.for) {
+
+// cause: "for"
+
+            warn("unexpected_a", the_for);
+        }
+        not_top_level(the_for);
+        functionage.loop += 1;
+        advance("(");
+
+// cause: "for(){}"
+
+        token_now.free = true;
+        if (token_nxt.id === ";") {
+
+// cause: "for(;;){}"
+
+            return stop("expected_a_b", the_for, "while (", "for (;");
+        }
+        if (
+            token_nxt.id === "var"
+            || token_nxt.id === "let"
+            || token_nxt.id === "const"
+        ) {
+
 // cause: "for(const aa in aa){}"
 
-                return stop("unexpected_a");
-            }
-            first = parse_expression(0);
-            if (first.id === "in") {
-                if (first.expression[0].arity !== "variable") {
+            return stop("unexpected_a");
+        }
+        first = parse_expression(0);
+        if (first.id === "in") {
+            if (first.expression[0].arity !== "variable") {
 
 // cause: "for(0 in aa){}"
 
-                    warn("bad_assignment_a", first.expression[0]);
-                }
-                the_for.name = first.expression[0];
-                the_for.expression = first.expression[1];
-                warn("expected_a_b", the_for, "Object.keys", "for in");
-            } else {
-                the_for.initial = first;
-                advance(";");
-                the_for.expression = parse_expression(0);
-                advance(";");
-                the_for.inc = parse_expression(0);
-                if (the_for.inc.id === "++") {
+                warn("bad_assignment_a", first.expression[0]);
+            }
+            the_for.name = first.expression[0];
+            the_for.expression = first.expression[1];
+            warn("expected_a_b", the_for, "Object.keys", "for in");
+        } else {
+            the_for.initial = first;
+            advance(";");
+            the_for.expression = parse_expression(0);
+            advance(";");
+            the_for.inc = parse_expression(0);
+            if (the_for.inc.id === "++") {
 
 // cause: "for(aa;aa;aa++){}"
 
-                    warn("expected_a_b", the_for.inc, "+= 1", "++");
-                }
+                warn("expected_a_b", the_for.inc, "+= 1", "++");
             }
-            advance(")");
-            the_for.block = block();
-            if (the_for.block.disrupt === true) {
+        }
+        advance(")");
+        the_for.block = block();
+        if (the_for.block.disrupt === true) {
 
 // cause: "/*jslint for*/\nfunction aa(bb,cc){for(0;0;0){break;}}"
 
-                warn("weird_loop", the_for);
-            }
-            functionage.loop -= 1;
-            return the_for;
-        });
-        stmt("function", do_function);
-        stmt("if", function () {
-            const the_if = token_now;
-            let the_else;
-            the_if.expression = condition();
-            the_if.block = block();
-            if (token_nxt.id === "else") {
-                advance("else");
-                the_else = token_now;
-                the_if.else = (
-                    token_nxt.id === "if"
+            warn("weird_loop", the_for);
+        }
+        functionage.loop -= 1;
+        return the_for;
+    });
+    stmt("function", do_function);
+    stmt("if", function () {
+        const the_if = token_now;
+        let the_else;
+        the_if.expression = condition();
+        the_if.block = block();
+        if (token_nxt.id === "else") {
+            advance("else");
+            the_else = token_now;
+            the_if.else = (
+                token_nxt.id === "if"
 
 // cause: "if(0){0}else if(0){0}"
 
-                    ? parse_statement()
+                ? parse_statement()
 
 // cause: "if(0){0}else{0}"
 
-                    : block()
-                );
-                if (the_if.block.disrupt === true) {
-                    if (the_if.else.disrupt === true) {
+                : block()
+            );
+            if (the_if.block.disrupt === true) {
+                if (the_if.else.disrupt === true) {
 
 // cause: "if(0){break;}else{break;}"
 
-                        the_if.disrupt = true;
-                    } else {
+                    the_if.disrupt = true;
+                } else {
 
 // cause: "if(0){break;}else{}"
 
-                        warn("unexpected_a", the_else);
-                    }
+                    warn("unexpected_a", the_else);
                 }
             }
-            return the_if;
-        });
-        stmt("import", function () {
-            const the_import = token_now;
-            let name;
-            if (typeof mode_module === "object") {
+        }
+        return the_if;
+    });
+    stmt("import", function () {
+        const the_import = token_now;
+        let name;
+        if (typeof mode_module === "object") {
 
 // cause: "/*global aa*/\nimport aa from \"aa\""
 
-                warn(
-                    "unexpected_directive_a",
-                    mode_module,
-                    mode_module.directive
-                );
-            }
-            mode_module = true;
-            if (token_nxt.identifier) {
-                name = token_nxt;
-                advance();
-                if (name.id === "ignore") {
+            warn(
+                "unexpected_directive_a",
+                mode_module,
+                mode_module.directive
+            );
+        }
+        mode_module = true;
+        if (token_nxt.identifier) {
+            name = token_nxt;
+            advance();
+            if (name.id === "ignore") {
 
 // cause: "import ignore from \"aa\""
 
-                    warn("unexpected_a", name);
-                }
-                enroll(name, "variable", true);
-                the_import.name = name;
-            } else {
-                const names = [];
-                advance("{");
-                if (token_nxt.id !== "}") {
-                    while (true) {
-                        if (!token_nxt.identifier) {
+                warn("unexpected_a", name);
+            }
+            enroll(name, "variable", true);
+            the_import.name = name;
+        } else {
+            const names = [];
+            advance("{");
+            if (token_nxt.id !== "}") {
+                while (true) {
+                    if (!token_nxt.identifier) {
 
 // cause: "import {"
 
-                            stop("expected_identifier_a");
-                        }
-                        name = token_nxt;
-                        advance();
-                        if (name.id === "ignore") {
+                        stop("expected_identifier_a");
+                    }
+                    name = token_nxt;
+                    advance();
+                    if (name.id === "ignore") {
 
 // cause: "import {ignore} from \"aa\""
 
-                            warn("unexpected_a", name);
-                        }
-                        enroll(name, "variable", true);
-                        names.push(name);
-                        if (token_nxt.id !== ",") {
-                            break;
-                        }
-                        advance(",");
+                        warn("unexpected_a", name);
                     }
+                    enroll(name, "variable", true);
+                    names.push(name);
+                    if (token_nxt.id !== ",") {
+                        break;
+                    }
+                    advance(",");
                 }
-                advance("}");
-                the_import.name = names;
             }
-            advance("from");
-            advance("(string)");
-            the_import.import = token_now;
-            if (!rx_module.test(token_now.value)) {
+            advance("}");
+            the_import.name = names;
+        }
+        advance("from");
+        advance("(string)");
+        the_import.import = token_now;
+        if (!rx_module.test(token_now.value)) {
 
 // cause: "import aa from \"!aa\""
 
-                warn("bad_module_name_a", token_now);
-            }
-            import_array.push(token_now.value);
-            semicolon();
-            return the_import;
-        });
-        stmt("let", do_var);
-        stmt("return", function () {
-            const the_return = token_now;
-            not_top_level(the_return);
-            if (functionage.finally > 0) {
+            warn("bad_module_name_a", token_now);
+        }
+        import_list.push(token_now.value);
+        semicolon();
+        return the_import;
+    });
+    stmt("let", do_var);
+    stmt("return", function () {
+        const the_return = token_now;
+        not_top_level(the_return);
+        if (functionage.finally > 0) {
 
 // cause: "function aa(){try{}finally{return;}}"
 
-                warn("unexpected_a", the_return);
-            }
-            the_return.disrupt = true;
-            if (token_nxt.id !== ";" && the_return.line === token_nxt.line) {
-                the_return.expression = parse_expression(10);
-            }
-            advance(";");
-            return the_return;
-        });
-        stmt("switch", function () {
-            const the_cases = [];
-            const the_switch = token_now;
-            let dups = [];
-            let last;
-            let stmts;
-            let the_disrupt = true;
-            not_top_level(the_switch);
-            if (functionage.finally > 0) {
+            warn("unexpected_a", the_return);
+        }
+        the_return.disrupt = true;
+        if (token_nxt.id !== ";" && the_return.line === token_nxt.line) {
+            the_return.expression = parse_expression(10);
+        }
+        advance(";");
+        return the_return;
+    });
+    stmt("switch", function () {
+        const the_cases = [];
+        const the_switch = token_now;
+        let dups = [];
+        let last;
+        let stmts;
+        let the_disrupt = true;
+        not_top_level(the_switch);
+        if (functionage.finally > 0) {
 
 // cause: "function aa(){try{}finally{switch(0){}}}"
 
-                warn("unexpected_a", the_switch);
-            }
-            functionage.switch += 1;
-            advance("(");
+            warn("unexpected_a", the_switch);
+        }
+        functionage.switch += 1;
+        advance("(");
 
 // cause: "switch(){}"
 
-            token_now.free = true;
-            the_switch.expression = parse_expression(0);
-            the_switch.block = the_cases;
-            advance(")");
-            advance("{");
-            (function major() {
-                const the_case = token_nxt;
-                the_case.arity = "statement";
-                the_case.expression = [];
-                (function minor() {
-                    advance("case");
-                    token_now.switch = true;
-                    const exp = parse_expression(0);
-                    if (dups.some(function (thing) {
-                        return are_similar(thing, exp);
-                    })) {
+        token_now.free = true;
+        the_switch.expression = parse_expression(0);
+        the_switch.block = the_cases;
+        advance(")");
+        advance("{");
+        (function major() {
+            const the_case = token_nxt;
+            the_case.arity = "statement";
+            the_case.expression = [];
+            (function minor() {
+                advance("case");
+                token_now.switch = true;
+                const exp = parse_expression(0);
+                if (dups.some(function (thing) {
+                    return are_similar(thing, exp);
+                })) {
 
 // cause: "switch(0){case 0:break;case 0:break}"
 
-                        warn("unexpected_a", exp);
-                    }
-                    dups.push(exp);
-                    the_case.expression.push(exp);
-                    advance(":");
-                    if (token_nxt.id === "case") {
-                        return minor();
-                    }
-                }());
-                stmts = parse_statements();
-                if (stmts.length < 1) {
+                    warn("unexpected_a", exp);
+                }
+                dups.push(exp);
+                the_case.expression.push(exp);
+                advance(":");
+                if (token_nxt.id === "case") {
+                    return minor();
+                }
+            }());
+            stmts = parse_statements();
+            if (stmts.length < 1) {
 
 // cause: "switch(0){case 0:}"
 
-                    warn("expected_statements_a");
-                    return;
-                }
-                the_case.block = stmts;
-                the_cases.push(the_case);
-                last = stmts[stmts.length - 1];
-                if (last.disrupt) {
-                    if (last.id === "break" && last.label === undefined) {
-                        the_disrupt = false;
-                    }
-                } else {
-                    warn(
-                        "expected_a_before_b",
-                        token_nxt,
-                        "break;",
-                        artifact(token_nxt)
-                    );
-                }
-                if (token_nxt.id === "case") {
-                    return major();
-                }
-            }());
-            dups = undefined;
-            if (token_nxt.id === "default") {
-                const the_default = token_nxt;
-                advance("default");
-                token_now.switch = true;
-                advance(":");
-                the_switch.else = parse_statements();
-                if (the_switch.else.length < 1) {
-
-// cause: "switch(0){case 0:break;default:}"
-
-                    warn("unexpected_a", the_default);
-                    the_disrupt = false;
-                } else {
-                    const the_last = the_switch.else[
-                        the_switch.else.length - 1
-                    ];
-                    if (
-                        the_last.id === "break"
-                        && the_last.label === undefined
-                    ) {
-
-// cause: "switch(0){case 0:break;default:break;}"
-
-                        warn("unexpected_a", the_last);
-                        the_last.disrupt = false;
-                    }
-                    the_disrupt = the_disrupt && the_last.disrupt;
-                }
-            } else {
-                the_disrupt = false;
+                warn("expected_statements_a");
+                return;
             }
-            advance("}", the_switch);
-            functionage.switch -= 1;
-            the_switch.disrupt = the_disrupt;
-            return the_switch;
-        });
-        stmt("throw", function () {
-            const the_throw = token_now;
-            the_throw.disrupt = true;
-            the_throw.expression = parse_expression(10);
-            semicolon();
-            if (functionage.try > 0) {
-
-// cause: "try{throw 0}catch(){}"
-
-                warn("unexpected_a", the_throw);
-            }
-            return the_throw;
-        });
-        stmt("try", function () {
-            const the_try = token_now;
-            let ignored;
-            let the_catch;
-            let the_disrupt;
-            if (functionage.try > 0) {
-
-// cause: "try{try{}catch(){}}catch(){}"
-
-                warn("unexpected_a", the_try);
-            }
-            functionage.try += 1;
-            the_try.block = block();
-            the_disrupt = the_try.block.disrupt;
-            if (token_nxt.id === "catch") {
-                advance("catch");
-                the_catch = token_nxt;
-                the_catch.context = empty();
-                the_catch.async = functionage.async;
-                the_try.catch = the_catch;
-
-// Create new function-scope for catch-parameter.
-
-                function_stack.push(functionage);
-                functionage = the_catch;
-                ignored = "ignore";
-                if (token_nxt.id === "(") {
-                    advance("(");
-                    if (!token_nxt.identifier) {
-
-// cause: "try{}catch(){}"
-
-                        return stop("expected_identifier_a", token_nxt);
-                    }
-                    if (token_nxt.id !== "ignore") {
-                        ignored = undefined;
-                        the_catch.name = token_nxt;
-                        enroll(token_nxt, "exception", true);
-                    }
-                    advance();
-                    advance(")");
-                }
-                the_catch.block = block(ignored);
-                if (the_catch.block.disrupt !== true) {
+            the_case.block = stmts;
+            the_cases.push(the_case);
+            last = stmts[stmts.length - 1];
+            if (last.disrupt) {
+                if (last.id === "break" && last.label === undefined) {
                     the_disrupt = false;
                 }
-
-// Restore previous function-scope after catch-block.
-
-                functionage = function_stack.pop();
-                functionage.async = Math.max(
-                    functionage.async,
-                    the_catch.async
-                );
             } else {
-
-// cause: "try{}finally{break;}"
-
                 warn(
                     "expected_a_before_b",
                     token_nxt,
-                    "catch",
+                    "break;",
                     artifact(token_nxt)
                 );
+            }
+            if (token_nxt.id === "case") {
+                return major();
+            }
+        }());
+        dups = undefined;
+        if (token_nxt.id === "default") {
+            const the_default = token_nxt;
+            advance("default");
+            token_now.switch = true;
+            advance(":");
+            the_switch.else = parse_statements();
+            if (the_switch.else.length < 1) {
 
+// cause: "switch(0){case 0:break;default:}"
+
+                warn("unexpected_a", the_default);
+                the_disrupt = false;
+            } else {
+                const the_last = the_switch.else[
+                    the_switch.else.length - 1
+                ];
+                if (
+                    the_last.id === "break"
+                    && the_last.label === undefined
+                ) {
+
+// cause: "switch(0){case 0:break;default:break;}"
+
+                    warn("unexpected_a", the_last);
+                    the_last.disrupt = false;
+                }
+                the_disrupt = the_disrupt && the_last.disrupt;
             }
-            if (token_nxt.id === "finally") {
-                functionage.finally += 1;
-                advance("finally");
-                the_try.else = block();
-                the_disrupt = the_try.else.disrupt;
-                functionage.finally -= 1;
+        } else {
+            the_disrupt = false;
+        }
+        advance("}", the_switch);
+        functionage.switch -= 1;
+        the_switch.disrupt = the_disrupt;
+        return the_switch;
+    });
+    stmt("throw", function () {
+        const the_throw = token_now;
+        the_throw.disrupt = true;
+        the_throw.expression = parse_expression(10);
+        semicolon();
+        if (functionage.try > 0) {
+
+// cause: "try{throw 0}catch(){}"
+
+            warn("unexpected_a", the_throw);
+        }
+        return the_throw;
+    });
+    stmt("try", function () {
+        const the_try = token_now;
+        let ignored;
+        let the_catch;
+        let the_disrupt;
+        if (functionage.try > 0) {
+
+// cause: "try{try{}catch(){}}catch(){}"
+
+            warn("unexpected_a", the_try);
+        }
+        functionage.try += 1;
+        the_try.block = block();
+        the_disrupt = the_try.block.disrupt;
+        if (token_nxt.id === "catch") {
+            advance("catch");
+            the_catch = token_nxt;
+            the_catch.context = empty();
+            the_catch.async = functionage.async;
+            the_try.catch = the_catch;
+
+// Create new function-scope for catch-parameter.
+
+            function_stack.push(functionage);
+            functionage = the_catch;
+            ignored = "ignore";
+            if (token_nxt.id === "(") {
+                advance("(");
+                if (!token_nxt.identifier) {
+
+// cause: "try{}catch(){}"
+
+                    return stop("expected_identifier_a", token_nxt);
+                }
+                if (token_nxt.id !== "ignore") {
+                    ignored = undefined;
+                    the_catch.name = token_nxt;
+                    enroll(token_nxt, "exception", true);
+                }
+                advance();
+                advance(")");
             }
-            the_try.disrupt = the_disrupt;
-            functionage.try -= 1;
-            return the_try;
-        });
-        stmt("var", do_var);
-        stmt("while", function () {
-            const the_while = token_now;
-            not_top_level(the_while);
-            functionage.loop += 1;
-            the_while.expression = condition();
-            the_while.block = block();
-            if (the_while.block.disrupt === true) {
+            the_catch.block = block(ignored);
+            if (the_catch.block.disrupt !== true) {
+                the_disrupt = false;
+            }
+
+// Restore previous function-scope after catch-block.
+
+            functionage = function_stack.pop();
+            functionage.async = Math.max(
+                functionage.async,
+                the_catch.async
+            );
+        } else {
+
+// cause: "try{}finally{break;}"
+
+            warn(
+                "expected_a_before_b",
+                token_nxt,
+                "catch",
+                artifact(token_nxt)
+            );
+
+        }
+        if (token_nxt.id === "finally") {
+            functionage.finally += 1;
+            advance("finally");
+            the_try.else = block();
+            the_disrupt = the_try.else.disrupt;
+            functionage.finally -= 1;
+        }
+        the_try.disrupt = the_disrupt;
+        functionage.try -= 1;
+        return the_try;
+    });
+    stmt("var", do_var);
+    stmt("while", function () {
+        const the_while = token_now;
+        not_top_level(the_while);
+        functionage.loop += 1;
+        the_while.expression = condition();
+        the_while.block = block();
+        if (the_while.block.disrupt === true) {
 
 // cause: "function aa(){while(0){break;}}"
 
-                warn("weird_loop", the_while);
-            }
-            functionage.loop -= 1;
-            return the_while;
-        });
-        stmt("with", function () {
+            warn("weird_loop", the_while);
+        }
+        functionage.loop -= 1;
+        return the_while;
+    });
+    stmt("with", function () {
 
 // cause: "with"
 
-            stop("unexpected_a", token_now);
-        });
+        stop("unexpected_a", token_now);
+    });
 
-        ternary("?", ":");
+    ternary("?", ":");
 
-        advance();
+    advance();
 
 // Parsing of JSON is simple:
 
-        if (mode_json) {
-            token_tree = (function parse_json() {
-                let negative;
-                switch (token_nxt.id) {
-                case "{":
-                    return (function json_object() {
-                        const brace = token_nxt;
+    if (mode_json) {
+        token_tree = (function parse_json() {
+            let negative;
+            switch (token_nxt.id) {
+            case "{":
+                return (function json_object() {
+                    const brace = token_nxt;
 
 // Explicit empty-object required to detect "__proto__".
 
-                        const object = empty();
-                        const properties = [];
-                        brace.expression = properties;
-                        advance("{");
-                        if (token_nxt.id !== "}") {
+                    const object = empty();
+                    const properties = [];
+                    brace.expression = properties;
+                    advance("{");
+                    if (token_nxt.id !== "}") {
 
 // JSON
 // Parse/loop through each property in {...}.
 
-                            while (true) {
-                                let name;
-                                let value;
-                                if (token_nxt.quote !== "\"") {
+                        while (true) {
+                            let name;
+                            let value;
+                            if (token_nxt.quote !== "\"") {
 
 // cause: "{0:0}"
 
-                                    warn(
-                                        "unexpected_a",
-                                        token_nxt,
-                                        token_nxt.quote
-                                    );
-                                }
-                                name = token_nxt;
-                                advance("(string)");
-                                if (object[token_now.value] !== undefined) {
+                                warn(
+                                    "unexpected_a",
+                                    token_nxt,
+                                    token_nxt.quote
+                                );
+                            }
+                            name = token_nxt;
+                            advance("(string)");
+                            if (object[token_now.value] !== undefined) {
 
 // cause: "{\"aa\":0,\"aa\":0}"
 
-                                    warn("duplicate_a", token_now);
-                                } else if (token_now.value === "__proto__") {
+                                warn("duplicate_a", token_now);
+                            } else if (token_now.value === "__proto__") {
 
 // cause: "{\"__proto__\":0}"
 
-                                    warn("bad_property_a", token_now);
-                                } else {
-                                    object[token_now.value] = token_now;
-                                }
-                                advance(":");
-                                value = parse_json();
-                                value.label = name;
-                                properties.push(value);
-                                if (token_nxt.id !== ",") {
-                                    break;
-                                }
-                                advance(",");
+                                warn("bad_property_a", token_now);
+                            } else {
+                                object[token_now.value] = token_now;
                             }
+                            advance(":");
+                            value = parse_json();
+                            value.label = name;
+                            properties.push(value);
+                            if (token_nxt.id !== ",") {
+                                break;
+                            }
+                            advance(",");
                         }
-                        advance("}", brace);
-                        return brace;
-                    }());
-                case "[":
+                    }
+                    advance("}", brace);
+                    return brace;
+                }());
+            case "[":
 
 // cause: "[]"
 
-                    return (function json_array() {
-                        const bracket = token_nxt;
-                        const elements = [];
-                        bracket.expression = elements;
-                        advance("[");
-                        if (token_nxt.id !== "]") {
-                            while (true) {
-                                elements.push(parse_json());
-                                if (token_nxt.id !== ",") {
+                return (function json_list() {
+                    const bracket = token_nxt;
+                    const elements = [];
+                    bracket.expression = elements;
+                    advance("[");
+                    if (token_nxt.id !== "]") {
+                        while (true) {
+                            elements.push(parse_json());
+                            if (token_nxt.id !== ",") {
 
 // cause: "[0,0]"
 
-                                    break;
-                                }
-                                advance(",");
+                                break;
                             }
+                            advance(",");
                         }
-                        advance("]", bracket);
-                        return bracket;
-                    }());
-                case "true":
-                case "false":
-                case "null":
+                    }
+                    advance("]", bracket);
+                    return bracket;
+                }());
+            case "true":
+            case "false":
+            case "null":
 
 // cause: "[false]"
 // cause: "[null]"
 // cause: "[true]"
 
-                    advance();
-                    return token_now;
-                case "(number)":
-                    if (!rx_JSON_number.test(token_nxt.value)) {
+                advance();
+                return token_now;
+            case "(number)":
+                if (!rx_JSON_number.test(token_nxt.value)) {
 
 // cause: "[0x0]"
 
-                        warn("unexpected_a");
-                    }
-                    advance();
-                    return token_now;
-                case "(string)":
-                    if (token_nxt.quote !== "\"") {
+                    warn("unexpected_a");
+                }
+                advance();
+                return token_now;
+            case "(string)":
+                if (token_nxt.quote !== "\"") {
 
 // cause: "['']"
 
-                        warn("unexpected_a", token_nxt, token_nxt.quote);
-                    }
-                    advance();
-                    return token_now;
-                case "-":
-                    negative = token_nxt;
-                    negative.arity = "unary";
-                    advance("-");
-                    advance("(number)");
-                    if (!rx_JSON_number.test(token_now.value)) {
+                    warn("unexpected_a", token_nxt, token_nxt.quote);
+                }
+                advance();
+                return token_now;
+            case "-":
+                negative = token_nxt;
+                negative.arity = "unary";
+                advance("-");
+                advance("(number)");
+                if (!rx_JSON_number.test(token_now.value)) {
 
 // cause: "[-0x0]"
 
-                        warn("unexpected_a", token_now);
-                    }
-                    negative.expression = token_now;
-                    return negative;
-                default:
+                    warn("unexpected_a", token_now);
+                }
+                negative.expression = token_now;
+                return negative;
+            default:
 
 // cause: "[undefined]"
 
-                    stop("unexpected_a");
-                }
-            }());
-            advance("(end)");
-            return;
-        }
+                stop("unexpected_a");
+            }
+        }());
+        advance("(end)");
+        return;
+    }
 
 // Because browsers encourage combining of script files, the first token might
 // be a semicolon to defend against a missing semicolon in the preceding file.
 
-        if (option_object.browser) {
-            if (token_nxt.id === ";") {
-                advance(";");
-            }
-            token_tree = parse_statements();
-            advance("(end)");
-            return;
-        }
-
-// If we are not in a browser, then the file form of strict pragma may be used.
-
-        if (
-            token_nxt.value === "use strict"
-        ) {
-            advance("(string)");
+    if (option_dict.browser) {
+        if (token_nxt.id === ";") {
             advance(";");
         }
         token_tree = parse_statements();
         advance("(end)");
+        return;
     }
 
+// If we are not in a browser, then the file form of strict pragma may be used.
 
-    function phase4_walk() {
+    if (
+        token_nxt.value === "use strict"
+    ) {
+        advance("(string)");
+        advance(";");
+    }
+    token_tree = parse_statements();
+    advance("(end)");
+}
+
+
+function phase4_walk() {
 
 // PHASE 4. Walk <token_tree>, traversing all of the nodes of the tree. It is a
 //          recursive traversal. Each node may be processed on the way down
 //          (preaction) and on the way up (postaction).
 
 // The stack of blocks.
-        const block_stack = [];
-        const posts = empty();
-        const pres = empty();
+    const block_stack = [];
+    const posts = empty();
+    const pres = empty();
 // The current block.
-        let blockage = global;
+    let blockage = token_global;
 // The current function.
-        let functionage = global;
-        let postaction;
-        let postamble;
-        let preaction;
-        let preamble;
+    let functionage = token_global;
+    let postaction;
+    let postamble;
+    let preaction;
+    let preamble;
 
 // Ambulation of the parse tree.
 
-        function action(when) {
+    function action(when) {
 
 // Produce a function that will register task functions that will be called as
 // the tree is traversed.
 
-            return function (arity, id, task) {
-                let a_set = when[arity];
-                let i_set;
+        return function (arity, id, task) {
+            let a_set = when[arity];
+            let i_set;
 
 // The id parameter is optional. If excluded, the task will be applied to all
 // ids.
 
-                if (typeof id !== "string") {
-                    task = id;
-                    id = "(all)";
-                }
+            if (typeof id !== "string") {
+                task = id;
+                id = "(all)";
+            }
 
 // If this arity has no registrations yet, then create a set object to hold
 // them.
 
-                if (a_set === undefined) {
-                    a_set = empty();
-                    when[arity] = a_set;
-                }
+            if (a_set === undefined) {
+                a_set = empty();
+                when[arity] = a_set;
+            }
 
 // If this id has no registrations yet, then create a set array to hold them.
 
-                i_set = a_set[id];
-                if (i_set === undefined) {
-                    i_set = [];
-                    a_set[id] = i_set;
-                }
+            i_set = a_set[id];
+            if (i_set === undefined) {
+                i_set = [];
+                a_set[id] = i_set;
+            }
 
 // Register the task with the arity and the id.
 
-                i_set.push(task);
-            };
-        }
+            i_set.push(task);
+        };
+    }
 
-        function amble(when) {
+    function amble(when) {
 
 // Produce a function that will act on the tasks registered by an action
 // function while walking the tree.
 
-            return function (the_token) {
+        return function (the_token) {
 
 // Given a task set that was built by an action function, run all of the
 // relevant tasks on the token.
 
-                let a_set = when[the_token.arity];
-                let i_set;
+            let a_set = when[the_token.arity];
+            let i_set;
 
 // If there are tasks associated with the token's arity...
 
-                if (a_set !== undefined) {
+            if (a_set !== undefined) {
 
 // If there are tasks associated with the token's id...
 
-                    i_set = a_set[the_token.id];
-                    if (i_set !== undefined) {
-                        i_set.forEach(function (task) {
-                            return task(the_token);
-                        });
-                    }
+                i_set = a_set[the_token.id];
+                if (i_set !== undefined) {
+                    i_set.forEach(function (task) {
+                        return task(the_token);
+                    });
+                }
 
 // If there are tasks for all ids.
 
-                    i_set = a_set["(all)"];
-                    if (i_set !== undefined) {
-                        i_set.forEach(function (task) {
-                            return task(the_token);
-                        });
-                    }
+                i_set = a_set["(all)"];
+                if (i_set !== undefined) {
+                    i_set.forEach(function (task) {
+                        return task(the_token);
+                    });
                 }
-            };
-        }
+            }
+        };
+    }
 
-        function top_level_only(the_thing) {
+    function top_level_only(the_thing) {
 
 // Some features must be at the most outermost level.
 
-            if (blockage !== global) {
+        if (blockage !== token_global) {
 
 // cause: "if(0){import aa from \"aa\";}"
 
-                warn("misplaced_a", the_thing);
-            }
+            warn("misplaced_a", the_thing);
         }
+    }
 
-        function walk_expression(thing) {
-            if (thing) {
-                if (Array.isArray(thing)) {
+    function walk_expression(thing) {
+        if (thing) {
+            if (Array.isArray(thing)) {
 
 // cause: "(function(){}())"
 // cause: "0&&0"
 
-                    thing.forEach(walk_expression);
-                } else {
-                    preamble(thing);
-                    walk_expression(thing.expression);
-                    if (thing.id === "function") {
+                thing.forEach(walk_expression);
+            } else {
+                preamble(thing);
+                walk_expression(thing.expression);
+                if (thing.id === "function") {
 
 // cause: "aa=function(){}"
 
-                        walk_statement(thing.block);
-                    }
-                    if (thing.arity === "pre" || thing.arity === "post") {
+                    walk_statement(thing.block);
+                }
+                if (thing.arity === "pre" || thing.arity === "post") {
 
 // cause: "aa=++aa"
 // cause: "aa=--aa"
 
-                        warn("unexpected_a", thing);
-                    } else if (
+                    warn("unexpected_a", thing);
+                } else if (
 
 // cause: "aa=0"
 
-                        thing.arity === "statement"
-                        || thing.arity === "assignment"
-                    ) {
+                    thing.arity === "statement"
+                    || thing.arity === "assignment"
+                ) {
 
 // cause: "aa[aa=0]"
 
-                        warn("unexpected_statement_a", thing);
-                    }
-                    postamble(thing);
+                    warn("unexpected_statement_a", thing);
                 }
+                postamble(thing);
             }
         }
+    }
 
-        function walk_statement(thing) {
-            if (thing) {
-                if (Array.isArray(thing)) {
+    function walk_statement(thing) {
+        if (thing) {
+            if (Array.isArray(thing)) {
 
 // cause: "+[]"
 
-                    thing.forEach(walk_statement);
-                } else {
-                    preamble(thing);
-                    walk_expression(thing.expression);
-                    if (thing.arity === "binary") {
-                        if (thing.id !== "(") {
+                thing.forEach(walk_statement);
+            } else {
+                preamble(thing);
+                walk_expression(thing.expression);
+                if (thing.arity === "binary") {
+                    if (thing.id !== "(") {
 
 // cause: "0&&0"
 
-                            warn("unexpected_expression_a", thing);
-                        }
-                    } else if (
-                        thing.arity !== "statement"
-                        && thing.arity !== "assignment"
-                        && thing.id !== "import"
-                    ) {
+                        warn("unexpected_expression_a", thing);
+                    }
+                } else if (
+                    thing.arity !== "statement"
+                    && thing.arity !== "assignment"
+                    && thing.id !== "import"
+                ) {
 
 // cause: "!0"
 // cause: "+[]"
@@ -4997,156 +4976,156 @@ function jslint(
 // cause: "async function aa(){await 0;}"
 // cause: "typeof 0"
 
-                        warn("unexpected_expression_a", thing);
-                    }
-                    walk_statement(thing.block);
-                    walk_statement(thing.else);
-                    postamble(thing);
+                    warn("unexpected_expression_a", thing);
                 }
+                walk_statement(thing.block);
+                walk_statement(thing.else);
+                postamble(thing);
             }
         }
+    }
 
-        function lookup(thing) {
-            if (thing.arity === "variable") {
+    function lookup(thing) {
+        if (thing.arity === "variable") {
 
 // Look up the variable in the current context.
 
-                let the_variable = functionage.context[thing.id];
+            let the_variable = functionage.context[thing.id];
 
 // If it isn't local, search all the other contexts. If there are name
 // collisions, take the most recent.
 
-                if (the_variable === undefined) {
-                    function_stack.forEach(function (outer) {
-                        const a_variable = outer.context[thing.id];
-                        if (
-                            a_variable !== undefined
-                            && a_variable.role !== "label"
-                        ) {
-                            the_variable = a_variable;
-                        }
-                    });
+            if (the_variable === undefined) {
+                function_stack.forEach(function (outer) {
+                    const a_variable = outer.context[thing.id];
+                    if (
+                        a_variable !== undefined
+                        && a_variable.role !== "label"
+                    ) {
+                        the_variable = a_variable;
+                    }
+                });
 
 // If it isn't in any of those either, perhaps it is a predefined global.
 // If so, add it to the global context.
 
-                    if (the_variable === undefined) {
-                        if (global_array[thing.id] === undefined) {
+                if (the_variable === undefined) {
+                    if (global_list[thing.id] === undefined) {
 
 // cause: "aa"
 // cause: "class aa{}"
 // cause: "let aa=0;try{aa();}catch(bb){bb();}bb();"
 
-                            warn("undeclared_a", thing);
-                            return;
-                        }
-                        the_variable = {
-                            dead: false,
-                            id: thing.id,
-                            init: true,
-                            parent: global,
-                            role: "variable",
-                            used: 0,
-                            writable: false
-                        };
-                        global.context[thing.id] = the_variable;
+                        warn("undeclared_a", thing);
+                        return;
                     }
-                    the_variable.closure = true;
-                    functionage.context[thing.id] = the_variable;
-                } else if (the_variable.role === "label") {
+                    the_variable = {
+                        dead: false,
+                        id: thing.id,
+                        init: true,
+                        parent: token_global,
+                        role: "variable",
+                        used: 0,
+                        writable: false
+                    };
+                    token_global.context[thing.id] = the_variable;
+                }
+                the_variable.closure = true;
+                functionage.context[thing.id] = the_variable;
+            } else if (the_variable.role === "label") {
 
 // cause: "aa:while(0){aa;}"
 
-                    warn("label_a", thing);
-                }
-                if (
-                    the_variable.dead
-                    && (
-                        the_variable.calls === undefined
-                        || functionage.name === undefined
-                        || the_variable.calls[functionage.name.id] === undefined
-                    )
-                ) {
+                warn("label_a", thing);
+            }
+            if (
+                the_variable.dead
+                && (
+                    the_variable.calls === undefined
+                    || functionage.name === undefined
+                    || the_variable.calls[functionage.name.id] === undefined
+                )
+            ) {
 
 // cause: "function aa(){bb();}\nfunction bb(){}"
 
-                    warn("out_of_scope_a", thing);
-                }
-                return the_variable;
+                warn("out_of_scope_a", thing);
             }
+            return the_variable;
         }
+    }
 
-        function subactivate(name) {
-            name.init = true;
-            name.dead = false;
-            blockage.live.push(name);
-        }
+    function subactivate(name) {
+        name.init = true;
+        name.dead = false;
+        blockage.live.push(name);
+    }
 
-        function preaction_function(thing) {
+    function preaction_function(thing) {
 
 // cause: "()=>0"
 // cause: "(function (){}())"
 // cause: "function aa(){}"
 
-            if (thing.arity === "statement" && blockage.body !== true) {
+        if (thing.arity === "statement" && blockage.body !== true) {
 
 // cause: "if(0){function aa(){}\n}"
 
-                warn("unexpected_a", thing);
-            }
-            function_stack.push(functionage);
-            block_stack.push(blockage);
-            functionage = thing;
-            blockage = thing;
-            thing.live = [];
-            if (typeof thing.name === "object") {
-                thing.name.dead = false;
-                thing.name.init = true;
-            }
-            if (thing.extra === "get") {
-                if (thing.parameters.length !== 0) {
+            warn("unexpected_a", thing);
+        }
+        function_stack.push(functionage);
+        block_stack.push(blockage);
+        functionage = thing;
+        blockage = thing;
+        thing.live = [];
+        if (typeof thing.name === "object") {
+            thing.name.dead = false;
+            thing.name.init = true;
+        }
+        if (thing.extra === "get") {
+            if (thing.parameters.length !== 0) {
 
 // cause: "/*jslint getset*/\naa={get aa(aa){}}"
 
-                    warn("bad_get", thing);
-                }
-            } else if (thing.extra === "set") {
-                if (thing.parameters.length !== 1) {
+                warn("bad_get", thing);
+            }
+        } else if (thing.extra === "set") {
+            if (thing.parameters.length !== 1) {
 
 // cause: "/*jslint getset*/\naa={set aa(){}}"
 
-                    warn("bad_set", thing);
-                }
+                warn("bad_set", thing);
             }
-            thing.parameters.forEach(function (name) {
-                walk_expression(name.expression);
-                if (name.id === "{" || name.id === "[") {
-                    name.names.forEach(subactivate);
-                } else {
-                    name.dead = false;
-                    name.init = true;
-                }
-            });
         }
+        thing.parameters.forEach(function (name) {
+            walk_expression(name.expression);
+            if (name.id === "{" || name.id === "[") {
+                name.names.forEach(subactivate);
+            } else {
+                name.dead = false;
+                name.init = true;
+            }
+        });
+    }
 
-        function bitwise_check(thing) {
+    function bitwise_check(thing) {
 
 // These are the bitwise operators.
 
-            switch (!option_object.bitwise && thing.id) {
-            case "&":
-            case "&=":
-            case "<<":
-            case "<<=":
-            case ">>":
-            case ">>=":
-            case ">>>":
-            case ">>>=":
-            case "^":
-            case "^=":
-            case "|":
-            case "|=":
-            case "~":
+        switch (!option_dict.bitwise && thing.id) {
+        case "&":
+        case "&=":
+        case "<<":
+        case "<<=":
+        case ">>":
+        case ">>=":
+        case ">>>":
+        case ">>>=":
+        case "^":
+        case "^=":
+        case "|":
+        case "|=":
+        case "~":
 
 // cause: "0&0"
 // cause: "0&=0"
@@ -5162,441 +5141,441 @@ function jslint(
 // cause: "0|=0"
 // cause: "~0"
 
-                warn("unexpected_a", thing);
-                break;
-            }
-            if (
-                thing.id !== "("
-                && thing.id !== "&&"
-                && thing.id !== "||"
-                && thing.id !== "="
-                && Array.isArray(thing.expression)
-                && thing.expression.length === 2
-                && (
-                    relationop[thing.expression[0].id] === true
-                    || relationop[thing.expression[1].id] === true
-                )
-            ) {
+            warn("unexpected_a", thing);
+            break;
+        }
+        if (
+            thing.id !== "("
+            && thing.id !== "&&"
+            && thing.id !== "||"
+            && thing.id !== "="
+            && Array.isArray(thing.expression)
+            && thing.expression.length === 2
+            && (
+                relationop[thing.expression[0].id] === true
+                || relationop[thing.expression[1].id] === true
+            )
+        ) {
 
 // cause: "0<0<0"
 
-                warn("unexpected_a", thing);
-            }
+            warn("unexpected_a", thing);
         }
+    }
 
-        function pop_block() {
-            blockage.live.forEach(function (name) {
-                name.dead = true;
-            });
-            delete blockage.live;
-            blockage = block_stack.pop();
-        }
+    function pop_block() {
+        blockage.live.forEach(function (name) {
+            name.dead = true;
+        });
+        delete blockage.live;
+        blockage = block_stack.pop();
+    }
 
-        function action_var(thing) {
-            thing.names.forEach(function (name) {
-                name.dead = false;
-                if (name.expression !== undefined) {
-                    walk_expression(name.expression);
-                    assert_or_throw(
-                        !(name.id === "{" || name.id === "["),
-                        `Expected !(name.id === "{" || name.id === "[").`
-                    );
+    function action_var(thing) {
+        thing.names.forEach(function (name) {
+            name.dead = false;
+            if (name.expression !== undefined) {
+                walk_expression(name.expression);
+                assert_or_throw(
+                    !(name.id === "{" || name.id === "["),
+                    `Expected !(name.id === "{" || name.id === "[").`
+                );
 //          Probably deadcode.
 //          if (name.id === "{" || name.id === "[") {
 //              name.names.forEach(subactivate);
 //          } else {
 //              name.init = true;
 //          }
-                    name.init = true;
-                }
-                blockage.live.push(name);
-            });
-        }
-
-        function init_variable(name) {
-            const the_variable = lookup(name);
-            if (the_variable !== undefined) {
-                if (the_variable.writable) {
-                    the_variable.init = true;
-                    return;
-                }
+                name.init = true;
             }
-            warn("bad_assignment_a", name);
-        }
+            blockage.live.push(name);
+        });
+    }
 
-        function postaction_function(thing) {
-            delete functionage.finally;
-            delete functionage.loop;
-            delete functionage.switch;
-            delete functionage.try;
-            functionage = function_stack.pop();
-            if (thing.wrapped) {
+    function init_variable(name) {
+        const the_variable = lookup(name);
+        if (the_variable !== undefined) {
+            if (the_variable.writable) {
+                the_variable.init = true;
+                return;
+            }
+        }
+        warn("bad_assignment_a", name);
+    }
+
+    function postaction_function(thing) {
+        delete functionage.finally;
+        delete functionage.loop;
+        delete functionage.switch;
+        delete functionage.try;
+        functionage = function_stack.pop();
+        if (thing.wrapped) {
 
 // cause: "aa=(function(){})"
 
-                warn("unexpected_parens", thing);
-            }
-            return pop_block();
+            warn("unexpected_parens", thing);
         }
+        return pop_block();
+    }
 
-        preaction = action(pres);
-        postaction = action(posts);
-        preamble = amble(pres);
-        postamble = amble(posts);
+    preaction = action(pres);
+    postaction = action(posts);
+    preamble = amble(pres);
+    postamble = amble(posts);
 
-        preaction("assignment", bitwise_check);
-        preaction("binary", bitwise_check);
-        preaction("binary", function (thing) {
-            if (relationop[thing.id] === true) {
-                const left = thing.expression[0];
-                const right = thing.expression[1];
-                if (left.id === "NaN" || right.id === "NaN") {
+    preaction("assignment", bitwise_check);
+    preaction("binary", bitwise_check);
+    preaction("binary", function (thing) {
+        if (relationop[thing.id] === true) {
+            const left = thing.expression[0];
+            const right = thing.expression[1];
+            if (left.id === "NaN" || right.id === "NaN") {
 
 // cause: "NaN===NaN"
 
-                    warn("number_isNaN", thing);
-                } else if (left.id === "typeof") {
-                    if (right.id !== "(string)") {
-                        if (right.id !== "typeof") {
+                warn("number_isNaN", thing);
+            } else if (left.id === "typeof") {
+                if (right.id !== "(string)") {
+                    if (right.id !== "typeof") {
 
 // cause: "typeof 0===0"
 
-                            warn("expected_string_a", right);
-                        }
-                    } else {
-                        const value = right.value;
-                        if (value === "null" || value === "undefined") {
+                        warn("expected_string_a", right);
+                    }
+                } else {
+                    const value = right.value;
+                    if (value === "null" || value === "undefined") {
 
 // cause: "typeof aa===\"undefined\""
 
-                            warn("unexpected_typeof_a", right, value);
-                        } else if (
-                            value !== "boolean"
-                            && value !== "function"
-                            && value !== "number"
-                            && value !== "object"
-                            && value !== "string"
-                            && value !== "symbol"
-                        ) {
+                        warn("unexpected_typeof_a", right, value);
+                    } else if (
+                        value !== "boolean"
+                        && value !== "function"
+                        && value !== "number"
+                        && value !== "object"
+                        && value !== "string"
+                        && value !== "symbol"
+                    ) {
 
 // cause: "typeof 0===\"aa\""
 
-                            warn("expected_type_string_a", right, value);
-                        }
+                        warn("expected_type_string_a", right, value);
                     }
                 }
             }
-        });
-        preaction("binary", "==", function (thing) {
+        }
+    });
+    preaction("binary", "==", function (thing) {
 
 // cause: "0==0"
 
-            warn("expected_a_b", thing, "===", "==");
-        });
-        preaction("binary", "!=", function (thing) {
+        warn("expected_a_b", thing, "===", "==");
+    });
+    preaction("binary", "!=", function (thing) {
 
 // cause: "0!=0"
 
-            warn("expected_a_b", thing, "!==", "!=");
-        });
-        preaction("binary", "=>", preaction_function);
-        preaction("binary", "||", function (thing) {
-            thing.expression.forEach(function (thang) {
-                if (thang.id === "&&" && !thang.wrapped) {
+        warn("expected_a_b", thing, "!==", "!=");
+    });
+    preaction("binary", "=>", preaction_function);
+    preaction("binary", "||", function (thing) {
+        thing.expression.forEach(function (thang) {
+            if (thang.id === "&&" && !thang.wrapped) {
 
 // cause: "0&&0||0"
 
-                    warn("and", thang);
-                }
-            });
-        });
-        preaction("binary", "(", function (thing) {
-            const left = thing.expression[0];
-            if (
-                left.identifier
-                && functionage.context[left.id] === undefined
-                && typeof functionage.name === "object"
-            ) {
-                const parent = functionage.name.parent;
-                if (parent) {
-                    const left_variable = parent.context[left.id];
-                    if (
-                        left_variable !== undefined
-                        && left_variable.dead
-                        && left_variable.parent === parent
-                        && left_variable.calls !== undefined
-                        && left_variable.calls[functionage.name.id]
-                        !== undefined
-                    ) {
-                        left_variable.dead = false;
-                    }
-                }
+                warn("and", thang);
             }
         });
-        preaction("binary", "in", function (thing) {
+    });
+    preaction("binary", "(", function (thing) {
+        const left = thing.expression[0];
+        if (
+            left.identifier
+            && functionage.context[left.id] === undefined
+            && typeof functionage.name === "object"
+        ) {
+            const parent = functionage.name.parent;
+            if (parent) {
+                const left_variable = parent.context[left.id];
+                if (
+                    left_variable !== undefined
+                    && left_variable.dead
+                    && left_variable.parent === parent
+                    && left_variable.calls !== undefined
+                    && left_variable.calls[functionage.name.id]
+                    !== undefined
+                ) {
+                    left_variable.dead = false;
+                }
+            }
+        }
+    });
+    preaction("binary", "in", function (thing) {
 
 // cause: "aa in aa"
 
-            warn("infix_in", thing);
-        });
-        preaction("binary", "instanceof", function (thing) {
+        warn("infix_in", thing);
+    });
+    preaction("binary", "instanceof", function (thing) {
 
 // cause: "0 instanceof 0"
 
-            warn("unexpected_a", thing);
-        });
-        preaction("statement", "{", function (thing) {
-            block_stack.push(blockage);
-            blockage = thing;
-            thing.live = [];
-        });
-        preaction("statement", "for", function (thing) {
-            if (thing.name !== undefined) {
-                const the_variable = lookup(thing.name);
-                if (the_variable !== undefined) {
-                    the_variable.init = true;
-                    if (!the_variable.writable) {
+        warn("unexpected_a", thing);
+    });
+    preaction("statement", "{", function (thing) {
+        block_stack.push(blockage);
+        blockage = thing;
+        thing.live = [];
+    });
+    preaction("statement", "for", function (thing) {
+        if (thing.name !== undefined) {
+            const the_variable = lookup(thing.name);
+            if (the_variable !== undefined) {
+                the_variable.init = true;
+                if (!the_variable.writable) {
 
 // cause: "const aa=0;for(aa in aa){}"
 
-                        warn("bad_assignment_a", thing.name);
-                    }
+                    warn("bad_assignment_a", thing.name);
                 }
             }
-            walk_statement(thing.initial);
-        });
-        preaction("statement", "function", preaction_function);
-        preaction("statement", "try", function (thing) {
-            if (thing.catch !== undefined) {
+        }
+        walk_statement(thing.initial);
+    });
+    preaction("statement", "function", preaction_function);
+    preaction("statement", "try", function (thing) {
+        if (thing.catch !== undefined) {
 
 // Create new function-scope for catch-parameter.
 
-                function_stack.push(functionage);
-                functionage = thing.catch;
-            }
-        });
-        preaction("unary", "~", bitwise_check);
-        preaction("unary", "function", preaction_function);
-        preaction("variable", function (thing) {
-            const the_variable = lookup(thing);
-            if (the_variable !== undefined) {
-                thing.variable = the_variable;
-                the_variable.used += 1;
-            }
-        });
+            function_stack.push(functionage);
+            functionage = thing.catch;
+        }
+    });
+    preaction("unary", "~", bitwise_check);
+    preaction("unary", "function", preaction_function);
+    preaction("variable", function (thing) {
+        const the_variable = lookup(thing);
+        if (the_variable !== undefined) {
+            thing.variable = the_variable;
+            the_variable.used += 1;
+        }
+    });
 
-        postaction("assignment", "+=", function (thing) {
-            let right = thing.expression[1];
-            if (right.constant) {
-                if (
-                    right.value === ""
-                    || (right.id === "(number)" && right.value === "0")
-                    || right.id === "(boolean)"
-                    || right.id === "null"
-                    || right.id === "undefined"
-                    || Number.isNaN(right.value)
-                ) {
-                    warn("unexpected_a", right);
-                }
+    postaction("assignment", "+=", function (thing) {
+        let right = thing.expression[1];
+        if (right.constant) {
+            if (
+                right.value === ""
+                || (right.id === "(number)" && right.value === "0")
+                || right.id === "(boolean)"
+                || right.id === "null"
+                || right.id === "undefined"
+                || Number.isNaN(right.value)
+            ) {
+                warn("unexpected_a", right);
             }
-        });
-        postaction("assignment", function (thing) {
+        }
+    });
+    postaction("assignment", function (thing) {
 
 // Assignment using = sets the init property of a variable. No other assignment
 // operator can do this. A = token keeps that variable (or array of variables
 // in case of destructuring) in its name property.
 
-            const lvalue = thing.expression[0];
-            if (thing.id === "=") {
-                if (thing.names !== undefined) {
+        const lvalue = thing.expression[0];
+        if (thing.id === "=") {
+            if (thing.names !== undefined) {
 
 // cause: "if(0){aa=0}"
 
-                    assert_or_throw(
-                        !Array.isArray(thing.names),
-                        `Expected !Array.isArray(thing.names).`
-                    );
+                assert_or_throw(
+                    !Array.isArray(thing.names),
+                    `Expected !Array.isArray(thing.names).`
+                );
 //          Probably deadcode.
 //          if (Array.isArray(thing.names)) {
 //              thing.names.forEach(init_variable);
 //          } else {
 //              init_variable(thing.names);
 //          }
-                    init_variable(thing.names);
-                } else {
-                    if (lvalue.id === "[" || lvalue.id === "{") {
-                        lvalue.expression.forEach(function (thing) {
-                            if (thing.variable) {
-                                thing.variable.init = true;
-                            }
-                        });
-                    } else if (
-                        lvalue.id === "."
-                        && thing.expression[1].id === "undefined"
-                    ) {
+                init_variable(thing.names);
+            } else {
+                if (lvalue.id === "[" || lvalue.id === "{") {
+                    lvalue.expression.forEach(function (thing) {
+                        if (thing.variable) {
+                            thing.variable.init = true;
+                        }
+                    });
+                } else if (
+                    lvalue.id === "."
+                    && thing.expression[1].id === "undefined"
+                ) {
 
 // cause: "aa.aa=undefined"
 
-                        warn(
-                            "expected_a_b",
-                            lvalue.expression,
-                            "delete",
-                            "undefined"
-                        );
-                    }
+                    warn(
+                        "expected_a_b",
+                        lvalue.expression,
+                        "delete",
+                        "undefined"
+                    );
                 }
-            } else {
-                if (lvalue.arity === "variable") {
-                    if (!lvalue.variable || lvalue.variable.writable !== true) {
-                        warn("bad_assignment_a", lvalue);
-                    }
+            }
+        } else {
+            if (lvalue.arity === "variable") {
+                if (!lvalue.variable || lvalue.variable.writable !== true) {
+                    warn("bad_assignment_a", lvalue);
                 }
-                const right = syntax_object[thing.expression[1].id];
-                if (
-                    right !== undefined
-                    && (
-                        right.id === "function"
-                        || right.id === "=>"
-                        || (
-                            right.constant
-                            && right.id !== "(number)"
-                            && (right.id !== "(string)" || thing.id !== "+=")
-                        )
+            }
+            const right = syntax_dict[thing.expression[1].id];
+            if (
+                right !== undefined
+                && (
+                    right.id === "function"
+                    || right.id === "=>"
+                    || (
+                        right.constant
+                        && right.id !== "(number)"
+                        && (right.id !== "(string)" || thing.id !== "+=")
                     )
-                ) {
+                )
+            ) {
 
 // cause: "aa+=undefined"
 
-                    warn("unexpected_a", thing.expression[1]);
-                }
+                warn("unexpected_a", thing.expression[1]);
             }
-        });
+        }
+    });
 
-        postaction("binary", function (thing) {
-            let right;
-            if (relationop[thing.id]) {
-                if (
-                    is_weird(thing.expression[0])
-                    || is_weird(thing.expression[1])
-                    || are_similar(thing.expression[0], thing.expression[1])
-                    || (
-                        thing.expression[0].constant === true
-                        && thing.expression[1].constant === true
-                    )
-                ) {
+    postaction("binary", function (thing) {
+        let right;
+        if (relationop[thing.id]) {
+            if (
+                is_weird(thing.expression[0])
+                || is_weird(thing.expression[1])
+                || are_similar(thing.expression[0], thing.expression[1])
+                || (
+                    thing.expression[0].constant === true
+                    && thing.expression[1].constant === true
+                )
+            ) {
 
 // cause: "if(0===0){0}"
 
-                    warn("weird_relation_a", thing);
-                }
+                warn("weird_relation_a", thing);
             }
-            if (thing.id === "+") {
-                if (!option_object.convert) {
-                    if (thing.expression[0].value === "") {
+        }
+        if (thing.id === "+") {
+            if (!option_dict.convert) {
+                if (thing.expression[0].value === "") {
 
 // cause: "\"\"+0"
 
-                        warn("expected_a_b", thing, "String(...)", "\"\" +");
-                    } else if (thing.expression[1].value === "") {
+                    warn("expected_a_b", thing, "String(...)", "\"\" +");
+                } else if (thing.expression[1].value === "") {
 
 // cause: "0+\"\""
 
-                        warn("expected_a_b", thing, "String(...)", "+ \"\"");
-                    }
+                    warn("expected_a_b", thing, "String(...)", "+ \"\"");
                 }
-            } else if (thing.id === "[") {
-                if (thing.expression[0].id === "window") {
+            }
+        } else if (thing.id === "[") {
+            if (thing.expression[0].id === "window") {
 
 // cause: "aa=window[0]"
 
-                    warn("weird_expression_a", thing, "window[...]");
-                }
-                if (thing.expression[0].id === "self") {
+                warn("weird_expression_a", thing, "window[...]");
+            }
+            if (thing.expression[0].id === "self") {
 
 // cause: "aa=self[0]"
 
-                    warn("weird_expression_a", thing, "self[...]");
-                }
-            } else if (thing.id === "." || thing.id === "?.") {
-                if (thing.expression.id === "RegExp") {
+                warn("weird_expression_a", thing, "self[...]");
+            }
+        } else if (thing.id === "." || thing.id === "?.") {
+            if (thing.expression.id === "RegExp") {
 
 // cause: "aa=RegExp.aa"
 
-                    warn("weird_expression_a", thing);
-                }
-            } else if (thing.id !== "=>" && thing.id !== "(") {
-                right = thing.expression[1];
-                if (
-                    (thing.id === "+" || thing.id === "-")
-                    && right.id === thing.id
-                    && right.arity === "unary"
-                    && !right.wrapped
-                ) {
+                warn("weird_expression_a", thing);
+            }
+        } else if (thing.id !== "=>" && thing.id !== "(") {
+            right = thing.expression[1];
+            if (
+                (thing.id === "+" || thing.id === "-")
+                && right.id === thing.id
+                && right.arity === "unary"
+                && !right.wrapped
+            ) {
 
 // cause: "0- -0"
 
-                    warn("wrap_unary", right);
-                }
-                if (
-                    thing.expression[0].constant === true
-                    && right.constant === true
-                ) {
-                    thing.constant = true;
-                }
+                warn("wrap_unary", right);
             }
-        });
-        postaction("binary", "&&", function (thing) {
             if (
-                is_weird(thing.expression[0])
-                || are_similar(thing.expression[0], thing.expression[1])
-                || thing.expression[0].constant === true
-                || thing.expression[1].constant === true
+                thing.expression[0].constant === true
+                && right.constant === true
             ) {
+                thing.constant = true;
+            }
+        }
+    });
+    postaction("binary", "&&", function (thing) {
+        if (
+            is_weird(thing.expression[0])
+            || are_similar(thing.expression[0], thing.expression[1])
+            || thing.expression[0].constant === true
+            || thing.expression[1].constant === true
+        ) {
 
 // cause: "aa=(``?``:``)&&(``?``:``)"
 // cause: "aa=0&&0"
 // cause: "aa=`${0}`&&`${0}`"
 
-                warn("weird_condition_a", thing);
-            }
-        });
-        postaction("binary", "||", function (thing) {
-            if (
-                is_weird(thing.expression[0])
-                || are_similar(thing.expression[0], thing.expression[1])
-                || thing.expression[0].constant === true
-            ) {
+            warn("weird_condition_a", thing);
+        }
+    });
+    postaction("binary", "||", function (thing) {
+        if (
+            is_weird(thing.expression[0])
+            || are_similar(thing.expression[0], thing.expression[1])
+            || thing.expression[0].constant === true
+        ) {
 
 // cause: "aa=0||0"
 
-                warn("weird_condition_a", thing);
-            }
-        });
-        postaction("binary", "=>", postaction_function);
-        postaction("binary", "(", function (thing) {
-            let left = thing.expression[0];
-            let the_new;
-            let arg;
-            if (left.id === "new") {
-                the_new = left;
-                left = left.expression;
-            }
-            if (left.id === "function") {
-                if (!thing.wrapped) {
+            warn("weird_condition_a", thing);
+        }
+    });
+    postaction("binary", "=>", postaction_function);
+    postaction("binary", "(", function (thing) {
+        let left = thing.expression[0];
+        let the_new;
+        let arg;
+        if (left.id === "new") {
+            the_new = left;
+            left = left.expression;
+        }
+        if (left.id === "function") {
+            if (!thing.wrapped) {
 
 // cause: "aa=function(){}()"
 
-                    warn("wrap_immediate", thing);
-                }
-            } else if (left.identifier) {
-                if (the_new !== undefined) {
-                    if (
-                        left.id[0] > "Z"
-                        || left.id === "Boolean"
-                        || left.id === "Number"
-                        || left.id === "String"
-                        || left.id === "Symbol"
-                    ) {
+                warn("wrap_immediate", thing);
+            }
+        } else if (left.identifier) {
+            if (the_new !== undefined) {
+                if (
+                    left.id[0] > "Z"
+                    || left.id === "Boolean"
+                    || left.id === "Number"
+                    || left.id === "String"
+                    || left.id === "Symbol"
+                ) {
 
 // cause: "new Boolean()"
 // cause: "new Number()"
@@ -5604,263 +5583,263 @@ function jslint(
 // cause: "new Symbol()"
 // cause: "new aa()"
 
-                        warn("unexpected_a", the_new);
-                    } else if (left.id === "Function") {
-                        if (!option_object.eval) {
+                    warn("unexpected_a", the_new);
+                } else if (left.id === "Function") {
+                    if (!option_dict.eval) {
 
 // cause: "new Function()"
 
-                            warn("unexpected_a", left, "new Function");
-                        }
-                    } else if (left.id === "Array") {
-                        arg = thing.expression;
-                        if (arg.length !== 2 || arg[1].id === "(string)") {
+                        warn("unexpected_a", left, "new Function");
+                    }
+                } else if (left.id === "Array") {
+                    arg = thing.expression;
+                    if (arg.length !== 2 || arg[1].id === "(string)") {
 
 // cause: "new Array()"
 
-                            warn("expected_a_b", left, "[]", "new Array");
-                        }
-                    } else if (left.id === "Object") {
+                        warn("expected_a_b", left, "[]", "new Array");
+                    }
+                } else if (left.id === "Object") {
 
 // cause: "new Object()"
 
-                        warn(
-                            "expected_a_b",
-                            left,
-                            "Object.create(null)",
-                            "new Object"
-                        );
-                    }
-                } else {
-                    if (
-                        left.id[0] >= "A"
-                        && left.id[0] <= "Z"
-                        && left.id !== "Boolean"
-                        && left.id !== "Number"
-                        && left.id !== "String"
-                        && left.id !== "Symbol"
-                    ) {
+                    warn(
+                        "expected_a_b",
+                        left,
+                        "Object.create(null)",
+                        "new Object"
+                    );
+                }
+            } else {
+                if (
+                    left.id[0] >= "A"
+                    && left.id[0] <= "Z"
+                    && left.id !== "Boolean"
+                    && left.id !== "Number"
+                    && left.id !== "String"
+                    && left.id !== "Symbol"
+                ) {
 
 // cause: "let Aa=Aa()"
 
-                        warn(
-                            "expected_a_before_b",
-                            left,
-                            "new",
-                            artifact(left)
-                        );
-                    }
+                    warn(
+                        "expected_a_before_b",
+                        left,
+                        "new",
+                        artifact(left)
+                    );
                 }
-            } else if (left.id === ".") {
-                let cack = the_new !== undefined;
-                if (left.expression.id === "Date" && left.name.id === "UTC") {
+            }
+        } else if (left.id === ".") {
+            let cack = the_new !== undefined;
+            if (left.expression.id === "Date" && left.name.id === "UTC") {
 
 // cause: "new Date.UTC()"
 
-                    cack = !cack;
-                }
-                if (rx_cap.test(left.name.id) !== cack) {
-                    if (the_new !== undefined) {
+                cack = !cack;
+            }
+            if (rx_cap.test(left.name.id) !== cack) {
+                if (the_new !== undefined) {
 
 // cause: "new Date.UTC()"
 
-                        warn("unexpected_a", the_new);
-                    } else {
+                    warn("unexpected_a", the_new);
+                } else {
 
 // cause: "let Aa=Aa.Aa()"
 
-                        warn(
-                            "expected_a_before_b",
-                            left.expression,
-                            "new",
-                            left.name.id
-                        );
-                    }
+                    warn(
+                        "expected_a_before_b",
+                        left.expression,
+                        "new",
+                        left.name.id
+                    );
                 }
-                if (left.name.id === "getTime") {
-                    const paren = left.expression;
-                    if (paren.id === "(") {
-                        const array = paren.expression;
-                        if (array.length === 1) {
-                            const new_date = array[0];
-                            if (
-                                new_date.id === "new"
-                                && new_date.expression.id === "Date"
-                            ) {
+            }
+            if (left.name.id === "getTime") {
+                const paren = left.expression;
+                if (paren.id === "(") {
+                    const array = paren.expression;
+                    if (array.length === 1) {
+                        const new_date = array[0];
+                        if (
+                            new_date.id === "new"
+                            && new_date.expression.id === "Date"
+                        ) {
 
 // cause: "new Date().getTime()"
 
-                                warn(
-                                    "expected_a_b",
-                                    new_date,
-                                    "Date.now()",
-                                    "new Date().getTime()"
-                                );
-                            }
+                            warn(
+                                "expected_a_b",
+                                new_date,
+                                "Date.now()",
+                                "new Date().getTime()"
+                            );
                         }
                     }
                 }
             }
-        });
-        postaction("binary", "[", function (thing) {
-            if (thing.expression[0].id === "RegExp") {
+        }
+    });
+    postaction("binary", "[", function (thing) {
+        if (thing.expression[0].id === "RegExp") {
 
 // cause: "aa=RegExp[0]"
 
-                warn("weird_expression_a", thing);
-            }
-            if (is_weird(thing.expression[1])) {
+            warn("weird_expression_a", thing);
+        }
+        if (is_weird(thing.expression[1])) {
 
 // cause: "aa[[0]]"
 
-                warn("weird_expression_a", thing.expression[1]);
-            }
-        });
-        postaction("statement", "{", pop_block);
-        postaction("statement", "const", action_var);
-        postaction("statement", "export", top_level_only);
-        postaction("statement", "for", function (thing) {
-            walk_statement(thing.inc);
-        });
-        postaction("statement", "function", postaction_function);
-        postaction("statement", "import", function (the_thing) {
-            const name = the_thing.name;
-            if (name) {
-                if (Array.isArray(name)) {
-                    name.forEach(function (name) {
-                        name.dead = false;
-                        name.init = true;
-                        blockage.live.push(name);
-                    });
-                } else {
+            warn("weird_expression_a", thing.expression[1]);
+        }
+    });
+    postaction("statement", "{", pop_block);
+    postaction("statement", "const", action_var);
+    postaction("statement", "export", top_level_only);
+    postaction("statement", "for", function (thing) {
+        walk_statement(thing.inc);
+    });
+    postaction("statement", "function", postaction_function);
+    postaction("statement", "import", function (the_thing) {
+        const name = the_thing.name;
+        if (name) {
+            if (Array.isArray(name)) {
+                name.forEach(function (name) {
                     name.dead = false;
                     name.init = true;
                     blockage.live.push(name);
-                }
-                return top_level_only(the_thing);
+                });
+            } else {
+                name.dead = false;
+                name.init = true;
+                blockage.live.push(name);
             }
-        });
-        postaction("statement", "let", action_var);
-        postaction("statement", "try", function (thing) {
-            if (thing.catch !== undefined) {
-                const the_name = thing.catch.name;
-                if (the_name !== undefined) {
-                    const the_variable = functionage.context[the_name.id];
-                    the_variable.dead = false;
-                    the_variable.init = true;
-                }
-                walk_statement(thing.catch.block);
+            return top_level_only(the_thing);
+        }
+    });
+    postaction("statement", "let", action_var);
+    postaction("statement", "try", function (thing) {
+        if (thing.catch !== undefined) {
+            const the_name = thing.catch.name;
+            if (the_name !== undefined) {
+                const the_variable = functionage.context[the_name.id];
+                the_variable.dead = false;
+                the_variable.init = true;
+            }
+            walk_statement(thing.catch.block);
 
 // Restore previous function-scope after catch-block.
 
-                functionage = function_stack.pop();
-            }
-        });
-        postaction("statement", "var", action_var);
-        postaction("ternary", function (thing) {
-            if (
-                is_weird(thing.expression[0])
-                || thing.expression[0].constant === true
-                || are_similar(thing.expression[1], thing.expression[2])
-            ) {
-                warn("unexpected_a", thing);
-            } else if (are_similar(thing.expression[0], thing.expression[1])) {
+            functionage = function_stack.pop();
+        }
+    });
+    postaction("statement", "var", action_var);
+    postaction("ternary", function (thing) {
+        if (
+            is_weird(thing.expression[0])
+            || thing.expression[0].constant === true
+            || are_similar(thing.expression[1], thing.expression[2])
+        ) {
+            warn("unexpected_a", thing);
+        } else if (are_similar(thing.expression[0], thing.expression[1])) {
 
 // cause: "aa?aa:0"
 
-                warn("expected_a_b", thing, "||", "?");
-            } else if (are_similar(thing.expression[0], thing.expression[2])) {
+            warn("expected_a_b", thing, "||", "?");
+        } else if (are_similar(thing.expression[0], thing.expression[2])) {
 
 // cause: "aa?0:aa"
 
-                warn("expected_a_b", thing, "&&", "?");
-            } else if (
-                thing.expression[1].id === "true"
-                && thing.expression[2].id === "false"
-            ) {
+            warn("expected_a_b", thing, "&&", "?");
+        } else if (
+            thing.expression[1].id === "true"
+            && thing.expression[2].id === "false"
+        ) {
 
 // cause: "aa?true:false"
 
-                warn("expected_a_b", thing, "!!", "?");
-            } else if (
-                thing.expression[1].id === "false"
-                && thing.expression[2].id === "true"
-            ) {
+            warn("expected_a_b", thing, "!!", "?");
+        } else if (
+            thing.expression[1].id === "false"
+            && thing.expression[2].id === "true"
+        ) {
 
 // cause: "aa?false:true"
 
-                warn("expected_a_b", thing, "!", "?");
-            } else if (
-                thing.expression[0].wrapped !== true
-                && (
-                    thing.expression[0].id === "||"
-                    || thing.expression[0].id === "&&"
-                )
-            ) {
+            warn("expected_a_b", thing, "!", "?");
+        } else if (
+            thing.expression[0].wrapped !== true
+            && (
+                thing.expression[0].id === "||"
+                || thing.expression[0].id === "&&"
+            )
+        ) {
 
 // cause: "(aa&&!aa?0:1)"
 
-                warn("wrap_condition", thing.expression[0]);
+            warn("wrap_condition", thing.expression[0]);
+        }
+    });
+    postaction("unary", function (thing) {
+        if (thing.id === "`") {
+            if (thing.expression.every(function (thing) {
+                return thing.constant;
+            })) {
+                thing.constant = true;
             }
-        });
-        postaction("unary", function (thing) {
-            if (thing.id === "`") {
-                if (thing.expression.every(function (thing) {
-                    return thing.constant;
-                })) {
-                    thing.constant = true;
-                }
-            } else if (thing.id === "!") {
-                if (thing.expression.constant === true) {
-                    warn("unexpected_a", thing);
-                }
-            } else if (thing.id === "!!") {
-                if (!option_object.convert) {
+        } else if (thing.id === "!") {
+            if (thing.expression.constant === true) {
+                warn("unexpected_a", thing);
+            }
+        } else if (thing.id === "!!") {
+            if (!option_dict.convert) {
 
 // cause: "!!0"
 
-                    warn("expected_a_b", thing, "Boolean(...)", "!!");
-                }
-            } else if (
-                thing.id !== "["
-                && thing.id !== "{"
-                && thing.id !== "function"
-                && thing.id !== "new"
-            ) {
-                if (thing.expression.constant === true) {
-                    thing.constant = true;
-                }
+                warn("expected_a_b", thing, "Boolean(...)", "!!");
             }
-        });
-        postaction("unary", "function", postaction_function);
-        postaction("unary", "+", function (thing) {
-            const right = thing.expression;
-            if (!option_object.convert) {
+        } else if (
+            thing.id !== "["
+            && thing.id !== "{"
+            && thing.id !== "function"
+            && thing.id !== "new"
+        ) {
+            if (thing.expression.constant === true) {
+                thing.constant = true;
+            }
+        }
+    });
+    postaction("unary", "function", postaction_function);
+    postaction("unary", "+", function (thing) {
+        const right = thing.expression;
+        if (!option_dict.convert) {
 
 // cause: "aa=+0"
 
-                warn("expected_a_b", thing, "Number(...)", "+");
-            }
-            if (right.id === "(" && right.expression[0].id === "new") {
-                warn("unexpected_a_before_b", thing, "+", "new");
-            } else if (
-                right.constant
-                || right.id === "{"
-                || (right.id === "[" && right.arity !== "binary")
-            ) {
-                warn("unexpected_a", thing, "+");
-            }
-        });
+            warn("expected_a_b", thing, "Number(...)", "+");
+        }
+        if (right.id === "(" && right.expression[0].id === "new") {
+            warn("unexpected_a_before_b", thing, "+", "new");
+        } else if (
+            right.constant
+            || right.id === "{"
+            || (right.id === "[" && right.arity !== "binary")
+        ) {
+            warn("unexpected_a", thing, "+");
+        }
+    });
 
-        walk_statement(token_tree);
-    }
+    walk_statement(token_tree);
+}
 
 
-    function phase5_whitage() {
+function phase5_whitage() {
 
-// PHASE 5. Check whitespace between tokens in <token_array>.
+// PHASE 5. Check whitespace between tokens in <token_list>.
 
-        let closer = "(end)";
+    let closer = "(end)";
 
 // free = false
 
@@ -5869,7 +5848,7 @@ function jslint(
 // cause: "aa(0,0)"
 // cause: "function(){}"
 
-        let free = false;
+    let free = false;
 
 // cause: "(0)"
 // cause: "(aa)"
@@ -5880,102 +5859,102 @@ function jslint(
 // cause: "switch(){}"
 // cause: "while(){}"
 
-        // let free = true;
+    // let free = true;
 
-        let left = global;
-        let margin = 0;
-        let nr_comments_skipped = 0;
-        let open = true;
-        let opening = true;
-        let right;
+    let left = token_global;
+    let margin = 0;
+    let nr_comments_skipped = 0;
+    let open = true;
+    let opening = true;
+    let right;
 
-        function expected_at(at) {
-            assert_or_throw(
-                !(right === undefined),
-                `Expected !(right === undefined).`
-            );
+    function expected_at(at) {
+        assert_or_throw(
+            !(right === undefined),
+            `Expected !(right === undefined).`
+        );
 //      Probably deadcode.
 //      if (right === undefined) {
 //          right = token_nxt;
 //      }
-            warn(
-                "expected_a_at_b_c",
-                right,
-                artifact(right),
+        warn(
+            "expected_a_at_b_c",
+            right,
+            artifact(right),
 
 // Fudge column numbers in warning message.
 
-                at + line_fudge,
-                right.from + line_fudge
-            );
-        }
+            at + line_fudge,
+            right.from + line_fudge
+        );
+    }
 
-        function at_margin(fit) {
-            const at = margin + fit;
-            if (right.from !== at) {
-                return expected_at(at);
-            }
+    function at_margin(fit) {
+        const at = margin + fit;
+        if (right.from !== at) {
+            return expected_at(at);
         }
+    }
 
-        function delve(the_function) {
-            Object.keys(the_function.context).forEach(function (id) {
-                if (id !== "ignore") {
-                    const name = the_function.context[id];
-                    if (name.parent === the_function) {
+    function delve(the_function) {
+        Object.keys(the_function.context).forEach(function (id) {
+            if (id !== "ignore") {
+                const name = the_function.context[id];
+                if (name.parent === the_function) {
 
 // cause: "let aa=function bb(){return;};"
 
-                        if (
-                            name.used === 0
-                            && assert_or_throw(
-                                name.role !== "function",
-                                `Expected name.role !== "function".`
-                            )
+                    if (
+                        name.used === 0
+                        && assert_or_throw(
+                            name.role !== "function",
+                            `Expected name.role !== "function".`
+                        )
 //                  Probably deadcode.
 //                  && (
 //                      name.role !== "function"
 //                      || name.parent.arity !== "unary"
 //                  )
-                        ) {
+                    ) {
 
 // cause: "/*jslint node*/\nlet aa;"
 // cause: "function aa(aa){return;}"
 
-                            warn("unused_a", name);
-                        } else if (!name.init) {
+                        warn("unused_a", name);
+                    } else if (!name.init) {
 
 // cause: "/*jslint node*/\nlet aa;aa();"
 
-                            warn("uninitialized_a", name);
-                        }
+                        warn("uninitialized_a", name);
                     }
                 }
+            }
 
 // cause: "function aa(ignore){return;}"
 
-            });
-        }
+        });
+    }
 
-        function no_space() {
-            if (left.line === right.line) {
+    function no_space() {
+        if (left.line === right.line) {
 
 // from:
 //                  if (left.line === right.line) {
 //                      no_space();
 //                  } else {
 
-                if (left.thru !== right.from && nr_comments_skipped === 0) {
+            if (left.thru !== right.from && nr_comments_skipped === 0) {
 
 // cause: "let aa = aa( );"
 
-                    warn(
-                        "unexpected_space_a_b",
-                        right,
-                        artifact(left),
-                        artifact(right)
-                    );
-                }
-            } else {
+                warn(
+                    "unexpected_space_a_b",
+                    right,
+                    artifact(left),
+                    artifact(right)
+                );
+            }
+        } else {
 
 // from:
 //                  } else if (
@@ -5986,8 +5965,8 @@ function jslint(
 //                      no_space();
 //                  } else if (
 
-                assert_or_throw(open, `Expected open.`);
-                assert_or_throw(free, `Expected free.`);
+            assert_or_throw(open, `Expected open.`);
+            assert_or_throw(free, `Expected free.`);
 //          Probably deadcode.
 //          if (open) {
 //              const at = (
@@ -6003,7 +5982,7 @@ function jslint(
 //                  expected_at(margin + 8);
 //              }
 //          }
-                if (right.from < margin) {
+            if (right.from < margin) {
 
 // cause:
 // let aa = aa(
@@ -6011,48 +5990,32 @@ function jslint(
 // ()
 // );
 
-                    expected_at(margin);
-                }
+                expected_at(margin);
             }
         }
+    }
 
-        function no_space_only() {
-            if (
-                left.id !== "(global)"
-                && left.nr + 1 === right.nr
-                && (
-                    left.line !== right.line
-                    || left.thru !== right.from
-                )
-            ) {
-                warn(
-                    "unexpected_space_a_b",
-                    right,
-                    artifact(left),
-                    artifact(right)
-                );
-            }
+    function no_space_only() {
+        if (
+            left.id !== "(global)"
+            && left.nr + 1 === right.nr
+            && (
+                left.line !== right.line
+                || left.thru !== right.from
+            )
+        ) {
+            warn(
+                "unexpected_space_a_b",
+                right,
+                artifact(left),
+                artifact(right)
+            );
         }
+    }
 
-        function one_space() {
-            if (left.line === right.line || !open) {
-                if (left.thru + 1 !== right.from && nr_comments_skipped === 0) {
-                    warn(
-                        "expected_space_a_b",
-                        right,
-                        artifact(left),
-                        artifact(right)
-                    );
-                }
-            } else {
-                if (right.from !== margin) {
-                    expected_at(margin);
-                }
-            }
-        }
-
-        function one_space_only() {
-            if (left.line !== right.line || left.thru + 1 !== right.from) {
+    function one_space() {
+        if (left.line === right.line || !open) {
+            if (left.thru + 1 !== right.from && nr_comments_skipped === 0) {
                 warn(
                     "expected_space_a_b",
                     right,
@@ -6060,50 +6023,66 @@ function jslint(
                     artifact(right)
                 );
             }
+        } else {
+            if (right.from !== margin) {
+                expected_at(margin);
+            }
         }
+    }
 
-        function pop() {
-            const previous = function_stack.pop();
-            closer = previous.closer;
-            free = previous.free;
-            margin = previous.margin;
-            open = previous.open;
-            opening = previous.opening;
+    function one_space_only() {
+        if (left.line !== right.line || left.thru + 1 !== right.from) {
+            warn(
+                "expected_space_a_b",
+                right,
+                artifact(left),
+                artifact(right)
+            );
         }
+    }
 
-        function push() {
-            function_stack.push({
-                closer,
-                free,
-                margin,
-                open,
-                opening
-            });
-        }
+    function pop() {
+        const previous = function_stack.pop();
+        closer = previous.closer;
+        free = previous.free;
+        margin = previous.margin;
+        open = previous.open;
+        opening = previous.opening;
+    }
+
+    function push() {
+        function_stack.push({
+            closer,
+            free,
+            margin,
+            open,
+            opening
+        });
+    }
 
 // Delve into the functions looking for variables that were not initialized
 // or used. If the file imports or exports, then its global object is also
 // delved.
 
 //      uninitialized_and_unused();
-        if (mode_module === true || option_object.node) {
-            delve(global);
-        }
-        function_array.forEach(delve);
+    if (mode_module === true || option_dict.node) {
+        delve(token_global);
+    }
+    function_list.forEach(delve);
 
-        if (option_object.white) {
-            return;
-        }
+    if (option_dict.white) {
+        return;
+    }
 
 // Go through the token list, looking at usage of whitespace.
 
 //      whitage();
-        function_stack = [];
-        token_array.forEach(function (the_token) {
-            right = the_token;
-            if (right.id === "(comment)" || right.id === "(end)") {
-                nr_comments_skipped += 1;
-            } else {
+    function_stack = [];
+    token_list.forEach(function (the_token) {
+        right = the_token;
+        if (right.id === "(comment)" || right.id === "(end)") {
+            nr_comments_skipped += 1;
+        } else {
 
 // If left is an opener and right is not the closer, then push the previous
 // state. If the token following the opener is on the next line, then this is
@@ -6114,27 +6093,27 @@ function jslint(
 
 // The open and close pairs.
 
-                switch (left.id) {
-                case "${":
-                case "(":
-                case "[":
-                case "{":
+            switch (left.id) {
+            case "${":
+            case "(":
+            case "[":
+            case "{":
 
 // cause: "let aa=("
 // cause: "let aa=["
 // cause: "let aa=`${"
 // cause: "let aa={"
 
-                    assert_or_throw(
-                        !(left.id + right.id === "${}"),
-                        "Expected !(left.id + right.id === \"${}\")."
-                    );
+                assert_or_throw(
+                    !(left.id + right.id === "${}"),
+                    "Expected !(left.id + right.id === \"${}\")."
+                );
 //                  Probably deadcode.
 //                  case "${}":
-                    switch (left.id + right.id) {
-                    case "()":
-                    case "[]":
-                    case "{}":
+                switch (left.id + right.id) {
+                case "()":
+                case "[]":
+                case "{}":
 
 // If left and right are opener and closer, then the placement of right depends
 // on the openness. Illegal pairs (like '{]') have already been detected.
@@ -6143,53 +6122,53 @@ function jslint(
 // cause: "let aa=aa();"
 // cause: "let aa={};"
 
-                        if (left.line === right.line) {
+                    if (left.line === right.line) {
 
 // cause: "let aa = aa( );"
 
-                            no_space();
-                        } else {
+                        no_space();
+                    } else {
 
 // cause: "let aa = aa(\n );"
 
-                            at_margin(0);
-                        }
-                        break;
-                    default:
+                        at_margin(0);
+                    }
+                    break;
+                default:
 
 // cause: "let aa=(0"
 // cause: "let aa=[0"
 // cause: "let aa=`${0"
 // cause: "let aa={0"
 
-                        opening = left.open || (left.line !== right.line);
-                        push();
-                        switch (left.id) {
-                        case "${":
-                            closer = "}";
-                            break;
-                        case "(":
-                            closer = ")";
-                            break;
-                        case "[":
-                            closer = "]";
-                            break;
-                        case "{":
-                            closer = "}";
-                            break;
-                        }
-                        if (opening) {
+                    opening = left.open || (left.line !== right.line);
+                    push();
+                    switch (left.id) {
+                    case "${":
+                        closer = "}";
+                        break;
+                    case "(":
+                        closer = ")";
+                        break;
+                    case "[":
+                        closer = "]";
+                        break;
+                    case "{":
+                        closer = "}";
+                        break;
+                    }
+                    if (opening) {
 
 // cause: "function aa(){\nreturn;\n}"
 // cause: "let aa=(\n0\n)"
 // cause: "let aa=[\n0\n]"
 // cause: "let aa=`${\n0\n}`"
 
-                            free = closer === ")" && left.free;
-                            open = true;
-                            margin += 4;
-                            if (right.role === "label") {
-                                if (right.from !== 0) {
+                        free = closer === ")" && left.free;
+                        open = true;
+                        margin += 4;
+                        if (right.role === "label") {
+                            if (right.from !== 0) {
 
 // cause:
 // function aa() {
@@ -6201,15 +6180,15 @@ function jslint(
 //     }
 // }
 
-                                    expected_at(0);
-                                }
-                            } else if (right.switch) {
-                                at_margin(-4);
-                            } else {
-                                at_margin(0);
+                                expected_at(0);
                             }
+                        } else if (right.switch) {
+                            at_margin(-4);
                         } else {
-                            if (right.statement || right.role === "label") {
+                            at_margin(0);
+                        }
+                    } else {
+                        if (right.statement || right.role === "label") {
 
 // cause:
 // function aa() {bb:
@@ -6217,31 +6196,31 @@ function jslint(
 //     }
 // }
 
-                                warn(
-                                    "expected_line_break_a_b",
-                                    right,
-                                    artifact(left),
-                                    artifact(right)
-                                );
-                            }
+                            warn(
+                                "expected_line_break_a_b",
+                                right,
+                                artifact(left),
+                                artifact(right)
+                            );
+                        }
 
 // cause: "${0}"
 // cause: "(0)"
 // cause: "[0]"
 // cause: "{0}"
 
-                            free = false;
-                            open = false;
+                        free = false;
+                        open = false;
 
 // cause: "let aa = ( 0 );"
 
-                            no_space_only();
-                        }
+                        no_space_only();
                     }
-                    break;
-                default:
-                    if (right.statement === true) {
-                        if (left.id === "else") {
+                }
+                break;
+            default:
+                if (right.statement === true) {
+                    if (left.id === "else") {
 
 // cause:
 // let aa = 0;
@@ -6251,25 +6230,25 @@ function jslint(
 //     aa();
 // }
 
-                            one_space_only();
-                        } else {
+                        one_space_only();
+                    } else {
 
 // cause: " let aa = 0;"
 
-                            at_margin(0);
-                            open = false;
-                        }
+                        at_margin(0);
+                        open = false;
+                    }
 
 // If right is a closer, then pop the previous state.
 
-                    } else if (right.id === closer) {
-                        pop();
-                        if (opening && right.id !== ";") {
-                            at_margin(0);
-                        } else {
-                            no_space_only();
-                        }
+                } else if (right.id === closer) {
+                    pop();
+                    if (opening && right.id !== ";") {
+                        at_margin(0);
                     } else {
+                        no_space_only();
+                    }
+                } else {
 
 // Left is not an opener, and right is not a closer.
 // The nature of left and right will determine the space between them.
@@ -6277,10 +6256,10 @@ function jslint(
 // If left is ',' or ';' or right is a statement then if open,
 // right must go at the margin, or if closed, a space between.
 
-                        if (right.switch) {
-                            at_margin(-4);
-                        } else if (right.role === "label") {
-                            if (right.from !== 0) {
+                    if (right.switch) {
+                        at_margin(-4);
+                    } else if (right.role === "label") {
+                        if (right.from !== 0) {
 
 // cause:
 // function aa() {
@@ -6292,18 +6271,18 @@ function jslint(
 //     }
 // }
 
-                                expected_at(0);
-                            }
-                        } else if (left.id === ",") {
-                            if (!open || (
-                                (free || closer === "]")
-                                && left.line === right.line
-                            )) {
+                            expected_at(0);
+                        }
+                    } else if (left.id === ",") {
+                        if (!open || (
+                            (free || closer === "]")
+                            && left.line === right.line
+                        )) {
 
 // cause: "let {aa,bb} = 0;"
 
-                                one_space();
-                            } else {
+                            one_space();
+                        } else {
 
 // cause:
 // function aa() {
@@ -6312,13 +6291,13 @@ function jslint(
 //     );
 // }
 
-                                at_margin(0);
-                            }
+                            at_margin(0);
+                        }
 
 // If right is a ternary operator, line it up on the margin.
 
-                        } else if (right.arity === "ternary") {
-                            if (open) {
+                    } else if (right.arity === "ternary") {
+                        if (open) {
 
 // cause:
 // let aa = (
@@ -6327,18 +6306,18 @@ function jslint(
 // : 1
 // );
 
-                                at_margin(0);
-                            } else {
+                            at_margin(0);
+                        } else {
 
 // cause: "let aa = (aa ? 0 : 1);"
 
-                                warn("use_open", right);
-                            }
-                        } else if (
-                            right.arity === "binary"
-                            && right.id === "("
-                            && free
-                        ) {
+                            warn("use_open", right);
+                        }
+                    } else if (
+                        right.arity === "binary"
+                        && right.id === "("
+                        && free
+                    ) {
 
 // cause:
 // let aa = aa(
@@ -6346,33 +6325,33 @@ function jslint(
 // ()
 // );
 
-                            no_space();
-                        } else if (
-                            left.id === "."
-                            || left.id === "?."
-                            || left.id === "..."
-                            || right.id === ","
-                            || right.id === ";"
-                            || right.id === ":"
-                            || (
-                                right.arity === "binary"
-                                && (right.id === "(" || right.id === "[")
-                            )
-                            || (
-                                right.arity === "function"
-                                && left.id !== "function"
-                            )
-                        ) {
+                        no_space();
+                    } else if (
+                        left.id === "."
+                        || left.id === "?."
+                        || left.id === "..."
+                        || right.id === ","
+                        || right.id === ";"
+                        || right.id === ":"
+                        || (
+                            right.arity === "binary"
+                            && (right.id === "(" || right.id === "[")
+                        )
+                        || (
+                            right.arity === "function"
+                            && left.id !== "function"
+                        )
+                    ) {
 
 // cause: "let aa = 0 ;"
 
-                            no_space_only();
-                        } else if (right.id === "." || right.id === "?.") {
+                        no_space_only();
+                    } else if (right.id === "." || right.id === "?.") {
 
 // cause: "let aa = aa ?.aa;"
 
-                            no_space_only();
-                        } else if (left.id === ";") {
+                        no_space_only();
+                    } else if (left.id === ";") {
 
 // cause:
 // /*jslint for*/
@@ -6386,23 +6365,23 @@ function jslint(
 //     }
 // }
 
-                            if (open) {
-                                at_margin(0);
-                            }
-                        } else if (
-                            left.arity === "ternary"
-                            || left.id === "case"
-                            || left.id === "catch"
-                            || left.id === "else"
-                            || left.id === "finally"
-                            || left.id === "while"
-                            || left.id === "await"
-                            || right.id === "catch"
-                            || right.id === "else"
-                            || right.id === "finally"
-                            || (right.id === "while" && !right.statement)
-                            || (left.id === ")" && right.id === "{")
-                        ) {
+                        if (open) {
+                            at_margin(0);
+                        }
+                    } else if (
+                        left.arity === "ternary"
+                        || left.id === "case"
+                        || left.id === "catch"
+                        || left.id === "else"
+                        || left.id === "finally"
+                        || left.id === "while"
+                        || left.id === "await"
+                        || right.id === "catch"
+                        || right.id === "else"
+                        || right.id === "finally"
+                        || (right.id === "while" && !right.statement)
+                        || (left.id === ")" && right.id === "{")
+                    ) {
 
 // cause:
 // function aa() {
@@ -6411,37 +6390,37 @@ function jslint(
 //     } while(aa());
 // }
 
-                            one_space_only();
-                        } else if (
+                        one_space_only();
+                    } else if (
 
 // There is a space between left and right.
 
-                            spaceop[left.id] === true
-                            || spaceop[right.id] === true
-                            || (
-                                left.arity === "binary"
-                                && (left.id === "+" || left.id === "-")
+                        spaceop[left.id] === true
+                        || spaceop[right.id] === true
+                        || (
+                            left.arity === "binary"
+                            && (left.id === "+" || left.id === "-")
+                        )
+                        || (
+                            right.arity === "binary"
+                            && (right.id === "+" || right.id === "-")
+                        )
+                        || left.id === "function"
+                        || left.id === ":"
+                        || (
+                            (
+                                left.identifier
+                                || left.id === "(string)"
+                                || left.id === "(number)"
                             )
-                            || (
-                                right.arity === "binary"
-                                && (right.id === "+" || right.id === "-")
+                            && (
+                                right.identifier
+                                || right.id === "(string)"
+                                || right.id === "(number)"
                             )
-                            || left.id === "function"
-                            || left.id === ":"
-                            || (
-                                (
-                                    left.identifier
-                                    || left.id === "(string)"
-                                    || left.id === "(number)"
-                                )
-                                && (
-                                    right.identifier
-                                    || right.id === "(string)"
-                                    || right.id === "(number)"
-                                )
-                            )
-                            || (left.arity === "statement" && right.id !== ";")
-                        ) {
+                        )
+                        || (left.arity === "statement" && right.id !== ";")
+                    ) {
 
 // cause: "let aa=0;"
 // cause:
@@ -6450,23 +6429,73 @@ function jslint(
 // 0
 // };
 
-                            one_space();
-                        } else if (left.arity === "unary" && left.id !== "`") {
-                            no_space_only();
-                        }
+                        one_space();
+                    } else if (left.arity === "unary" && left.id !== "`") {
+                        no_space_only();
                     }
                 }
-                nr_comments_skipped = 0;
-                delete left.calls;
-                delete left.dead;
-                delete left.free;
-                delete left.init;
-                delete left.open;
-                delete left.used;
-                left = right;
             }
-        });
-    }
+            nr_comments_skipped = 0;
+            delete left.calls;
+            delete left.dead;
+            delete left.free;
+            delete left.init;
+            delete left.open;
+            delete left.used;
+            left = right;
+        }
+    });
+}
+
+function jslint(...arg_list) {
+
+// The jslint function itself.
+
+    //!! [
+        //!! source = "",
+        //!! option_dict = empty(),
+        //!! global_list = []
+    //!! ] = arg_list;
+    source = arg_list[0] || "";
+    option_dict = arg_list[1] || empty();
+    global_list = arg_list[2] || [];
+
+    directives = [];
+    export_dict = empty();
+    function_list = [];
+    token_global = {
+        async: 0,
+        body: true,
+        context: empty(),
+        finally: 0,
+        from: 0,
+        id: "(global)",
+        level: 0,
+        line: 1,
+        live: [],
+        loop: 0,
+        switch: 0,
+        thru: 0,
+        try: 0
+    };
+    import_list = [];
+    line_fudge = 1;
+    property = empty();
+    syntax_dict = empty();
+    token_list = [];
+    warning_list = [];
+    function_stack = [];
+    line_list = undefined;
+    mode_json = false;
+    mode_mega = false;
+    mode_module = false;
+    mode_shebang = false;
+// true if JSLint cannot finish.
+    let mode_stop = true;
+    mode_var = undefined;
+    tenure = undefined;
+    token_nxt = token_global;
+    token_tree = undefined;
 
     try {
 
@@ -6477,27 +6506,27 @@ function jslint(
 // automatic semicolon insertion and nested megastring literals, which allows
 // full tokenization to precede parsing.
 
-        option_object = Object.assign(empty(), option_object);
-        global_array = Object.assign(empty(), global_array);
-        populate(standard, global_array, false);
-        Object.keys(option_object).forEach(function (name) {
-            if (option_object[name] === true) {
+        option_dict = Object.assign(empty(), option_dict);
+        global_list = Object.assign(empty(), global_list);
+        populate(standard, global_list, false);
+        Object.keys(option_dict).forEach(function (name) {
+            if (option_dict[name] === true) {
                 const allowed = allowed_option[name];
                 if (Array.isArray(allowed)) {
-                    populate(allowed, global_array, false);
+                    populate(allowed, global_list, false);
                 }
             }
         });
 
-// PHASE 1. Split <source> by newlines into <line_array>.
+// PHASE 1. Split <source> by newlines into <line_list>.
 
         phase1_split();
 
-// PHASE 2. Lex <line_array> into <token_array>.
+// PHASE 2. Lex <line_list> into <token_list>.
 
         phase2_lex();
 
-// PHASE 3. Parse <token_array> into <token_tree> using Pratt parsing.
+// PHASE 3. Parse <token_list> into <token_tree> using Pratt parsing.
 
         phase3_parse();
 
@@ -6509,12 +6538,12 @@ function jslint(
             phase4_walk();
         }
 
-// PHASE 5. Check whitespace between tokens in <token_array>.
+// PHASE 5. Check whitespace between tokens in <token_list>.
 
-        if (!mode_json && warning_array.length === 0) {
+        if (!mode_json && warning_list.length === 0) {
             phase5_whitage();
         }
-        if (!option_object.browser) {
+        if (!option_dict.browser) {
             directives.forEach(function (comment) {
                 if (comment.directive === "global") {
 
@@ -6524,7 +6553,7 @@ function jslint(
                 }
             });
         }
-        if (option_object.test_internal_error) {
+        if (option_dict.test_internal_error) {
             assert_or_throw(undefined, "test_internal_error");
         }
         mode_stop = false;
@@ -6532,7 +6561,7 @@ function jslint(
         e.mode_stop = true;
         e.message = "[JSLint was unable to finish]\n" + e.message;
         if (e.name !== "JSLintError") {
-            warning_array.push(Object.assign(e, {
+            warning_list.push(Object.assign(e, {
                 column: line_fudge,
                 line: line_fudge,
                 line_source: "",
@@ -6541,9 +6570,9 @@ function jslint(
         }
     }
 
-// Sort warning_array by mode_stop first, line, column respectively.
+// Sort warning_list by mode_stop first, line, column respectively.
 
-    warning_array.sort(function (a, b) {
+    warning_list.sort(function (a, b) {
         return (
             Boolean(b.mode_stop) - Boolean(a.mode_stop)
             || a.line - b.line
@@ -6572,26 +6601,26 @@ function jslint(
     return {
         directives,
         edition,
-        exports: export_object,
-        froms: import_array,
-        functions: function_array,
-        global,
+        exports: export_dict,
+        froms: import_list,
+        functions: function_list,
+        global: token_global,
         id: "(JSLint)",
         json: mode_json,
-        lines: line_array,
+        lines: line_list,
         module: mode_module === true,
-        ok: warning_array.length === 0 && !mode_stop,
-        option: option_object,
+        ok: warning_list.length === 0 && !mode_stop,
+        option: option_dict,
         property,
         shebang: (
             mode_shebang
-            ? line_array[line_fudge].line_source
+            ? line_list[line_fudge].line_source
             : undefined
         ),
         stop: mode_stop,
-        tokens: token_array,
+        tokens: token_list,
         tree: token_tree,
-        warnings: warning_array
+        warnings: warning_list
     };
 }
 

--- a/jslint.js
+++ b/jslint.js
@@ -88,52 +88,32 @@
 /*jslint debug, node*/
 
 /*property
-    index,
-    directive_list, export_dict, function_list, import_list, line_list,
-    mode_json, mode_module, mode_property, mode_shebang,
-    global_list, option_dict, property_dict, source, syntax_dict, tenure,
-    token_global, token_list, token_tree, warning_list,
-    JSLINT_CLI, a, all, and, argv, arity, assign, async, b, bad_assignment_a,
-    bad_directive_a, bad_get, bad_module_name_a, bad_option_a, bad_property_a,
-    bad_set, bind, bitwise, block, body, browser, c, calls, catch, cli, closer,
-    closure, code, column, concat, console_error, constant, context, convert,
-    couch, create, cwd, d, dead, debug, default, devel, directive,
-    directive_quiet, directives, disrupt, dot, duplicate_a, edition, ellipsis,
-    else, empty_block, endsWith, env, error, eval, every, exec, exit,
-    expected_a, expected_a_at_b_c, expected_a_b, expected_a_b_from_c_d,
-    expected_a_before_b, expected_digits_after_a, expected_four_digits,
-    expected_identifier_a, expected_line_break_a_b, expected_regexp_factor_a,
-    expected_space_a_b, expected_statements_a, expected_string_a,
-    expected_type_string_a, exports, expression, extra, file, finally, flag,
-    for, forEach, formatted_message, free, freeze, freeze_exports, from, froms,
-    fud, function_in_loop, functions, getset, global, id, identifier, import,
-    inc, indexOf, infix_in, init, initial, isArray, isNaN, join, jslint, json,
-    keys, label, label_a, lbp, led, length, level, line, line_offset,
+    JSLINT_CLI, a, all, allowed_option, argv, arity, artifact, assign, async, b,
+    bind, bitwise, block, body, browser, c, calls, catch, closer, closure, code,
+    column, concat, console_error, constant, context, convert, couch, create,
+    cwd, d, dead, debug, default, devel, directive, directive_list,
+    directive_quiet, directives, disrupt, dot, edition, ellipsis, else,
+    endsWith, env, error, eval, every, exec, exit, export_dict, exports,
+    expression, extra, file, finally, flag, for, forEach, formatted_message,
+    free, freeze, from, froms, fud, function_list, functions, getset, global,
+    global_list, id, identifier, import, import_list, inc, index, indexOf, init,
+    initial, isArray, isNaN, is_equal, is_weird, join, jslint, jslint_cli, json,
+    keys, label, lbp, led, length, level, line, line_list, line_offset,
     line_source, lines, live, long, loop, m, map, margin, match, max, message,
-    misplaced_a, misplaced_directive_a, missing_await_statement,
-    missing_browser, missing_m, mode_stop, module, naked_block, name, names,
-    nested_comment, node, not_label_a, now, nr, nud, number_isNaN, ok, open,
-    opening, option, out_of_scope_a, padStart, parameters, parent, pop,
-    promises, property, push, quote, raw, readFile, readdir, redefinition_a_b,
-    repeat, replace, required_a_optional_b, reserved_a, resolve, role, search,
-    shebang, signature, single, slice, some, sort, source, split, stack,
-    stack_trace, startsWith, statement, stop, subscript_a, switch, test,
-    test_internal_error, then, this, thru, todo_comment, tokens, too_long,
-    too_many_digits, tree, trim, try, type, unclosed_comment, unclosed_disable,
-    unclosed_mega, unclosed_string, undeclared_a, unexpected_a,
-    unexpected_a_after_b, unexpected_a_before_b, unexpected_at_top_level_a,
-    unexpected_char_a, unexpected_comment, unexpected_directive_a,
-    unexpected_expression_a, unexpected_label_a, unexpected_parens,
-    unexpected_space_a_b, unexpected_statement_a, unexpected_trailing_space,
-    unexpected_typeof_a, uninitialized_a, unopened_enable, unordered,
-    unreachable_a, unregistered_property_a, unused_a, use_double, use_open,
-    use_spaces, used, value, var_loop, var_switch, variable, versions, warning,
-    warnings, weird_condition_a, weird_expression_a, weird_loop,
-    weird_relation_a, white, wrap_condition, wrap_immediate, wrap_parameter,
-    wrap_regexp, wrap_unary, wrapped, writable
+    mode_json, mode_module, mode_property, mode_shebang, mode_stop, module,
+    name, names, node, now, nr, nud, ok, open, opening, option, option_dict,
+    padStart, parameters, parent, pop, promises, property, property_dict, push,
+    quote, readFile, readdir, repeat, replace, resolve, role, search, shebang,
+    signature, single, slice, some, sort, source, split, stack, stack_trace,
+    startsWith, statement, stop, stop_at, switch, syntax_dict, tenure, test,
+    test_internal_error, then, this, thru, token_global, token_list, token_tree,
+    tokens, tree, trim, try, type, unordered, used, value, variable, versions,
+    warn, warn_at, warning, warning_list, warnings, white, wrapped, writable
 */
 
 const edition = "v2021.6.4-beta";
+
+const line_fudge = 1;   // Fudge starting line and starting column to 1.
 
 function assert_or_throw(passed, message) {
 
@@ -180,546 +160,70 @@ function populate(array, object = empty(), value = true) {
     return object;
 }
 
-const allowed_option = {
-
-// These are the options that are recognized in the option object or that may
-// appear in a /*jslint*/ directive. Most options will have a boolean value,
-// usually true. Some options will also predefine some number of global
-// variables.
-
-    bitwise: true,
-    browser: [
-        "caches", "CharacterData", "clearInterval", "clearTimeout",
-        "document",
-        "DocumentType", "DOMException", "Element", "Event", "event",
-        "fetch",
-        "FileReader", "FontFace", "FormData", "history",
-        "IntersectionObserver",
-        "localStorage", "location", "MutationObserver", "name", "navigator",
-        "screen", "sessionStorage", "setInterval", "setTimeout", "Storage",
-        "TextDecoder", "TextEncoder", "URL", "window", "Worker",
-        "XMLHttpRequest"
-    ],
-    convert: true,
-    couch: [
-        "emit", "getRow", "isArray", "log", "provides", "registerType",
-        "require", "send", "start", "sum", "toJSON"
-    ],
-    debug: true,
-    devel: [
-        "alert", "confirm", "console", "prompt"
-    ],
-    eval: true,
-    for: true,
-    getset: true,
-    long: true,
-    name: true,
-    node: [
-        "Buffer", "clearImmediate", "clearInterval", "clearTimeout",
-        "console", "exports", "module", "process", "require",
-        "setImmediate", "setInterval", "setTimeout", "TextDecoder",
-        "TextEncoder", "URL", "URLSearchParams", "__dirname", "__filename"
-    ],
-    single: true,
-    test_internal_error: true,
-    this: true,
-    unordered: true,
-    white: true
-};
-
-// The relational operators.
-
-const relationop = populate([
-    "!=", "!==", "==", "===", "<", "<=", ">", ">="
-]);
-
-// This is the set of infix operators that require a space on each side.
-
-const spaceop = populate([
-    "!=", "!==", "%", "%=", "&", "&=", "&&", "*", "*=", "+=", "-=", "/",
-    "/=", "<", "<=", "<<", "<<=", "=", "==", "===", "=>", ">", ">=",
-    ">>", ">>=", ">>>", ">>>=", "^", "^=", "|", "|=", "||"
-]);
-
-const standard = [
-
-// These are the globals that are provided by the language standard.
-
-    "Array", "ArrayBuffer", "Boolean", "DataView", "Date", "Error",
-    "EvalError",
-    "Float32Array", "Float64Array", "Generator", "GeneratorFunction",
-    "Int16Array", "Int32Array", "Int8Array", "Intl", "JSON", "Map", "Math",
-    "Number", "Object", "Promise", "Proxy", "RangeError", "ReferenceError",
-    "Reflect", "RegExp", "Set", "String", "Symbol", "SyntaxError", "System",
-    "TypeError", "URIError", "Uint16Array", "Uint32Array", "Uint8Array",
-    "Uint8ClampedArray", "WeakMap", "WeakSet", "decodeURI",
-    "decodeURIComponent", "encodeURI", "encodeURIComponent", "globalThis",
-    "import", "parseFloat", "parseInt"
-];
-
-const bundle = {
-
-// The bundle contains the raw text messages that are generated by jslint. It
-// seems that they are all error messages and warnings. There are no "Atta
-// boy!" or "You are so awesome!" messages. There is no positive reinforcement
-// or encouragement. This relentless negativity can undermine self-esteem and
-// wound the inner child. But if you accept it as sound advice rather than as
-// personal criticism, it can make your programs better.
-
-    and: "The '&&' subexpression should be wrapped in parens.",
-    bad_assignment_a: "Bad assignment to '{a}'.",
-    bad_directive_a: "Bad directive '{a}'.",
-    bad_get: "A get function takes no parameters.",
-    bad_module_name_a: "Bad module name '{a}'.",
-    bad_option_a: "Bad option '{a}'.",
-    bad_property_a: "Bad property name '{a}'.",
-    bad_set: "A set function takes one parameter.",
-    duplicate_a: "Duplicate '{a}'.",
-    empty_block: "Empty block.",
-    expected_a: "Expected '{a}'.",
-    expected_a_at_b_c: "Expected '{a}' at column {b}, not column {c}.",
-    expected_a_b: "Expected '{a}' and instead saw '{b}'.",
-    expected_a_b_from_c_d: (
-        "Expected '{a}' to match '{b}' from line {c} and instead saw '{d}'."
-    ),
-    expected_a_before_b: "Expected '{a}' before '{b}'.",
-    expected_digits_after_a: "Expected digits after '{a}'.",
-    expected_four_digits: "Expected four digits after '\\u'.",
-    expected_identifier_a: "Expected an identifier and instead saw '{a}'.",
-    expected_line_break_a_b: (
-        "Expected a line break between '{a}' and '{b}'."
-    ),
-    expected_regexp_factor_a: (
-        "Expected a regexp factor and instead saw '{a}'."
-    ),
-    expected_space_a_b: "Expected one space between '{a}' and '{b}'.",
-    expected_statements_a: "Expected statements before '{a}'.",
-    expected_string_a: "Expected a string and instead saw '{a}'.",
-    expected_type_string_a: "Expected a type string and instead saw '{a}'.",
-    freeze_exports: (
-        "Expected 'Object.freeze('. All export values should be frozen."
-    ),
-    function_in_loop: "Don't create functions within a loop.",
-    infix_in: (
-        "Unexpected 'in'. Compare with undefined, "
-        + "or use the hasOwnProperty method instead."
-    ),
-    label_a: "'{a}' is a statement label.",
-    misplaced_a: "Place '{a}' at the outermost level.",
-    misplaced_directive_a: (
-        "Place the '/*{a}*/' directive before the first statement."
-    ),
-    missing_await_statement: "Expected await statement in async function.",
-    missing_browser: "/*global*/ requires the Assume a browser option.",
-    missing_m: "Expected 'm' flag on a multiline regular expression.",
-    naked_block: "Naked block.",
-    nested_comment: "Nested comment.",
-    not_label_a: "'{a}' is not a label.",
-    number_isNaN: "Use Number.isNaN function to compare with NaN.",
-    out_of_scope_a: "'{a}' is out of scope.",
-    redefinition_a_b: "Redefinition of '{a}' from line {b}.",
-    required_a_optional_b: (
-        "Required parameter '{a}' after optional parameter '{b}'."
-    ),
-    reserved_a: "Reserved name '{a}'.",
-    subscript_a: "['{a}'] is better written in dot notation.",
-    todo_comment: "Unexpected TODO comment.",
-    too_long: "Line is longer than 80 characters.",
-    too_many_digits: "Too many digits.",
-    unclosed_comment: "Unclosed comment.",
-    unclosed_disable: (
-        "Directive '/*jslint-disable*/' was not closed "
-        + "with '/*jslint-enable*/'."
-    ),
-    unclosed_mega: "Unclosed mega literal.",
-    unclosed_string: "Unclosed string.",
-    undeclared_a: "Undeclared '{a}'.",
-    unexpected_a: "Unexpected '{a}'.",
-    unexpected_a_after_b: "Unexpected '{a}' after '{b}'.",
-    unexpected_a_before_b: "Unexpected '{a}' before '{b}'.",
-    unexpected_at_top_level_a: "Expected '{a}' to be in a function.",
-    unexpected_char_a: "Unexpected character '{a}'.",
-    unexpected_comment: "Unexpected comment.",
-    unexpected_directive_a: (
-        "When using modules, don't use directive '/*{a}'."
-    ),
-    unexpected_expression_a: (
-        "Unexpected expression '{a}' in statement position."
-    ),
-    unexpected_label_a: "Unexpected label '{a}'.",
-    unexpected_parens: "Don't wrap function literals in parens.",
-    unexpected_space_a_b: "Unexpected space between '{a}' and '{b}'.",
-    unexpected_statement_a: (
-        "Unexpected statement '{a}' in expression position."
-    ),
-    unexpected_trailing_space: "Unexpected trailing space.",
-    unexpected_typeof_a: (
-        "Unexpected 'typeof'. Use '===' to compare directly with {a}."
-    ),
-    uninitialized_a: "Uninitialized '{a}'.",
-    unopened_enable: (
-        "Directive '/*jslint-enable*/' was not opened "
-        + "with '/*jslint-disable*/'."
-    ),
-    unreachable_a: "Unreachable '{a}'.",
-    unregistered_property_a: "Unregistered property name '{a}'.",
-    unused_a: "Unused '{a}'.",
-    use_double: "Use double quotes, not single quotes.",
-    use_open: (
-        "Wrap a ternary expression in parens, "
-        + "with a line break after the left paren."
-    ),
-    use_spaces: "Use spaces, not tabs.",
-    var_loop: "Don't declare variables in a loop.",
-    var_switch: "Don't declare variables in a switch.",
-    weird_condition_a: "Weird condition '{a}'.",
-    weird_expression_a: "Weird expression '{a}'.",
-    weird_loop: "Weird loop.",
-    weird_relation_a: "Weird relation '{a}'.",
-    wrap_condition: "Wrap the condition in parens.",
-    wrap_immediate: (
-        "Wrap an immediate function invocation in parentheses to assist "
-        + "the reader in understanding that the expression is the result "
-        + "of a function, and not the function itself."
-    ),
-    wrap_parameter: "Wrap the parameter in parens.",
-    wrap_regexp: "Wrap this regexp in parens to avoid confusion.",
-    wrap_unary: "Wrap the unary expression in parens."
-};
-
-// Regular expression literals:
-
-function tag_regexp(strings) {
-    return new RegExp(strings.raw[0].replace(/\s/g, ""));
-}
-
-// supplant {variables}
-const rx_supplant = /\{([^{}]*)\}/g;
-// identifier
-const rx_identifier = tag_regexp ` ^(
-    [ a-z A-Z _ $ ]
-    [ a-z A-Z 0-9 _ $ ]*
-)$`;
-const rx_module = tag_regexp ` ^ [ a-z A-Z 0-9 _ $ : . @ \- \/ ]+ $ `;
-// tab
-const rx_tab = /\t/g;
-// token
-const rx_token = tag_regexp ` ^ (
-    (\s+)
-  | (
-      [ a-z A-Z _ $ ]
-      [ a-z A-Z 0-9 _ $ ]*
-    )
-  | [
-      ( ) { } \[ \] , : ; ' " ~ \`
-  ]
-  | \? [ ? . ]?
-  | = (?:
-        = =?
-      | >
-    )?
-  | \.+
-  | \* [ * \/ = ]?
-  | \/ [ * \/ ]?
-  | \+ [ = + ]?
-  | - [ = \- ]?
-  | [ \^ % ] =?
-  | & [ & = ]?
-  | \| [ | = ]?
-  | >{1,3} =?
-  | < <? =?
-  | ! (?:
-        !
-      | = =?
-    )?
-  | (
-        0
-      | [ 1-9 ] [ 0-9 ]*
-    )
-) ( .* ) $ `;
-const rx_digits = /^[0-9]*/;
-const rx_hexs = /^[0-9A-F]*/i;
-const rx_octals = /^[0-7]*/;
-const rx_bits = /^[01]*/;
-// JSON number
-const rx_JSON_number = tag_regexp ` ^
-    -?
-    (?: 0 | [ 1-9 ] \d* )
-    (?: \. \d* )?
-    (?: [ e E ] [ \- + ]? \d+ )?
-$ `;
-// initial cap
-const rx_cap = /^[A-Z]/;
-
-const line_fudge = 1;   // Fudge starting line and starting column to 1.
-
-// Error reportage functions:
-
-function artifact(the_token) {
-
-// Return a string representing an artifact.
-
-    assert_or_throw(
-        the_token !== undefined,
-        "Expected the_token !== undefined."
-    );
-// Probably deadcode.
-// if (the_token === undefined) {
-//     the_token = token_nxt;
-// }
-    return (
-        (the_token.id === "(string)" || the_token.id === "(number)")
-        ? String(the_token.value)
-        : the_token.id
-    );
-}
-
-function warn_at(code, state, line, column, a, b, c, d) {
-
-// Report an error at some line and column of the program. The warning object
-// resembles an exception.
-
-    const warning = Object.assign(empty(), {
-        a,
-        b,
-        c,
-        code,
-
-// Fudge column numbers in warning message.
-
-        column: column || line_fudge,
-        d,
-        line,
-        line_source: "",
-        name: "JSLintError"
-    }, state.line_list[line]);
-    warning.message = bundle[code].replace(rx_supplant, function (
-        ignore,
-        filling
-    ) {
-        assert_or_throw(
-            warning[filling] !== undefined,
-            "Expected warning[filling] !== undefined."
-        );
-
-// Probably deadcode.
-// return (
-//     replacement !== undefined
-//     ? replacement
-//     : found
-// );
-
-        return warning[filling];
-    });
-
-// Include stack_trace for jslint to debug itself for errors.
-
-    if (state.option_dict.debug) {
-        warning.stack_trace = new Error().stack;
-    }
-    if (warning.directive_quiet) {
-
-// cause: "0 //jslint-quiet"
-
-        return warning;
-    }
-    state.warning_list.push(warning);
-    return warning;
-}
-
-function stop_at(code, state, line, column, a, b, c, d) {
-
-// Same as warn_at, except that it stops the analysis.
-
-    throw warn_at(code, state, line, column, a, b, c, d);
-}
-
-function warn(code, state, the_token, a, b, c, d) {
-
-// Same as warn_at, except the warning will be associated with a specific token.
-// If there is already a warning on this token, suppress the new one. It is
-// likely that the first warning will be the most meaningful.
-
-    assert_or_throw(
-        the_token !== undefined,
-        "Expected the_token !== undefined."
-    );
-// Probably deadcode.
-// if (the_token === undefined) {
-//     the_token = token_nxt;
-// }
-    if (the_token.warning === undefined) {
-        the_token.warning = warn_at(
-            code,
-            state,
-            the_token.line,
-            (the_token.from || 0) + line_fudge,
-            a || artifact(the_token),
-            b,
-            c,
-            d
-        );
-        return the_token.warning;
-    }
-}
-
-function stop(code, state, the_token, a, b, c, d) {
-
-// Similar to warn and stop_at. If the token already had a warning, that
-// warning will be replaced with this new one. It is likely that the stopping
-// warning will be the more meaningful.
-
-    assert_or_throw(
-        the_token !== undefined,
-        "Expected the_token !== undefined."
-    );
-// Probably deadcode.
-// if (the_token === undefined) {
-//     the_token = token_nxt;
-// }
-    delete the_token.warning;
-    throw warn(code, state, the_token, a, b, c, d);
-}
-
-function is_weird(thing) {
-    return (
-        thing.id === "(regexp)"
-        || thing.id === "{"
-        || thing.id === "=>"
-        || thing.id === "function"
-        || (thing.id === "[" && thing.arity === "unary")
-    );
-}
-
-function are_similar(a, b) {
-    let a_string;
-    let b_string;
-
-// cause: "0&&0"
-
-    assert_or_throw(!(a === b), `Expected !(a === b).`);
-
-// Probably deadcode.
-// if (a === b) {
-//     return true;
-// }
-
-    if (Array.isArray(a)) {
-        return (
-            Array.isArray(b)
-            && a.length === b.length
-            && a.every(function (value, index) {
-
-// cause: "`${0}`&&`${0}`"
-
-                return are_similar(value, b[index]);
-            })
-        );
-    }
-    assert_or_throw(!Array.isArray(b), `Expected !Array.isArray(b).`);
-
-// Probably deadcode.
-// if (Array.isArray(b)) {
-//     return false;
-// }
-
-    if (a.id === "(number)" && b.id === "(number)") {
-        return a.value === b.value;
-    }
-    if (a.id === "(string)") {
-        a_string = a.value;
-    } else if (a.id === "`" && a.constant) {
-        a_string = a.value[0];
-    }
-    if (b.id === "(string)") {
-        b_string = b.value;
-    } else if (b.id === "`" && b.constant) {
-        b_string = b.value[0];
-    }
-    if (typeof a_string === "string") {
-        return a_string === b_string;
-    }
-    if (is_weird(a) || is_weird(b)) {
-        return false;
-    }
-    if (a.arity === b.arity && a.id === b.id) {
-
-// cause: "aa.bb&&aa.bb"
-
-        if (a.id === ".") {
-            return (
-                are_similar(a.expression, b.expression)
-                && are_similar(a.name, b.name)
-            );
-        }
-
-// cause: "+0&&+0"
-
-        if (a.arity === "unary") {
-            return are_similar(a.expression, b.expression);
-        }
-        if (a.arity === "binary") {
-
-// cause: "aa[0]&&aa[0]"
-
-            return (
-                a.id !== "("
-                && are_similar(a.expression[0], b.expression[0])
-                && are_similar(a.expression[1], b.expression[1])
-            );
-        }
-        if (a.arity === "ternary") {
-
-// cause: "aa=(``?``:``)&&(``?``:``)"
-
-            return (
-                are_similar(a.expression[0], b.expression[0])
-                && are_similar(a.expression[1], b.expression[1])
-                && are_similar(a.expression[2], b.expression[2])
-            );
-        }
-        assert_or_throw(
-            !(a.arity === "function" || a.arity === "regexp"),
-            `Expected !(a.arity === "function" || a.arity === "regexp").`
-        );
-
-// Probably deadcode.
-// if (a.arity === "function" || a.arity === "regexp") {
-//     return false;
-// }
-
-// cause: "undefined&&undefined"
-
-        return true;
-    }
-
-// cause: "null&&undefined"
-
-    return false;
-}
-
-
-function phase1_split() {
+function jslint_phase1_split() {
 
 // PHASE 1. Split <source> by newlines into <line_list>.
 
     return;
 }
 
-
-function phase2_lex(state) {
+function jslint_phase2_lex(state) {
 
 // PHASE 2. Lex <line_list> into <token_list>.
 
     const {
+        allowed_option,
+        artifact,
         directive_list,
         global_list,
         line_list,
         option_dict,
+        stop,
+        stop_at,
         tenure,
         token_global,
-        token_list
+        token_list,
+        warn,
+        warn_at
     } = state;
+    const rx_bits = (
+        /^[01]*/
+    );
+    const rx_digits = (
+        /^[0-9]*/
+    );
+    const rx_hexs = (
+        /^[0-9A-F]*/i
+    );
+    const rx_octals = (
+        /^[0-7]*/
+    );
+    const rx_tab = (
+        /\t/g
+    );
+    const rx_token = new RegExp(
+        "^("
+        + "(\\s+)"
+        + "|([a-zA-Z_$][a-zA-Z0-9_$]*)"
+        + "|[(){}\\[\\],:;'\"~\\`]"
+        + "|\\?[?.]?"
+        + "|=(?:==?|>)?"
+        + "|\\.+"
+        + "|\\*[*\\/=]?"
+        + "|\\/[*\\/]?"
+        + "|\\+[=+]?"
+        + "|-[=\\-]?"
+        + "|[\\^%]=?"
+        + "|&[&=]?"
+        + "|\\"
+        + "|[|=]?"
+        + "|>{1,3}=?"
+        + "|<<?=?"
+        + "|!(?:!|==?)?"
+        + "|(0|[1-9][0-9]*)"
+        + ")"
+        + "(.*)$"
+    );
     let char;           // A popular character.
     let column = 0;     // The column number of the next character.
     let from;           // The starting column number of the token.
@@ -759,11 +263,11 @@ function phase2_lex(state) {
 
 // cause: "aa=/[/"
 
-                ? stop_at("expected_a", state, line, column - 1, match, char)
+                ? stop_at("expected_a", line, column - 1, match, char)
 
 // cause: "aa=/aa{/"
 
-                : stop_at("expected_a_b", state, line, column, match, char)
+                : stop_at("expected_a_b", line, column, match, char)
             );
         }
         char = line_source.slice(0, 1);
@@ -795,7 +299,7 @@ function phase2_lex(state) {
 
 // cause: "0x"
 
-            warn_at("expected_digits_after_a", state, line, column, snippet);
+            warn_at("expected_digits_after_a", line, column, snippet);
         }
         column += length;
         line_source = line_source.slice(length);
@@ -822,7 +326,7 @@ function phase2_lex(state) {
 
 // cause: "too_long"
 
-            warn_at("too_long", state, line);
+            warn_at("too_long", line);
         }
         column = 0;
         line += 1;
@@ -850,7 +354,7 @@ function phase2_lex(state) {
 
 // cause: "/*jslint-enable*/"
 
-                stop_at("unopened_enable", state, line);
+                stop_at("unopened_enable", line);
             }
             line_disable = undefined;
         } else if (line_source.endsWith(" //jslint-quiet")) {
@@ -871,7 +375,7 @@ function phase2_lex(state) {
 
 // cause: "\t"
 
-                warn_at("use_spaces", state, line, at);
+                warn_at("use_spaces", line, at);
             }
             line_source = line_source.replace(rx_tab, " ");
         }
@@ -879,12 +383,7 @@ function phase2_lex(state) {
 
 // cause: " "
 
-            warn_at(
-                "unexpected_trailing_space",
-                state,
-                line,
-                line_source.length - 1
-            );
+            warn_at("unexpected_trailing_space", line, line_source.length - 1);
         }
         return line_source;
     }
@@ -931,7 +430,6 @@ function phase2_lex(state) {
 
             warn(
                 "expected_space_a_b",
-                state,
                 the_token,
                 artifact(token_prv),
                 artifact(the_token)
@@ -941,7 +439,7 @@ function phase2_lex(state) {
 
 // cause: ".0"
 
-            warn("expected_a_before_b", state, token_prv, "0", ".");
+            warn("expected_a_before_b", token_prv, "0", ".");
         }
         if (token_before_slash.id === "." && the_token.identifier) {
             the_token.dot = true;
@@ -972,15 +470,25 @@ function phase2_lex(state) {
 
 // cause: "\"\\"
 
-            return stop_at("unclosed_string", state, line, column);
+            return stop_at("unclosed_string", line, column);
         case "/":
+            return char_after();
         case "\\":
+            return char_after();
         case "`":
+            return char_after();
         case "b":
+            return char_after();
         case "f":
+            return char_after();
         case "n":
+            return char_after();
         case "r":
+            return char_after();
         case "t":
+
+// cause: "\"\\/\\\\\\`\\b\\f\\n\\r\\t\""
+
             return char_after();
         case "u":
             if (char_after("u") === "{") {
@@ -988,26 +496,19 @@ function phase2_lex(state) {
 
 // cause: "[\"\\u{12345}\"]"
 
-                    warn_at("unexpected_a", state, line, column, char);
+                    warn_at("unexpected_a", line, column, char);
                 }
                 if (read_digits(rx_hexs) > 5) {
 
 // cause: "\"\\u{123456}\""
 
-                    warn_at("too_many_digits", state, line, column);
+                    warn_at("too_many_digits", line, column);
                 }
                 if (char !== "}") {
 
 // cause: "\"\\u{12345\""
 
-                    stop_at(
-                        "expected_a_before_b",
-                        state,
-                        line,
-                        column,
-                        "}",
-                        char
-                    );
+                    stop_at("expected_a_before_b", line, column, "}", char);
                 }
                 return char_after();
             }
@@ -1016,7 +517,7 @@ function phase2_lex(state) {
 
 // cause: "\"\\u0\""
 
-                warn_at("expected_four_digits", state, line, column);
+                warn_at("expected_four_digits", line, column);
             }
             return;
         default:
@@ -1026,7 +527,7 @@ function phase2_lex(state) {
 
 // cause: "\"\\0\""
 
-            warn_at("unexpected_a_before_b", state, line, column, "\\", char);
+            warn_at("unexpected_a_before_b", line, column, "\\", char);
         }
     }
 
@@ -1053,7 +554,7 @@ function phase2_lex(state) {
 
 // cause: "`${//}`"
 
-                warn("unexpected_comment", state, the_comment, "`");
+                warn("unexpected_comment", the_comment, "`");
             }
 
 // Create token from comment /*...*/.
@@ -1064,7 +565,7 @@ function phase2_lex(state) {
 
 // cause: "/*/"
 
-                warn_at("unexpected_a", state, line, column + ii, "/");
+                warn_at("unexpected_a", line, column + ii, "/");
             }
 
 // Lex/loop through each line until "*/".
@@ -1082,7 +583,7 @@ function phase2_lex(state) {
 
 // cause: "/*/*"
 
-                        warn_at("nested_comment", state, line, column + jj);
+                        warn_at("nested_comment", line, column + jj);
                     }
                 }
                 snippet.push(line_source);
@@ -1091,7 +592,7 @@ function phase2_lex(state) {
 
 // cause: "/*"
 
-                    return stop_at("unclosed_comment", state, line, column);
+                    return stop_at("unclosed_comment", line, column);
                 }
             }
             jj = line_source.slice(0, ii).search(
@@ -1102,7 +603,7 @@ function phase2_lex(state) {
 
 // cause: "/*/**/"
 
-                warn_at("nested_comment", state, line, column + jj);
+                warn_at("nested_comment", line, column + jj);
             }
             snippet.push(line_source.slice(0, ii));
             snippet = snippet.join(" ");
@@ -1123,7 +624,7 @@ function phase2_lex(state) {
 
 // cause: "//\u0074odo"
 
-            warn("todo_comment", state, the_comment);
+            warn("todo_comment", the_comment);
         }
 
 // Lex directives in comment.
@@ -1140,7 +641,7 @@ function phase2_lex(state) {
 
 // cause: "0\n/*global aa*/"
 
-            warn_at("misplaced_directive_a", state, line, from, match[1]);
+            warn_at("misplaced_directive_a", line, from, match[1]);
             return the_comment;
         }
         the_comment.directive = match[1];
@@ -1163,12 +664,7 @@ function phase2_lex(state) {
 
 // cause: "/*jslint !*/"
 
-                    return stop(
-                        "bad_directive_a",
-                        state,
-                        the_comment,
-                        body
-                    );
+                    return stop("bad_directive_a", the_comment, body);
                 }
                 break;
             }
@@ -1197,14 +693,14 @@ function phase2_lex(state) {
 // } else if (value === "false") {
 //     option_dict[name] = false;
 // } else {
-//     warn("bad_option_a", state, the_comment, name + ":" + value);
+//     warn("bad_option_a", the_comment, name + ":" + value);
 
                     }
                 } else {
 
 // cause: "/*jslint undefined*/"
 
-                    warn("bad_option_a", state, the_comment, name);
+                    warn("bad_option_a", the_comment, name);
                 }
             } else if (the_comment.directive === "property") {
                 state.mode_property = true;
@@ -1214,12 +710,7 @@ function phase2_lex(state) {
 
 // cause: "/*global aa:false*/"
 
-                    warn(
-                        "bad_option_a",
-                        state,
-                        the_comment,
-                        name + ":" + value
-                    );
+                    warn("bad_option_a", the_comment, name + ":" + value);
                 }
                 global_list[name] = false;
                 state.mode_module = the_comment;
@@ -1238,7 +729,7 @@ function phase2_lex(state) {
 
 // cause: "`${`"
 
-            return stop_at("expected_a_b", state, line, column, "}", "`");
+            return stop_at("expected_a_b", line, column, "}", "`");
         }
         from_mega = from;
         line_mega = line;
@@ -1290,14 +781,7 @@ function phase2_lex(state) {
 
 // cause: "`${{"
 
-                        return stop_at(
-                            "expected_a_b",
-                            state,
-                            line,
-                            column,
-                            "}",
-                            "{"
-                        );
+                        return stop_at("expected_a_b", line, column, "}", "{");
                     }
                     if (id === "}") {
                         break;
@@ -1332,12 +816,7 @@ function phase2_lex(state) {
 
 // cause: "`"
 
-                    return stop_at(
-                        "unclosed_mega",
-                        state,
-                        line_mega,
-                        from_mega
-                    );
+                    return stop_at("unclosed_mega", line_mega, from_mega);
                 }
             }
         }
@@ -1382,7 +861,6 @@ function phase2_lex(state) {
 
             return stop_at(
                 "unexpected_a_after_b",
-                state,
                 line,
                 column,
                 snippet.slice(-1),
@@ -1414,17 +892,30 @@ function phase2_lex(state) {
                 char_after_escape("BbDdSsWw-[]^");
                 return true;
             case "":
-            case "[":
-            case "]":
-            case "/":
-            case "^":
+                return false;
             case "-":
+                return false;
+            case "/":
+                return false;
+            case "[":
+                return false;
+            case "]":
+                return false;
+            case "^":
+
+// cause: "aa=/[-]/"
+// cause: "aa=/[.^]/"
+// cause: "aa=/[/"
+// cause: "aa=/[\\\\/]/"
+// cause: "aa=/[\\\\[]/"
+// cause: "aa=/[\\\\]]/"
+
                 return false;
             case " ":
 
 // cause: "aa=/[ ]/"
 
-                warn_at("expected_a_b", state, line, column, "\\u0020", " ");
+                warn_at("expected_a_b", line, column, "\\u0020", " ");
                 char_after();
                 return true;
             case "`":
@@ -1432,7 +923,7 @@ function phase2_lex(state) {
 
 // cause: "`${/[`]/}`"
 
-                    warn_at("unexpected_a", state, line, column, "`");
+                    warn_at("unexpected_a", line, column, "`");
                 }
                 char_after();
                 return true;
@@ -1462,13 +953,7 @@ function phase2_lex(state) {
 
 // cause: "/ /"
 
-                        warn_at(
-                            "expected_regexp_factor_a",
-                            state,
-                            line,
-                            column,
-                            char
-                        );
+                        warn_at("expected_regexp_factor_a", line, column, char);
                     }
 
 // RegExp
@@ -1504,14 +989,7 @@ function phase2_lex(state) {
 // cause: "aa=/(:)/"
 // cause: "aa=/?/"
 
-                        warn_at(
-                            "expected_a_before_b",
-                            state,
-                            line,
-                            column,
-                            "?",
-                            ":"
-                        );
+                        warn_at("expected_a_before_b", line, column, "?", ":");
                     }
 
 // RegExp
@@ -1543,7 +1021,6 @@ function phase2_lex(state) {
 
                                     return stop_at(
                                         "unexpected_a",
-                                        state,
                                         line,
                                         column - 1,
                                         "-"
@@ -1559,7 +1036,6 @@ function phase2_lex(state) {
 
                         warn_at(
                             "expected_a_before_b",
-                            state,
                             line,
                             column,
                             "\\",
@@ -1577,14 +1053,7 @@ function phase2_lex(state) {
                 case "*":
                 case "}":
                 case "{":
-                    warn_at(
-                        "expected_a_before_b",
-                        state,
-                        line,
-                        column,
-                        "\\",
-                        char
-                    );
+                    warn_at("expected_a_before_b", line, column, "\\", char);
                     char_after();
                     break;
                 case "`":
@@ -1592,7 +1061,7 @@ function phase2_lex(state) {
 
 // cause: "`${/`/}`"
 
-                        warn_at("unexpected_a", state, line, column, "`");
+                        warn_at("unexpected_a", line, column, "`");
                     }
                     char_after();
                     break;
@@ -1600,7 +1069,7 @@ function phase2_lex(state) {
 
 // cause: "aa=/ /"
 
-                    warn_at("expected_a_b", state, line, column, "\\s", " ");
+                    warn_at("expected_a_b", line, column, "\\s", " ");
                     char_after();
                     break;
                 case "$":
@@ -1623,10 +1092,22 @@ function phase2_lex(state) {
 // Match an optional quantifier.
 
                 switch (char) {
-                case "?":
                 case "*":
+                    if (char_after("*") === "?") {
+                        char_after("?");
+                    }
+                    break;
                 case "+":
-                    if (char_after() === "?") {
+                    if (char_after("+") === "?") {
+                        char_after("?");
+                    }
+                    break;
+                case "?":
+                    if (char_after("?") === "?") {
+
+// cause: "aa=/.??/"
+
+                        warn_at("unexpected_a", line, column, char);
                         char_after("?");
                     }
                     break;
@@ -1635,14 +1116,7 @@ function phase2_lex(state) {
 
 // cause: "aa=/aa{/"
 
-                        warn_at(
-                            "expected_a_before_b",
-                            state,
-                            line,
-                            column,
-                            "0",
-                            ","
-                        );
+                        warn_at("expected_a_before_b", line, column, "0", ",");
                     }
                     if (char === ",") {
 
@@ -1654,7 +1128,7 @@ function phase2_lex(state) {
 
 // cause: "aa=/.{0}?/"
 
-                        warn_at("unexpected_a", state, line, column, char);
+                        warn_at("unexpected_a", line, column, char);
                         char_after("?");
                     }
                     break;
@@ -1673,7 +1147,7 @@ function phase2_lex(state) {
 
 // cause: "aa=/=/"
 
-            warn_at("expected_a_before_b", state, line, column, "\\", "=");
+            warn_at("expected_a_before_b", line, column, "\\", "=");
         }
         regexp_choice();
 
@@ -1706,9 +1180,13 @@ function phase2_lex(state) {
 
             switch (!flag[char] && char) {
             case "g":
+                break;
             case "i":
+                break;
             case "m":
+                break;
             case "u":
+                break;
             case "y":
 
 // cause: "aa=/./gimuy"
@@ -1719,7 +1197,7 @@ function phase2_lex(state) {
 // cause: "aa=/./gg"
 // cause: "aa=/./z"
 
-                warn_at("unexpected_a", state, line, column, char);
+                warn_at("unexpected_a", line, column, char);
             }
             flag[char] = true;
             char_after();
@@ -1729,7 +1207,7 @@ function phase2_lex(state) {
 
 // cause: "aa=/.//"
 
-            return stop_at("unexpected_a", state, line, from, char);
+            return stop_at("unexpected_a", line, from, char);
         }
         result = token_create("(regexp)", char);
         result.flag = flag;
@@ -1738,7 +1216,7 @@ function phase2_lex(state) {
 
 // cause: "aa=/$^/"
 
-            warn_at("missing_m", state, line, column);
+            warn_at("missing_m", line, column);
         }
         return result;
     }
@@ -1783,7 +1261,7 @@ function phase2_lex(state) {
 // cause: "void /./"
 // cause: "yield /./"
 
-                    return stop("unexpected_a", state, the_token);
+                    return stop("unexpected_a", the_token);
                 }
             }
         } else {
@@ -1799,7 +1277,7 @@ function phase2_lex(state) {
 
 // cause: "!/./"
 
-                warn("wrap_regexp", state, the_token);
+                warn("wrap_regexp", the_token);
                 return the_token;
             }
         }
@@ -1807,7 +1285,7 @@ function phase2_lex(state) {
             column += 1;
             line_source = line_source.slice(1);
             snippet = "/=";
-            warn_at("unexpected_a", state, line, column, "/=");
+            warn_at("unexpected_a", line, column, "/=");
         }
         return token_create(snippet);
     }
@@ -1821,7 +1299,7 @@ function phase2_lex(state) {
 
 // cause: "''"
 
-            warn_at("use_double", state, line, column);
+            warn_at("use_double", line, column);
         }
         snippet = "";
         char_after();
@@ -1842,7 +1320,7 @@ function phase2_lex(state) {
 
 // cause: "\""
 
-                return stop_at("unclosed_string", state, line, column);
+                return stop_at("unclosed_string", line, column);
             case "\\":
                 char_after_escape(quote);
                 break;
@@ -1851,7 +1329,7 @@ function phase2_lex(state) {
 
 // cause: "`${\"`\"}`"
 
-                    warn_at("unexpected_a", state, line, column, "`");
+                    warn_at("unexpected_a", line, column, "`");
                 }
                 char_after("`");
                 break;
@@ -1879,12 +1357,12 @@ function phase2_lex(state) {
 
 // cause: "`${//}`"
 
-                        ? stop_at("unclosed_mega", state, line_mega, from_mega)
+                        ? stop_at("unclosed_mega", line_mega, from_mega)
                         : line_disable !== undefined
 
 // cause: "/*jslint-disable*/"
 
-                        ? stop_at("unclosed_disable", state, line_disable)
+                        ? stop_at("unclosed_disable", line_disable)
                         : token_create("(end)")
                     );
                 }
@@ -1904,7 +1382,6 @@ function phase2_lex(state) {
 
                 return stop_at(
                     "unexpected_char_a",
-                    state,
                     line,
                     column,
                     line_source[0]
@@ -1974,8 +1451,7 @@ function phase2_lex(state) {
     }
 }
 
-
-function phase3_parse(state) {
+function jslint_phase3_parse(state) {
 
 // PHASE 3. Parse <token_list> into <token_tree> using the Pratt-parser.
 
@@ -1994,17 +1470,28 @@ function phase3_parse(state) {
 // Specialized tokens may have additional properties.
 
     const {
+        artifact,
         export_dict,
         function_list,
         import_list,
+        is_equal,
         option_dict,
         property_dict,
+        stop,
         syntax_dict,
         tenure,
         token_global,
-        token_list
+        token_list,
+        warn,
+        warn_at
     } = state;
     const function_stack = [];  // The stack of functions.
+    const rx_identifier = (
+        /^([a-zA-Z_$][a-zA-Z0-9_$]*)$/
+    );
+    const rx_json_number = (
+        /^-?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][\-+]?\d+)?$/
+    );
     let anon = "anonymous";     // The guessed name for anonymous functions.
     let functionage = token_global;     // The current function.
     let mode_var;               // "var" if using var; "let" if using let.
@@ -2037,19 +1524,12 @@ function phase3_parse(state) {
 
 // cause: "()"
 
-                ? stop(
-                    "expected_a_b",
-                    state,
-                    token_nxt,
-                    id,
-                    artifact(token_nxt)
-                )
+                ? stop("expected_a_b", token_nxt, id, artifact(token_nxt))
 
 // cause: "{\"aa\":0"
 
                 : stop(
                     "expected_a_b_from_c_d",
-                    state,
                     token_nxt,
                     id,
                     artifact(match),
@@ -2075,7 +1555,7 @@ function phase3_parse(state) {
 
 // cause: "[//]"
 
-                warn("unexpected_a", state, token_nxt);
+                warn("unexpected_a", token_nxt);
             }
         }
     }
@@ -2111,7 +1591,7 @@ function phase3_parse(state) {
 
 // cause: "let undefined"
 
-            warn("reserved_a", state, name);
+            warn("reserved_a", name);
         } else {
 
 // Has the name been enrolled in this context?
@@ -2121,13 +1601,7 @@ function phase3_parse(state) {
 
 // cause: "let aa;let aa"
 
-                warn(
-                    "redefinition_a_b",
-                    state,
-                    name,
-                    name.id,
-                    earlier.line
-                );
+                warn("redefinition_a_b", name, name.id, earlier.line);
 
 // Has the name been enrolled in an outer context?
 
@@ -2144,7 +1618,7 @@ function phase3_parse(state) {
 
 // cause: "let ignore;function aa(ignore){}"
 
-                            warn("unexpected_a", state, name);
+                            warn("unexpected_a", name);
                         }
                     } else {
                         if (
@@ -2161,7 +1635,6 @@ function phase3_parse(state) {
 
                             warn(
                                 "redefinition_a_b",
-                                state,
                                 name,
                                 name.id,
                                 earlier.line
@@ -2223,7 +1696,7 @@ function phase3_parse(state) {
 // cause: "!"
 // cause: "let aa=`${}`;"
 
-            return stop("unexpected_a", state, token_now);
+            return stop("unexpected_a", token_now);
         }
 
 // Parse/loop through each symbol in expression.
@@ -2262,27 +1735,57 @@ function phase3_parse(state) {
 
 // cause: "while((0)){}"
 
-            warn("unexpected_a", state, the_paren);
+            warn("unexpected_a", the_paren);
         }
 
 // Check for anticondition.
 
         switch (the_value.id) {
         case "%":
+            warn("unexpected_a", the_value);
+            break;
         case "&":
+            warn("unexpected_a", the_value);
+            break;
         case "(number)":
+            warn("unexpected_a", the_value);
+            break;
         case "(string)":
+            warn("unexpected_a", the_value);
+            break;
         case "*":
+            warn("unexpected_a", the_value);
+            break;
         case "+":
+            warn("unexpected_a", the_value);
+            break;
         case "-":
+            warn("unexpected_a", the_value);
+            break;
         case "/":
+            warn("unexpected_a", the_value);
+            break;
         case "<<":
+            warn("unexpected_a", the_value);
+            break;
         case ">>":
+            warn("unexpected_a", the_value);
+            break;
         case ">>>":
+            warn("unexpected_a", the_value);
+            break;
         case "?":
+            warn("unexpected_a", the_value);
+            break;
         case "^":
+            warn("unexpected_a", the_value);
+            break;
         case "typeof":
+            warn("unexpected_a", the_value);
+            break;
         case "|":
+            warn("unexpected_a", the_value);
+            break;
         case "~":
 
 // cause: "if(\"aa\"){}"
@@ -2302,7 +1805,7 @@ function phase3_parse(state) {
 // cause: "if(typeof 0){}"
 // cause: "if(~0){}"
 
-            warn("unexpected_a", state, the_value);
+            warn("unexpected_a", the_value);
             break;
         }
         return the_value;
@@ -2320,7 +1823,6 @@ function phase3_parse(state) {
 
             warn_at(
                 "expected_a_b",
-                state,
                 token_now.line,
                 token_now.thru + 1,
                 ";",
@@ -2347,7 +1849,7 @@ function phase3_parse(state) {
 
 // cause: "ignore:"
 
-                warn("unexpected_a", state, the_label);
+                warn("unexpected_a", the_label);
             }
             advance(":");
             if (
@@ -2368,7 +1870,7 @@ function phase3_parse(state) {
 
 // cause: "aa:"
 
-            warn("unexpected_label_a", state, the_label);
+            warn("unexpected_label_a", the_label);
         }
 
 // Parse the statement.
@@ -2396,7 +1898,7 @@ function phase3_parse(state) {
 
 // cause: "(0)"
 
-                warn("unexpected_a", state, first);
+                warn("unexpected_a", first);
             }
             semicolon();
         }
@@ -2420,11 +1922,22 @@ function phase3_parse(state) {
         while (true) {
             switch (token_nxt.id) {
             case "}":
+                return statement_list;
             case "case":
+                return statement_list;
             case "default":
+                return statement_list;
             case "else":
+                return statement_list;
             case "(end)":
                 return statement_list;
+
+// cause: ";"
+// cause: "case"
+// cause: "default"
+// cause: "else"
+// cause: "}"
+
             }
             a_statement = parse_statement();
             statement_list.push(a_statement);
@@ -2432,7 +1945,7 @@ function phase3_parse(state) {
 
 // cause: "while(0){break;0;}"
 
-                warn("unreachable_a", state, a_statement);
+                warn("unreachable_a", a_statement);
             }
             disrupt = a_statement.disrupt;
         }
@@ -2446,7 +1959,7 @@ function phase3_parse(state) {
 
 // cause: "while(0){}"
 
-            warn("unexpected_at_top_level_a", state, thing);
+            warn("unexpected_at_top_level_a", thing);
         }
     }
 
@@ -2485,7 +1998,7 @@ function phase3_parse(state) {
 
 // cause: "function aa(){}"
 
-                warn("empty_block", state, the_block);
+                warn("empty_block", the_block);
             }
             the_block.disrupt = false;
         } else {
@@ -2513,7 +2026,7 @@ function phase3_parse(state) {
 
 // cause: "0=0"
 
-            warn("bad_assignment_a", state, the_thing);
+            warn("bad_assignment_a", the_thing);
             return false;
         }
         return true;
@@ -2544,7 +2057,7 @@ function phase3_parse(state) {
                 || (id !== "." && id !== "?." && id !== "(" && id !== "[")
             )
         ) {
-            warn("unexpected_a", state, right || token_nxt);
+            warn("unexpected_a", right || token_nxt);
             return false;
         }
         return true;
@@ -2590,7 +2103,7 @@ function phase3_parse(state) {
                 || right.arity === "pre"
                 || right.arity === "post"
             ) {
-                warn("unexpected_a", state, right);
+                warn("unexpected_a", right);
             }
             mutation_check(left);
             return the_token;
@@ -2734,7 +2247,7 @@ function phase3_parse(state) {
 
 // cause: "let aa={0:0}"
 
-            return stop("expected_identifier_a", state, name);
+            return stop("expected_identifier_a", name);
         }
 
 // If we have seen this name before, increment its count.
@@ -2752,7 +2265,7 @@ function phase3_parse(state) {
 
 // cause: "/*property aa*/\naa.bb"
 
-                    warn("unregistered_property_a", state, name);
+                    warn("unregistered_property_a", name);
                 }
             } else if (
                 !option_dict.name
@@ -2769,7 +2282,7 @@ function phase3_parse(state) {
 // cause: "aa.aaSync"
 // cause: "aa.aa_"
 
-                warn("bad_property_a", state, name);
+                warn("bad_property_a", name);
             }
             property_dict[id] = 1;
         }
@@ -2792,7 +2305,7 @@ function phase3_parse(state) {
 
 // cause: "0?0:0"
 
-                warn("use_open", state, the_token);
+                warn("use_open", the_token);
             }
             return the_token;
         };
@@ -2835,7 +2348,7 @@ function phase3_parse(state) {
 
 // cause: "arguments"
 
-        warn("unexpected_a", state, token_now);
+        warn("unexpected_a", token_now);
         return token_now;
     });
     constant("eval", "function", function () {
@@ -2843,18 +2356,12 @@ function phase3_parse(state) {
 
 // cause: "eval"
 
-            warn("unexpected_a", state, token_now);
+            warn("unexpected_a", token_now);
         } else if (token_nxt.id !== "(") {
 
 // cause: "/*jslint eval*/\neval"
 
-            warn(
-                "expected_a_before_b",
-                state,
-                token_nxt,
-                "(",
-                artifact(token_nxt)
-            );
+            warn("expected_a_before_b", token_nxt, "(", artifact(token_nxt));
         }
         return token_now;
     });
@@ -2864,18 +2371,12 @@ function phase3_parse(state) {
 
 // cause: "Function()"
 
-            warn("unexpected_a", state, token_now);
+            warn("unexpected_a", token_now);
         } else if (token_nxt.id !== "(") {
 
 // cause: "/*jslint eval*/\nFunction"
 
-            warn(
-                "expected_a_before_b",
-                state,
-                token_nxt,
-                "(",
-                artifact(token_nxt)
-            );
+            warn("expected_a_before_b", token_nxt, "(", artifact(token_nxt));
         }
         return token_now;
     });
@@ -2883,7 +2384,7 @@ function phase3_parse(state) {
 
 // cause: "ignore"
 
-        warn("unexpected_a", state, token_now);
+        warn("unexpected_a", token_now);
         return token_now;
     });
     constant("Infinity", "number", Infinity);
@@ -2891,14 +2392,14 @@ function phase3_parse(state) {
 
 // cause: "isFinite"
 
-        warn("expected_a_b", state, token_now, "Number.isFinite", "isFinite");
+        warn("expected_a_b", token_now, "Number.isFinite", "isFinite");
         return token_now;
     });
     constant("isNaN", "function", function () {
 
 // cause: "isNaN(0)"
 
-        warn("number_isNaN", state, token_now);
+        warn("number_isNaN", token_now);
         return token_now;
     });
     constant("NaN", "number", NaN);
@@ -2908,7 +2409,7 @@ function phase3_parse(state) {
 
 // cause: "this"
 
-            warn("unexpected_a", state, token_now);
+            warn("unexpected_a", token_now);
         }
         return token_now;
     });
@@ -2998,7 +2499,7 @@ function phase3_parse(state) {
 
 // cause: "aa((0))"
 
-                warn("unexpected_a", state, the_paren);
+                warn("unexpected_a", the_paren);
             }
             if (the_argument.id === "(") {
                 the_argument.wrapped = true;
@@ -3044,7 +2545,7 @@ function phase3_parse(state) {
 
 // cause: "aa.0"
 
-            stop("expected_identifier_a", state, token_nxt);
+            stop("expected_identifier_a", token_nxt);
         }
         advance();
         survey(name);
@@ -3092,7 +2593,7 @@ function phase3_parse(state) {
 
 // cause: "aa?.0"
 
-            stop("expected_identifier_a", state, token_nxt);
+            stop("expected_identifier_a", token_nxt);
         }
         advance();
         survey(name);
@@ -3112,7 +2613,7 @@ function phase3_parse(state) {
 
 // cause: "aa[`aa`]"
 
-                warn("subscript_a", state, the_subscript, name);
+                warn("subscript_a", the_subscript, name);
             }
         }
 
@@ -3127,7 +2628,7 @@ function phase3_parse(state) {
 
 // cause: "aa=>0"
 
-        return stop("wrap_parameter", state, left);
+        return stop("wrap_parameter", left);
     });
 
     function do_tick() {
@@ -3209,13 +2710,13 @@ function phase3_parse(state) {
 
 // cause: "/="
 
-        stop("expected_a_b", state, token_now, "/\\=", "/=");
+        stop("expected_a_b", token_now, "/\\=", "/=");
     });
     prefix("=>", function () {
 
 // cause: "=>0"
 
-        return stop("expected_a_before_b", state, token_now, "()", "=>");
+        return stop("expected_a_before_b", token_now, "()", "=>");
     });
     prefix("new", function () {
         const the_new = token_now;
@@ -3224,13 +2725,7 @@ function phase3_parse(state) {
 
 // cause: "new aa"
 
-            warn(
-                "expected_a_before_b",
-                state,
-                token_nxt,
-                "()",
-                artifact(token_nxt)
-            );
+            warn("expected_a_before_b", token_nxt, "()", artifact(token_nxt));
         }
         the_new.expression = right;
         return the_new;
@@ -3242,7 +2737,7 @@ function phase3_parse(state) {
 // cause: "void"
 // cause: "void 0"
 
-        warn("unexpected_a", state, the_void);
+        warn("unexpected_a", the_void);
         the_void.expression = parse_expression(0);
         return the_void;
     });
@@ -3264,7 +2759,6 @@ function phase3_parse(state) {
 
                         warn(
                             "required_a_optional_b",
-                            state,
                             token_nxt,
                             token_nxt.id,
                             optional.id
@@ -3281,11 +2775,7 @@ function phase3_parse(state) {
 // cause: "function aa(aa=0,{}){}"
 // cause: "function aa({0}){}"
 
-                            return stop(
-                                "expected_identifier_a",
-                                state,
-                                token_nxt
-                            );
+                            return stop("expected_identifier_a", token_nxt);
                         }
                         survey(subparam);
                         artifact_now = artifact_nxt;
@@ -3299,7 +2789,6 @@ function phase3_parse(state) {
 
                             warn(
                                 "expected_a_before_b",
-                                state,
                                 subparam,
                                 artifact_nxt,
                                 artifact_now
@@ -3318,7 +2807,6 @@ function phase3_parse(state) {
 
                                 return stop(
                                     "expected_identifier_a",
-                                    state,
                                     token_nxt
                                 );
                             }
@@ -3353,7 +2841,6 @@ function phase3_parse(state) {
 
                         warn(
                             "required_a_optional_b",
-                            state,
                             token_nxt,
                             token_nxt.id,
                             optional.id
@@ -3369,11 +2856,7 @@ function phase3_parse(state) {
 
 // cause: "function aa(aa=0,[]){}"
 
-                            return stop(
-                                "expected_identifier_a",
-                                state,
-                                token_nxt
-                            );
+                            return stop("expected_identifier_a", token_nxt);
                         }
                         advance();
                         param.names.push(subparam);
@@ -3408,7 +2891,6 @@ function phase3_parse(state) {
 
                             warn(
                                 "required_a_optional_b",
-                                state,
                                 token_nxt,
                                 token_nxt.id,
                                 optional.id
@@ -3419,7 +2901,7 @@ function phase3_parse(state) {
 
 // cause: "function aa(0){}"
 
-                        return stop("expected_identifier_a", state, token_nxt);
+                        return stop("expected_identifier_a", token_nxt);
                     }
                     param = token_nxt;
                     list.push(param);
@@ -3439,7 +2921,6 @@ function phase3_parse(state) {
 
                                 warn(
                                     "required_a_optional_b",
-                                    state,
                                     param,
                                     param.id,
                                     optional.id
@@ -3473,7 +2954,7 @@ function phase3_parse(state) {
 // cause: "function(){}"
 // cause: "function*aa(){}"
 
-                    return stop("expected_identifier_a", state, token_nxt);
+                    return stop("expected_identifier_a", token_nxt);
                 }
                 name = token_nxt;
                 enroll(name, "variable", true);
@@ -3499,7 +2980,7 @@ function phase3_parse(state) {
 //  assert_or_throw(!mode_mega, `Expected !mode_mega.`);
 //  Probably deadcode.
 //  if (mode_mega) {
-//      warn("unexpected_a", state, the_function);
+//      warn("unexpected_a", the_function);
 //  }
 
 // Don't create functions in loops. It is inefficient, and it can lead to
@@ -3509,7 +2990,7 @@ function phase3_parse(state) {
 
 // cause: "while(0){aa.map(function(){});}"
 
-            warn("function_in_loop", state, the_function);
+            warn("function_in_loop", the_function);
         }
 
 // Give the function properties for storing its names and for observing the
@@ -3529,10 +3010,7 @@ function phase3_parse(state) {
         function_stack.push(functionage);
         function_list.push(the_function);
         functionage = the_function;
-        if (
-            the_function.arity !== "statement"
-            && typeof name === "object"
-        ) {
+        if (the_function.arity !== "statement" && typeof name === "object") {
 
 // cause: "let aa=function bb(){return;};"
 
@@ -3569,7 +3047,7 @@ function phase3_parse(state) {
 
 // cause: "function aa(){}0"
 
-            return stop("unexpected_a", state, token_nxt);
+            return stop("unexpected_a", token_nxt);
         }
         if (
             token_nxt.id === "."
@@ -3579,7 +3057,7 @@ function phase3_parse(state) {
 
 // cause: "function aa(){}\n[]"
 
-            warn("unexpected_a", state, token_nxt);
+            warn("unexpected_a", token_nxt);
         }
 
 // Restore the previous context.
@@ -3602,7 +3080,7 @@ function phase3_parse(state) {
 
 // cause: "async function aa(){}"
 
-            warn("missing_await_statement", state, the_function);
+            warn("missing_await_statement", the_function);
         }
         return the_function;
     }
@@ -3615,7 +3093,7 @@ function phase3_parse(state) {
 // cause: "function aa(){aa=await 0;}"
 // cause: "function aa(){await 0;}"
 
-            warn("unexpected_a", state, the_await);
+            warn("unexpected_a", the_await);
         } else {
             functionage.async += 1;
         }
@@ -3644,7 +3122,7 @@ function phase3_parse(state) {
 
 // cause: "while(0){aa.map(()=>0);}"
 
-            warn("function_in_loop", state, the_fart);
+            warn("function_in_loop", the_fart);
         }
 
 // Give the function properties storing its names and for observing the depth
@@ -3672,7 +3150,7 @@ function phase3_parse(state) {
 
 // cause: "()=>{}"
 
-            warn("expected_a_b", state, the_fart, "function", "=>");
+            warn("expected_a_b", the_fart, "function", "=>");
             the_fart.block = block("body");
         } else {
             the_fart.expression = parse_expression(0);
@@ -3709,7 +3187,7 @@ function phase3_parse(state) {
 
 // cause: "((0))"
 
-            warn("unexpected_a", state, the_paren);
+            warn("unexpected_a", the_paren);
         }
         the_value.wrapped = true;
         advance(")", the_paren);
@@ -3720,23 +3198,17 @@ function phase3_parse(state) {
 // cause: "([])=>0"
 // cause: "({})=>0"
 
-                    warn(
-                        "expected_a_before_b",
-                        state,
-                        the_paren,
-                        "function",
-                        "("
-                    );
+                    warn("expected_a_before_b", the_paren, "function", "(");
 
 // cause: "([])=>0"
 // cause: "({})=>0"
 
-                    return stop("expected_a_b", state, token_nxt, "{", "=>");
+                    return stop("expected_a_b", token_nxt, "{", "=>");
                 }
 
 // cause: "(0)=>0"
 
-                return stop("expected_identifier_a", state, the_value);
+                return stop("expected_identifier_a", the_value);
             }
             the_paren.expression = [the_value];
             return fart([the_paren.expression, "(" + the_value.id + ")"]);
@@ -3772,7 +3244,6 @@ function phase3_parse(state) {
 
                     warn(
                         "expected_a_before_b",
-                        state,
                         name,
                         artifact_nxt,
                         artifact_now
@@ -3786,7 +3257,7 @@ function phase3_parse(state) {
 
 // cause: "aa={get aa(){}}"
 
-                        warn("unexpected_a", state, name);
+                        warn("unexpected_a", name);
                     }
                     extra = name.id;
                     full = extra + " " + token_nxt.id;
@@ -3797,7 +3268,7 @@ function phase3_parse(state) {
 
 // cause: "aa={get aa(){},get aa(){}}"
 
-                        warn("duplicate_a", state, name);
+                        warn("duplicate_a", name);
                     }
                     seen[id] = false;
                     seen[full] = true;
@@ -3807,7 +3278,7 @@ function phase3_parse(state) {
 
 // cause: "aa={aa,aa}"
 
-                        warn("duplicate_a", state, name);
+                        warn("duplicate_a", name);
                     }
                     seen[id] = true;
                 }
@@ -3856,12 +3327,7 @@ function phase3_parse(state) {
 
 // cause: "aa={aa:aa}"
 
-                            warn(
-                                "unexpected_a",
-                                state,
-                                the_colon,
-                                ": " + name.id
-                            );
+                            warn("unexpected_a", the_colon, ": " + name.id);
                         }
                     }
                     value.label = name;
@@ -3895,7 +3361,7 @@ function phase3_parse(state) {
 
 // cause: ";"
 
-        warn("unexpected_a", state, token_now);
+        warn("unexpected_a", token_now);
         return token_now;
     });
     stmt("{", function () {
@@ -3903,7 +3369,7 @@ function phase3_parse(state) {
 // cause: ";{}"
 // cause: "class aa{}"
 
-        warn("naked_block", state, token_now);
+        warn("naked_block", token_now);
         return block("naked");
     });
     stmt("async", do_async);
@@ -3918,7 +3384,7 @@ function phase3_parse(state) {
 
 // cause: "break"
 
-            warn("unexpected_a", state, the_break);
+            warn("unexpected_a", the_break);
         }
         the_break.disrupt = true;
         if (token_nxt.identifier && token_now.line === token_nxt.line) {
@@ -3932,12 +3398,12 @@ function phase3_parse(state) {
 
 // cause: "aa:{function aa(aa){break aa;}}"
 
-                    warn("out_of_scope_a", state, token_nxt);
+                    warn("out_of_scope_a", token_nxt);
                 } else {
 
 // cause: "aa:{break aa;}"
 
-                    warn("not_label_a", state, token_nxt);
+                    warn("not_label_a", token_nxt);
                 }
             } else {
                 the_label.used += 1;
@@ -3963,13 +3429,7 @@ function phase3_parse(state) {
 
 // cause: "let aa;var aa"
 
-                warn(
-                    "expected_a_b",
-                    state,
-                    the_statement,
-                    mode_var,
-                    the_statement.id
-                );
+                warn("expected_a_b", the_statement, mode_var, the_statement.id);
             }
         }
 
@@ -3979,13 +3439,13 @@ function phase3_parse(state) {
 
 // cause: "switch(0){case 0:var aa}"
 
-            warn("var_switch", state, the_statement);
+            warn("var_switch", the_statement);
         }
         if (functionage.loop > 0 && the_statement.id === "var") {
 
 // cause: "while(0){var aa;}"
 
-            warn("var_loop", state, the_statement);
+            warn("var_loop", the_statement);
         }
         (function next() {
             let artifact_now;
@@ -3998,12 +3458,12 @@ function phase3_parse(state) {
 
 // cause: "let {0}"
 
-                        return stop("expected_identifier_a", state, token_nxt);
+                        return stop("expected_identifier_a", token_nxt);
                     }
                     const name = token_nxt;
                     survey(name);
                     artifact_now = artifact_nxt;
-                    artifact_nxt = `identifier ${artifact(name)}`;
+                    artifact_nxt = `variable ${artifact(name)}`;
                     if (
                         !option_dict.unordered
                         && artifact_now > artifact_nxt
@@ -4013,7 +3473,6 @@ function phase3_parse(state) {
 
                         warn(
                             "expected_a_before_b",
-                            state,
                             name,
                             artifact_nxt,
                             artifact_now
@@ -4027,11 +3486,7 @@ function phase3_parse(state) {
 // cause: "let {aa:0}"
 // cause: "let {aa:{aa}}"
 
-                            return stop(
-                                "expected_identifier_a",
-                                state,
-                                token_nxt
-                            );
+                            return stop("expected_identifier_a", token_nxt);
                         }
                         token_nxt.label = name;
                         the_statement.names.push(token_nxt);
@@ -4073,7 +3528,7 @@ function phase3_parse(state) {
 
 // cause: "let[]"
 
-                        return stop("expected_identifier_a", state, token_nxt);
+                        return stop("expected_identifier_a", token_nxt);
                     }
                     const name = token_nxt;
                     advance();
@@ -4105,7 +3560,7 @@ function phase3_parse(state) {
 
 // cause: "let ignore;function aa(ignore) {}"
 
-                    warn("unexpected_a", state, name);
+                    warn("unexpected_a", name);
                 }
                 enroll(name, "variable", mode_const);
                 if (token_nxt.id === "=" || mode_const) {
@@ -4120,7 +3575,7 @@ function phase3_parse(state) {
 // cause: "let 0"
 // cause: "var{aa:{aa}}"
 
-                return stop("expected_identifier_a", state, token_nxt);
+                return stop("expected_identifier_a", token_nxt);
             }
         }());
         semicolon();
@@ -4135,11 +3590,11 @@ function phase3_parse(state) {
 // cause: "continue"
 // cause: "function aa(){while(0){try{}finally{continue}}}"
 
-            warn("unexpected_a", state, the_continue);
+            warn("unexpected_a", the_continue);
         }
         not_top_level(the_continue);
         the_continue.disrupt = true;
-        warn("unexpected_a", state, the_continue);
+        warn("unexpected_a", the_continue);
         advance(";");
         return the_continue;
     });
@@ -4149,7 +3604,7 @@ function phase3_parse(state) {
 
 // cause: "debugger"
 
-            warn("unexpected_a", state, the_debug);
+            warn("unexpected_a", the_debug);
         }
         semicolon();
         return the_debug;
@@ -4164,7 +3619,7 @@ function phase3_parse(state) {
 
 // cause: "delete 0"
 
-            stop("expected_a_b", state, the_value, ".", artifact(the_value));
+            stop("expected_a_b", the_value, ".", artifact(the_value));
         }
         the_token.expression = the_value;
         semicolon();
@@ -4182,7 +3637,7 @@ function phase3_parse(state) {
 
 // cause: "function aa(){do{break;}while(0)}"
 
-            warn("weird_loop", state, the_do);
+            warn("weird_loop", the_do);
         }
         functionage.loop -= 1;
         return the_do;
@@ -4198,7 +3653,7 @@ function phase3_parse(state) {
 
 // cause: "export {}"
 
-                stop("expected_identifier_a", state, token_nxt);
+                stop("expected_identifier_a", token_nxt);
             }
             the_id = token_nxt.id;
             the_name = token_global.context[the_id];
@@ -4206,14 +3661,14 @@ function phase3_parse(state) {
 
 // cause: "export {aa}"
 
-                warn("unexpected_a", state, token_nxt);
+                warn("unexpected_a", token_nxt);
             } else {
                 the_name.used += 1;
                 if (export_dict[the_id] !== undefined) {
 
 // cause: "let aa;export{aa,aa}"
 
-                    warn("duplicate_a", state, token_nxt);
+                    warn("duplicate_a", token_nxt);
                 }
                 export_dict[the_id] = the_name;
             }
@@ -4227,7 +3682,7 @@ function phase3_parse(state) {
 
 // cause: "export default 0;export default 0"
 
-                warn("duplicate_a", state, token_nxt);
+                warn("duplicate_a", token_nxt);
             }
             advance("default");
             the_thing = parse_expression(0);
@@ -4240,7 +3695,7 @@ function phase3_parse(state) {
 
 // cause: "export default {}"
 
-                warn("freeze_exports", state, the_thing);
+                warn("freeze_exports", the_thing);
 
 // Fixes issues #282 - optional-semicolon.
 
@@ -4257,7 +3712,7 @@ function phase3_parse(state) {
 
 // cause: "export function aa(){}"
 
-                warn("freeze_exports", state, token_nxt);
+                warn("freeze_exports", token_nxt);
                 the_thing = parse_statement();
                 the_name = the_thing.name;
                 the_id = the_name.id;
@@ -4266,7 +3721,7 @@ function phase3_parse(state) {
 // cause: "let aa;export{aa};export function aa(){}"
 
                 if (export_dict[the_id] !== undefined) {
-                    warn("duplicate_a", state, the_name);
+                    warn("duplicate_a", the_name);
                 }
                 export_dict[the_id] = the_thing;
                 the_export.expression.push(the_thing);
@@ -4282,7 +3737,7 @@ function phase3_parse(state) {
 // cause: "export let"
 // cause: "export var"
 
-                warn("unexpected_a", state, token_nxt);
+                warn("unexpected_a", token_nxt);
                 parse_statement();
             } else if (token_nxt.id === "{") {
 
@@ -4302,7 +3757,7 @@ function phase3_parse(state) {
 
 // cause: "export"
 
-                stop("unexpected_a", state, token_nxt);
+                stop("unexpected_a", token_nxt);
             }
         }
         state.mode_module = true;
@@ -4315,7 +3770,7 @@ function phase3_parse(state) {
 
 // cause: "for"
 
-            warn("unexpected_a", state, the_for);
+            warn("unexpected_a", the_for);
         }
         not_top_level(the_for);
         functionage.loop += 1;
@@ -4328,7 +3783,7 @@ function phase3_parse(state) {
 
 // cause: "for(;;){}"
 
-            return stop("expected_a_b", state, the_for, "while (", "for (;");
+            return stop("expected_a_b", the_for, "while (", "for (;");
         }
         if (
             token_nxt.id === "var"
@@ -4338,7 +3793,7 @@ function phase3_parse(state) {
 
 // cause: "for(const aa in aa){}"
 
-            return stop("unexpected_a", state, token_nxt);
+            return stop("unexpected_a", token_nxt);
         }
         first = parse_expression(0);
         if (first.id === "in") {
@@ -4346,11 +3801,11 @@ function phase3_parse(state) {
 
 // cause: "for(0 in aa){}"
 
-                warn("bad_assignment_a", state, first.expression[0]);
+                warn("bad_assignment_a", first.expression[0]);
             }
             the_for.name = first.expression[0];
             the_for.expression = first.expression[1];
-            warn("expected_a_b", state, the_for, "Object.keys", "for in");
+            warn("expected_a_b", the_for, "Object.keys", "for in");
         } else {
             the_for.initial = first;
             advance(";");
@@ -4361,7 +3816,7 @@ function phase3_parse(state) {
 
 // cause: "for(aa;aa;aa++){}"
 
-                warn("expected_a_b", state, the_for.inc, "+= 1", "++");
+                warn("expected_a_b", the_for.inc, "+= 1", "++");
             }
         }
         advance(")");
@@ -4370,7 +3825,7 @@ function phase3_parse(state) {
 
 // cause: "/*jslint for*/\nfunction aa(bb,cc){for(0;0;0){break;}}"
 
-            warn("weird_loop", state, the_for);
+            warn("weird_loop", the_for);
         }
         functionage.loop -= 1;
         return the_for;
@@ -4405,7 +3860,7 @@ function phase3_parse(state) {
 
 // cause: "if(0){break;}else{}"
 
-                    warn("unexpected_a", state, the_else);
+                    warn("unexpected_a", the_else);
                 }
             }
         }
@@ -4420,7 +3875,6 @@ function phase3_parse(state) {
 
             warn(
                 "unexpected_directive_a",
-                state,
                 state.mode_module,
                 state.mode_module.directive
             );
@@ -4433,7 +3887,7 @@ function phase3_parse(state) {
 
 // cause: "import ignore from \"aa\""
 
-                warn("unexpected_a", state, name);
+                warn("unexpected_a", name);
             }
             enroll(name, "variable", true);
             the_import.name = name;
@@ -4446,7 +3900,7 @@ function phase3_parse(state) {
 
 // cause: "import {"
 
-                        stop("expected_identifier_a", state, token_nxt);
+                        stop("expected_identifier_a", token_nxt);
                     }
                     name = token_nxt;
                     advance();
@@ -4454,7 +3908,7 @@ function phase3_parse(state) {
 
 // cause: "import {ignore} from \"aa\""
 
-                        warn("unexpected_a", state, name);
+                        warn("unexpected_a", name);
                     }
                     enroll(name, "variable", true);
                     names.push(name);
@@ -4470,11 +3924,14 @@ function phase3_parse(state) {
         advance("from");
         advance("(string)");
         the_import.import = token_now;
-        if (!rx_module.test(token_now.value)) {
+        if (!(
+            // rx_module
+            /^[a-zA-Z0-9_$:.@\-\/]+$/
+        ).test(token_now.value)) {
 
 // cause: "import aa from \"!aa\""
 
-            warn("bad_module_name_a", state, token_now);
+            warn("bad_module_name_a", token_now);
         }
         import_list.push(token_now.value);
         semicolon();
@@ -4488,7 +3945,7 @@ function phase3_parse(state) {
 
 // cause: "function aa(){try{}finally{return;}}"
 
-            warn("unexpected_a", state, the_return);
+            warn("unexpected_a", the_return);
         }
         the_return.disrupt = true;
         if (token_nxt.id !== ";" && the_return.line === token_nxt.line) {
@@ -4509,7 +3966,7 @@ function phase3_parse(state) {
 
 // cause: "function aa(){try{}finally{switch(0){}}}"
 
-            warn("unexpected_a", state, the_switch);
+            warn("unexpected_a", the_switch);
         }
         functionage.switch += 1;
         advance("(");
@@ -4530,12 +3987,12 @@ function phase3_parse(state) {
                 token_now.switch = true;
                 const exp = parse_expression(0);
                 if (dups.some(function (thing) {
-                    return are_similar(thing, exp);
+                    return is_equal(thing, exp);
                 })) {
 
 // cause: "switch(0){case 0:break;case 0:break}"
 
-                    warn("unexpected_a", state, exp);
+                    warn("unexpected_a", exp);
                 }
                 dups.push(exp);
                 the_case.expression.push(exp);
@@ -4549,7 +4006,7 @@ function phase3_parse(state) {
 
 // cause: "switch(0){case 0:}"
 
-                warn("expected_statements_a", state, token_nxt);
+                warn("expected_statements_a", token_nxt);
                 return;
             }
             the_case.block = stmts;
@@ -4562,7 +4019,6 @@ function phase3_parse(state) {
             } else {
                 warn(
                     "expected_a_before_b",
-                    state,
                     token_nxt,
                     "break;",
                     artifact(token_nxt)
@@ -4583,7 +4039,7 @@ function phase3_parse(state) {
 
 // cause: "switch(0){case 0:break;default:}"
 
-                warn("unexpected_a", state, the_default);
+                warn("unexpected_a", the_default);
                 the_disrupt = false;
             } else {
                 const the_last = the_switch.else[
@@ -4596,7 +4052,7 @@ function phase3_parse(state) {
 
 // cause: "switch(0){case 0:break;default:break;}"
 
-                    warn("unexpected_a", state, the_last);
+                    warn("unexpected_a", the_last);
                     the_last.disrupt = false;
                 }
                 the_disrupt = the_disrupt && the_last.disrupt;
@@ -4618,7 +4074,7 @@ function phase3_parse(state) {
 
 // cause: "try{throw 0}catch(){}"
 
-            warn("unexpected_a", state, the_throw);
+            warn("unexpected_a", the_throw);
         }
         return the_throw;
     });
@@ -4631,7 +4087,7 @@ function phase3_parse(state) {
 
 // cause: "try{try{}catch(){}}catch(){}"
 
-            warn("unexpected_a", state, the_try);
+            warn("unexpected_a", the_try);
         }
         functionage.try += 1;
         the_try.block = block();
@@ -4654,7 +4110,7 @@ function phase3_parse(state) {
 
 // cause: "try{}catch(){}"
 
-                    return stop("expected_identifier_a", state, token_nxt);
+                    return stop("expected_identifier_a", token_nxt);
                 }
                 if (token_nxt.id !== "ignore") {
                     ignored = undefined;
@@ -4682,7 +4138,6 @@ function phase3_parse(state) {
 
             warn(
                 "expected_a_before_b",
-                state,
                 token_nxt,
                 "catch",
                 artifact(token_nxt)
@@ -4711,7 +4166,7 @@ function phase3_parse(state) {
 
 // cause: "function aa(){while(0){break;}}"
 
-            warn("weird_loop", state, the_while);
+            warn("weird_loop", the_while);
         }
         functionage.loop -= 1;
         return the_while;
@@ -4720,7 +4175,7 @@ function phase3_parse(state) {
 
 // cause: "with"
 
-        stop("unexpected_a", state, token_now);
+        stop("unexpected_a", token_now);
     });
 
     ternary("?", ":");
@@ -4757,7 +4212,6 @@ function phase3_parse(state) {
 
                                 warn(
                                     "unexpected_a",
-                                    state,
                                     token_nxt,
                                     token_nxt.quote
                                 );
@@ -4768,12 +4222,12 @@ function phase3_parse(state) {
 
 // cause: "{\"aa\":0,\"aa\":0}"
 
-                                warn("duplicate_a", state, token_now);
+                                warn("duplicate_a", token_now);
                             } else if (token_now.value === "__proto__") {
 
 // cause: "{\"__proto__\":0}"
 
-                                warn("bad_property_a", state, token_now);
+                                warn("bad_property_a", token_now);
                             } else {
                                 object[token_now.value] = token_now;
                             }
@@ -4814,9 +4268,13 @@ function phase3_parse(state) {
                     advance("]", bracket);
                     return bracket;
                 }());
-            case "true":
             case "false":
+                advance();
+                return token_now;
             case "null":
+                advance();
+                return token_now;
+            case "true":
 
 // cause: "[false]"
 // cause: "[null]"
@@ -4825,11 +4283,11 @@ function phase3_parse(state) {
                 advance();
                 return token_now;
             case "(number)":
-                if (!rx_JSON_number.test(token_nxt.value)) {
+                if (!rx_json_number.test(token_nxt.value)) {
 
 // cause: "[0x0]"
 
-                    warn("unexpected_a", state, token_nxt);
+                    warn("unexpected_a", token_nxt);
                 }
                 advance();
                 return token_now;
@@ -4838,7 +4296,7 @@ function phase3_parse(state) {
 
 // cause: "['']"
 
-                    warn("unexpected_a", state, token_nxt, token_nxt.quote);
+                    warn("unexpected_a", token_nxt, token_nxt.quote);
                 }
                 advance();
                 return token_now;
@@ -4847,11 +4305,11 @@ function phase3_parse(state) {
                 negative.arity = "unary";
                 advance("-");
                 advance("(number)");
-                if (!rx_JSON_number.test(token_now.value)) {
+                if (!rx_json_number.test(token_now.value)) {
 
 // cause: "[-0x0]"
 
-                    warn("unexpected_a", state, token_now);
+                    warn("unexpected_a", token_now);
                 }
                 negative.expression = token_now;
                 return negative;
@@ -4859,7 +4317,7 @@ function phase3_parse(state) {
 
 // cause: "[undefined]"
 
-                stop("unexpected_a", state, token_nxt);
+                stop("unexpected_a", token_nxt);
             }
         }());
         advance("(end)");
@@ -4890,23 +4348,29 @@ function phase3_parse(state) {
     advance("(end)");
 }
 
-
-function phase4_walk(state) {
+function jslint_phase4_walk(state) {
 
 // PHASE 4. Walk <token_tree>, traversing all of the nodes of the tree. It is a
 //          recursive traversal. Each node may be processed on the way down
 //          (preaction) and on the way up (postaction).
 
     const {
+        artifact,
         global_list,
+        is_equal,
+        is_weird,
         option_dict,
         syntax_dict,
-        token_global
+        token_global,
+        warn
     } = state;
-    const function_stack = [];  // The stack of functions.
     const block_stack = [];     // The stack of blocks.
+    const function_stack = [];  // The stack of functions.
     const posts = empty();
     const pres = empty();
+    const relationop = populate([       // The relational operators.
+        "!=", "!==", "==", "===", "<", "<=", ">", ">="
+    ]);
     let blockage = token_global;        // The current block.
     let functionage = token_global;     // The current function.
     let postaction;
@@ -5001,7 +4465,7 @@ function phase4_walk(state) {
 
 // cause: "if(0){import aa from \"aa\";}"
 
-            warn("misplaced_a", state, the_thing);
+            warn("misplaced_a", the_thing);
         }
     }
 
@@ -5027,7 +4491,7 @@ function phase4_walk(state) {
 // cause: "aa=++aa"
 // cause: "aa=--aa"
 
-                    warn("unexpected_a", state, thing);
+                    warn("unexpected_a", thing);
                 } else if (
 
 // cause: "aa=0"
@@ -5038,7 +4502,7 @@ function phase4_walk(state) {
 
 // cause: "aa[aa=0]"
 
-                    warn("unexpected_statement_a", state, thing);
+                    warn("unexpected_statement_a", thing);
                 }
                 postamble(thing);
             }
@@ -5060,7 +4524,7 @@ function phase4_walk(state) {
 
 // cause: "0&&0"
 
-                        warn("unexpected_expression_a", state, thing);
+                        warn("unexpected_expression_a", thing);
                     }
                 } else if (
                     thing.arity !== "statement"
@@ -5075,7 +4539,7 @@ function phase4_walk(state) {
 // cause: "async function aa(){await 0;}"
 // cause: "typeof 0"
 
-                    warn("unexpected_expression_a", state, thing);
+                    warn("unexpected_expression_a", thing);
                 }
                 walk_statement(thing.block);
                 walk_statement(thing.else);
@@ -5115,7 +4579,7 @@ function phase4_walk(state) {
 // cause: "class aa{}"
 // cause: "let aa=0;try{aa();}catch(bb){bb();}bb();"
 
-                        warn("undeclared_a", state, thing);
+                        warn("undeclared_a", thing);
                         return;
                     }
                     the_variable = {
@@ -5135,7 +4599,7 @@ function phase4_walk(state) {
 
 // cause: "aa:while(0){aa;}"
 
-                warn("label_a", state, thing);
+                warn("label_a", thing);
             }
             if (
                 the_variable.dead
@@ -5148,7 +4612,7 @@ function phase4_walk(state) {
 
 // cause: "function aa(){bb();}\nfunction bb(){}"
 
-                warn("out_of_scope_a", state, thing);
+                warn("out_of_scope_a", thing);
             }
             return the_variable;
         }
@@ -5170,7 +4634,7 @@ function phase4_walk(state) {
 
 // cause: "if(0){function aa(){}\n}"
 
-            warn("unexpected_a", state, thing);
+            warn("unexpected_a", thing);
         }
         function_stack.push(functionage);
         block_stack.push(blockage);
@@ -5186,14 +4650,14 @@ function phase4_walk(state) {
 
 // cause: "/*jslint getset*/\naa={get aa(aa){}}"
 
-                warn("bad_get", state, thing);
+                warn("bad_get", thing);
             }
         } else if (thing.extra === "set") {
             if (thing.parameters.length !== 1) {
 
 // cause: "/*jslint getset*/\naa={set aa(){}}"
 
-                warn("bad_set", state, thing);
+                warn("bad_set", thing);
             }
         }
         thing.parameters.forEach(function (name) {
@@ -5213,17 +4677,41 @@ function phase4_walk(state) {
 
         switch (!option_dict.bitwise && thing.id) {
         case "&":
+            warn("unexpected_a", thing);
+            break;
         case "&=":
+            warn("unexpected_a", thing);
+            break;
         case "<<":
+            warn("unexpected_a", thing);
+            break;
         case "<<=":
+            warn("unexpected_a", thing);
+            break;
         case ">>":
+            warn("unexpected_a", thing);
+            break;
         case ">>=":
+            warn("unexpected_a", thing);
+            break;
         case ">>>":
+            warn("unexpected_a", thing);
+            break;
         case ">>>=":
+            warn("unexpected_a", thing);
+            break;
         case "^":
+            warn("unexpected_a", thing);
+            break;
         case "^=":
+            warn("unexpected_a", thing);
+            break;
         case "|":
+            warn("unexpected_a", thing);
+            break;
         case "|=":
+            warn("unexpected_a", thing);
+            break;
         case "~":
 
 // cause: "0&0"
@@ -5240,7 +4728,7 @@ function phase4_walk(state) {
 // cause: "0|=0"
 // cause: "~0"
 
-            warn("unexpected_a", state, thing);
+            warn("unexpected_a", thing);
             break;
         }
         if (
@@ -5258,7 +4746,7 @@ function phase4_walk(state) {
 
 // cause: "0<0<0"
 
-            warn("unexpected_a", state, thing);
+            warn("unexpected_a", thing);
         }
     }
 
@@ -5301,7 +4789,7 @@ function phase4_walk(state) {
                 return;
             }
         }
-        warn("bad_assignment_a", state, name);
+        warn("bad_assignment_a", name);
     }
 
     function postaction_function(thing) {
@@ -5314,7 +4802,7 @@ function phase4_walk(state) {
 
 // cause: "aa=(function(){})"
 
-            warn("unexpected_parens", state, thing);
+            warn("unexpected_parens", thing);
         }
         return pop_block();
     }
@@ -5334,14 +4822,14 @@ function phase4_walk(state) {
 
 // cause: "NaN===NaN"
 
-                warn("number_isNaN", state, thing);
+                warn("number_isNaN", thing);
             } else if (left.id === "typeof") {
                 if (right.id !== "(string)") {
                     if (right.id !== "typeof") {
 
 // cause: "typeof 0===0"
 
-                        warn("expected_string_a", state, right);
+                        warn("expected_string_a", right);
                     }
                 } else {
                     const value = right.value;
@@ -5349,7 +4837,7 @@ function phase4_walk(state) {
 
 // cause: "typeof aa===\"undefined\""
 
-                        warn("unexpected_typeof_a", state, right, value);
+                        warn("unexpected_typeof_a", right, value);
                     } else if (
                         value !== "boolean"
                         && value !== "function"
@@ -5361,7 +4849,7 @@ function phase4_walk(state) {
 
 // cause: "typeof 0===\"aa\""
 
-                        warn("expected_type_string_a", state, right, value);
+                        warn("expected_type_string_a", right, value);
                     }
                 }
             }
@@ -5371,13 +4859,13 @@ function phase4_walk(state) {
 
 // cause: "0==0"
 
-        warn("expected_a_b", state, thing, "===", "==");
+        warn("expected_a_b", thing, "===", "==");
     });
     preaction("binary", "!=", function (thing) {
 
 // cause: "0!=0"
 
-        warn("expected_a_b", state, thing, "!==", "!=");
+        warn("expected_a_b", thing, "!==", "!=");
     });
     preaction("binary", "=>", preaction_function);
     preaction("binary", "||", function (thing) {
@@ -5386,7 +4874,7 @@ function phase4_walk(state) {
 
 // cause: "0&&0||0"
 
-                warn("and", state, thang);
+                warn("and", thang);
             }
         });
     });
@@ -5417,13 +4905,13 @@ function phase4_walk(state) {
 
 // cause: "aa in aa"
 
-        warn("infix_in", state, thing);
+        warn("infix_in", thing);
     });
     preaction("binary", "instanceof", function (thing) {
 
 // cause: "0 instanceof 0"
 
-        warn("unexpected_a", state, thing);
+        warn("unexpected_a", thing);
     });
     preaction("statement", "{", function (thing) {
         block_stack.push(blockage);
@@ -5439,7 +4927,7 @@ function phase4_walk(state) {
 
 // cause: "const aa=0;for(aa in aa){}"
 
-                    warn("bad_assignment_a", state, thing.name);
+                    warn("bad_assignment_a", thing.name);
                 }
             }
         }
@@ -5476,7 +4964,7 @@ function phase4_walk(state) {
                 || right.id === "undefined"
                 || Number.isNaN(right.value)
             ) {
-                warn("unexpected_a", state, right);
+                warn("unexpected_a", right);
             }
         }
     });
@@ -5521,7 +5009,6 @@ function phase4_walk(state) {
 
                     warn(
                         "expected_a_b",
-                        state,
                         lvalue.expression,
                         "delete",
                         "undefined"
@@ -5531,7 +5018,7 @@ function phase4_walk(state) {
         } else {
             if (lvalue.arity === "variable") {
                 if (!lvalue.variable || lvalue.variable.writable !== true) {
-                    warn("bad_assignment_a", state, lvalue);
+                    warn("bad_assignment_a", lvalue);
                 }
             }
             const right = syntax_dict[thing.expression[1].id];
@@ -5550,7 +5037,7 @@ function phase4_walk(state) {
 
 // cause: "aa+=undefined"
 
-                warn("unexpected_a", state, thing.expression[1]);
+                warn("unexpected_a", thing.expression[1]);
             }
         }
     });
@@ -5561,7 +5048,7 @@ function phase4_walk(state) {
             if (
                 is_weird(thing.expression[0])
                 || is_weird(thing.expression[1])
-                || are_similar(thing.expression[0], thing.expression[1])
+                || is_equal(thing.expression[0], thing.expression[1])
                 || (
                     thing.expression[0].constant === true
                     && thing.expression[1].constant === true
@@ -5570,7 +5057,7 @@ function phase4_walk(state) {
 
 // cause: "if(0===0){0}"
 
-                warn("weird_relation_a", state, thing);
+                warn("weird_relation_a", thing);
             }
         }
         if (thing.id === "+") {
@@ -5579,12 +5066,12 @@ function phase4_walk(state) {
 
 // cause: "\"\"+0"
 
-                    warn("expected_a_b", state, thing, "String(...)", "\"\" +");
+                    warn("expected_a_b", thing, "String(...)", "\"\" +");
                 } else if (thing.expression[1].value === "") {
 
 // cause: "0+\"\""
 
-                    warn("expected_a_b", state, thing, "String(...)", "+ \"\"");
+                    warn("expected_a_b", thing, "String(...)", "+ \"\"");
                 }
             }
         } else if (thing.id === "[") {
@@ -5592,20 +5079,20 @@ function phase4_walk(state) {
 
 // cause: "aa=window[0]"
 
-                warn("weird_expression_a", state, thing, "window[...]");
+                warn("weird_expression_a", thing, "window[...]");
             }
             if (thing.expression[0].id === "self") {
 
 // cause: "aa=self[0]"
 
-                warn("weird_expression_a", state, thing, "self[...]");
+                warn("weird_expression_a", thing, "self[...]");
             }
         } else if (thing.id === "." || thing.id === "?.") {
             if (thing.expression.id === "RegExp") {
 
 // cause: "aa=RegExp.aa"
 
-                warn("weird_expression_a", state, thing);
+                warn("weird_expression_a", thing);
             }
         } else if (thing.id !== "=>" && thing.id !== "(") {
             right = thing.expression[1];
@@ -5618,7 +5105,7 @@ function phase4_walk(state) {
 
 // cause: "0- -0"
 
-                warn("wrap_unary", state, right);
+                warn("wrap_unary", right);
             }
             if (
                 thing.expression[0].constant === true
@@ -5631,28 +5118,29 @@ function phase4_walk(state) {
     postaction("binary", "&&", function (thing) {
         if (
             is_weird(thing.expression[0])
-            || are_similar(thing.expression[0], thing.expression[1])
+            || is_equal(thing.expression[0], thing.expression[1])
             || thing.expression[0].constant === true
             || thing.expression[1].constant === true
         ) {
 
 // cause: "aa=(``?``:``)&&(``?``:``)"
+// cause: "aa=/./&&0"
 // cause: "aa=0&&0"
 // cause: "aa=`${0}`&&`${0}`"
 
-            warn("weird_condition_a", state, thing);
+            warn("weird_condition_a", thing);
         }
     });
     postaction("binary", "||", function (thing) {
         if (
             is_weird(thing.expression[0])
-            || are_similar(thing.expression[0], thing.expression[1])
+            || is_equal(thing.expression[0], thing.expression[1])
             || thing.expression[0].constant === true
         ) {
 
 // cause: "aa=0||0"
 
-            warn("weird_condition_a", state, thing);
+            warn("weird_condition_a", thing);
         }
     });
     postaction("binary", "=>", postaction_function);
@@ -5669,7 +5157,7 @@ function phase4_walk(state) {
 
 // cause: "aa=function(){}()"
 
-                warn("wrap_immediate", state, thing);
+                warn("wrap_immediate", thing);
             }
         } else if (left.identifier) {
             if (the_new !== undefined) {
@@ -5687,13 +5175,13 @@ function phase4_walk(state) {
 // cause: "new Symbol()"
 // cause: "new aa()"
 
-                    warn("unexpected_a", state, the_new);
+                    warn("unexpected_a", the_new);
                 } else if (left.id === "Function") {
                     if (!option_dict.eval) {
 
 // cause: "new Function()"
 
-                        warn("unexpected_a", state, left, "new Function");
+                        warn("unexpected_a", left, "new Function");
                     }
                 } else if (left.id === "Array") {
                     arg = thing.expression;
@@ -5701,7 +5189,7 @@ function phase4_walk(state) {
 
 // cause: "new Array()"
 
-                        warn("expected_a_b", state, left, "[]", "new Array");
+                        warn("expected_a_b", left, "[]", "new Array");
                     }
                 } else if (left.id === "Object") {
 
@@ -5709,7 +5197,6 @@ function phase4_walk(state) {
 
                     warn(
                         "expected_a_b",
-                        state,
                         left,
                         "Object.create(null)",
                         "new Object"
@@ -5727,13 +5214,7 @@ function phase4_walk(state) {
 
 // cause: "let Aa=Aa()"
 
-                    warn(
-                        "expected_a_before_b",
-                        state,
-                        left,
-                        "new",
-                        artifact(left)
-                    );
+                    warn("expected_a_before_b", left, "new", artifact(left));
                 }
             }
         } else if (left.id === ".") {
@@ -5744,19 +5225,21 @@ function phase4_walk(state) {
 
                 cack = !cack;
             }
-            if (rx_cap.test(left.name.id) !== cack) {
+            if ((
+                // rx_cap
+                /^[A-Z]/
+            ).test(left.name.id) !== cack) {
                 if (the_new !== undefined) {
 
 // cause: "new Date.UTC()"
 
-                    warn("unexpected_a", state, the_new);
+                    warn("unexpected_a", the_new);
                 } else {
 
 // cause: "let Aa=Aa.Aa()"
 
                     warn(
                         "expected_a_before_b",
-                        state,
                         left.expression,
                         "new",
                         left.name.id
@@ -5778,7 +5261,6 @@ function phase4_walk(state) {
 
                             warn(
                                 "expected_a_b",
-                                state,
                                 new_date,
                                 "Date.now()",
                                 "new Date().getTime()"
@@ -5794,13 +5276,13 @@ function phase4_walk(state) {
 
 // cause: "aa=RegExp[0]"
 
-            warn("weird_expression_a", state, thing);
+            warn("weird_expression_a", thing);
         }
         if (is_weird(thing.expression[1])) {
 
 // cause: "aa[[0]]"
 
-            warn("weird_expression_a", state, thing.expression[1]);
+            warn("weird_expression_a", thing.expression[1]);
         }
     });
     postaction("statement", "{", pop_block);
@@ -5848,19 +5330,19 @@ function phase4_walk(state) {
         if (
             is_weird(thing.expression[0])
             || thing.expression[0].constant === true
-            || are_similar(thing.expression[1], thing.expression[2])
+            || is_equal(thing.expression[1], thing.expression[2])
         ) {
-            warn("unexpected_a", state, thing);
-        } else if (are_similar(thing.expression[0], thing.expression[1])) {
+            warn("unexpected_a", thing);
+        } else if (is_equal(thing.expression[0], thing.expression[1])) {
 
 // cause: "aa?aa:0"
 
-            warn("expected_a_b", state, thing, "||", "?");
-        } else if (are_similar(thing.expression[0], thing.expression[2])) {
+            warn("expected_a_b", thing, "||", "?");
+        } else if (is_equal(thing.expression[0], thing.expression[2])) {
 
 // cause: "aa?0:aa"
 
-            warn("expected_a_b", state, thing, "&&", "?");
+            warn("expected_a_b", thing, "&&", "?");
         } else if (
             thing.expression[1].id === "true"
             && thing.expression[2].id === "false"
@@ -5868,7 +5350,7 @@ function phase4_walk(state) {
 
 // cause: "aa?true:false"
 
-            warn("expected_a_b", state, thing, "!!", "?");
+            warn("expected_a_b", thing, "!!", "?");
         } else if (
             thing.expression[1].id === "false"
             && thing.expression[2].id === "true"
@@ -5876,7 +5358,7 @@ function phase4_walk(state) {
 
 // cause: "aa?false:true"
 
-            warn("expected_a_b", state, thing, "!", "?");
+            warn("expected_a_b", thing, "!", "?");
         } else if (
             thing.expression[0].wrapped !== true
             && (
@@ -5887,7 +5369,7 @@ function phase4_walk(state) {
 
 // cause: "(aa&&!aa?0:1)"
 
-            warn("wrap_condition", state, thing.expression[0]);
+            warn("wrap_condition", thing.expression[0]);
         }
     });
     postaction("unary", function (thing) {
@@ -5899,14 +5381,14 @@ function phase4_walk(state) {
             }
         } else if (thing.id === "!") {
             if (thing.expression.constant === true) {
-                warn("unexpected_a", state, thing);
+                warn("unexpected_a", thing);
             }
         } else if (thing.id === "!!") {
             if (!option_dict.convert) {
 
 // cause: "!!0"
 
-                warn("expected_a_b", state, thing, "Boolean(...)", "!!");
+                warn("expected_a_b", thing, "Boolean(...)", "!!");
             }
         } else if (
             thing.id !== "["
@@ -5926,34 +5408,41 @@ function phase4_walk(state) {
 
 // cause: "aa=+0"
 
-            warn("expected_a_b", state, thing, "Number(...)", "+");
+            warn("expected_a_b", thing, "Number(...)", "+");
         }
         if (right.id === "(" && right.expression[0].id === "new") {
-            warn("unexpected_a_before_b", state, thing, "+", "new");
+            warn("unexpected_a_before_b", thing, "+", "new");
         } else if (
             right.constant
             || right.id === "{"
             || (right.id === "[" && right.arity !== "binary")
         ) {
-            warn("unexpected_a", state, thing, "+");
+            warn("unexpected_a", thing, "+");
         }
     });
 
     walk_statement(state.token_tree);
 }
 
-
-function phase5_whitage(state) {
+function jslint_phase5_whitage(state) {
 
 // PHASE 5. Check whitespace between tokens in <token_list>.
 
     const {
+        artifact,
         function_list,
         option_dict,
         token_global,
-        token_list
+        token_list,
+        warn
     } = state;
     const function_stack = [];  // The stack of functions.
+    const spaceop = populate([  // This is the set of infix operators that
+                                // require a space on each side.
+        "!=", "!==", "%", "%=", "&", "&=", "&&", "*", "*=", "+=", "-=", "/",
+        "/=", "<", "<=", "<<", "<<=", "=", "==", "===", "=>", ">", ">=",
+        ">>", ">>=", ">>>", ">>>=", "^", "^=", "|", "|=", "||"
+    ]);
     let closer = "(end)";
 
 // free = false
@@ -5996,7 +5485,6 @@ function phase5_whitage(state) {
 
         warn(
             "expected_a_at_b_c",
-            state,
             right,
             artifact(right),
 
@@ -6040,12 +5528,12 @@ function phase5_whitage(state) {
 // cause: "/*jslint node*/\nlet aa;"
 // cause: "function aa(aa){return;}"
 
-                        warn("unused_a", state, name);
+                        warn("unused_a", name);
                     } else if (!name.init) {
 
 // cause: "/*jslint node*/\nlet aa;aa();"
 
-                        warn("uninitialized_a", state, name);
+                        warn("uninitialized_a", name);
                     }
                 }
             }
@@ -6069,7 +5557,6 @@ function phase5_whitage(state) {
 
                 warn(
                     "unexpected_space_a_b",
-                    state,
                     right,
                     artifact(left),
                     artifact(right)
@@ -6129,7 +5616,6 @@ function phase5_whitage(state) {
         ) {
             warn(
                 "unexpected_space_a_b",
-                state,
                 right,
                 artifact(left),
                 artifact(right)
@@ -6142,7 +5628,6 @@ function phase5_whitage(state) {
             if (left.thru + 1 !== right.from && nr_comments_skipped === 0) {
                 warn(
                     "expected_space_a_b",
-                    state,
                     right,
                     artifact(left),
                     artifact(right)
@@ -6157,13 +5642,7 @@ function phase5_whitage(state) {
 
     function one_space_only() {
         if (left.line !== right.line || left.thru + 1 !== right.from) {
-            warn(
-                "expected_space_a_b",
-                state,
-                right,
-                artifact(left),
-                artifact(right)
-            );
+            warn("expected_space_a_b", right, artifact(left), artifact(right));
         }
     }
 
@@ -6325,7 +5804,6 @@ function phase5_whitage(state) {
 
                             warn(
                                 "expected_line_break_a_b",
-                                state,
                                 right,
                                 artifact(left),
                                 artifact(right)
@@ -6439,7 +5917,7 @@ function phase5_whitage(state) {
 
 // cause: "let aa = (aa ? 0 : 1);"
 
-                            warn("use_open", state, right);
+                            warn("use_open", right);
                         }
                     } else if (
                         right.arity === "binary"
@@ -6584,6 +6062,52 @@ function jslint(
 
 // The jslint function itself.
 
+    const allowed_option = {
+
+// These are the options that are recognized in the option object or that may
+// appear in a /*jslint*/ directive. Most options will have a boolean value,
+// usually true. Some options will also predefine some number of global
+// variables.
+
+        bitwise: true,
+        browser: [
+            "caches", "CharacterData", "clearInterval", "clearTimeout",
+            "document",
+            "DocumentType", "DOMException", "Element", "Event", "event",
+            "fetch",
+            "FileReader", "FontFace", "FormData", "history",
+            "IntersectionObserver",
+            "localStorage", "location", "MutationObserver", "name", "navigator",
+            "screen", "sessionStorage", "setInterval", "setTimeout", "Storage",
+            "TextDecoder", "TextEncoder", "URL", "window", "Worker",
+            "XMLHttpRequest"
+        ],
+        convert: true,
+        couch: [
+            "emit", "getRow", "isArray", "log", "provides", "registerType",
+            "require", "send", "start", "sum", "toJSON"
+        ],
+        debug: true,
+        devel: [
+            "alert", "confirm", "console", "prompt"
+        ],
+        eval: true,
+        for: true,
+        getset: true,
+        long: true,
+        name: true,
+        node: [
+            "Buffer", "clearImmediate", "clearInterval", "clearTimeout",
+            "console", "exports", "module", "process", "require",
+            "setImmediate", "setInterval", "setTimeout", "TextDecoder",
+            "TextEncoder", "URL", "URLSearchParams", "__dirname", "__filename"
+        ],
+        single: true,
+        test_internal_error: true,
+        this: true,
+        unordered: true,
+        white: true
+    };
     const directive_list = []; // The directive comments.
     const export_dict = empty(); // The exported names and values.
     const function_list = []; // The array containing all of the functions.
@@ -6600,6 +6124,19 @@ function jslint(
     });
     const property_dict = empty();      // The object containing the tallied
                                         // property names.
+    const standard = [          // These are the globals that are provided by
+                                // the language standard.
+        "Array", "ArrayBuffer", "Boolean", "DataView", "Date", "Error",
+        "EvalError",
+        "Float32Array", "Float64Array", "Generator", "GeneratorFunction",
+        "Int16Array", "Int32Array", "Int8Array", "Intl", "JSON", "Map", "Math",
+        "Number", "Object", "Promise", "Proxy", "RangeError", "ReferenceError",
+        "Reflect", "RegExp", "Set", "String", "Symbol", "SyntaxError", "System",
+        "TypeError", "URIError", "Uint16Array", "Uint32Array", "Uint8Array",
+        "Uint8ClampedArray", "WeakMap", "WeakSet", "decodeURI",
+        "decodeURIComponent", "encodeURI", "encodeURIComponent", "globalThis",
+        "import", "parseFloat", "parseInt"
+    ];
     const state = empty();      // jslint state-object to be passed between
                                 // jslint functions.
     const syntax_dict = empty();        // The object containing the parser.
@@ -6612,7 +6149,7 @@ function jslint(
         from: 0,
         id: "(global)",
         level: 0,
-        line: 1,
+        line: line_fudge,
         live: [],
         loop: 0,
         switch: 0,
@@ -6622,6 +6159,520 @@ function jslint(
     const token_list = [];      // The array of tokens.
     const warning_list = [];    // The array collecting all generated warnings.
     let mode_stop = false;      // true if JSLint cannot finish.
+
+// Error reportage functions:
+
+    function artifact(the_token) {
+
+// Return a string representing an artifact.
+
+        assert_or_throw(
+            the_token !== undefined,
+            "Expected the_token !== undefined."
+        );
+// Probably deadcode.
+// if (the_token === undefined) {
+//     the_token = token_nxt;
+// }
+        return (
+            (the_token.id === "(string)" || the_token.id === "(number)")
+            ? String(the_token.value)
+            : the_token.id
+        );
+    }
+
+    function is_weird(thing) {
+        switch (thing.id) {
+        case "(regexp)":
+        case "=>":
+        case "function":
+        case "{":
+            return true;
+        case "[":
+            return thing.arity === "unary";
+        default:
+            return false;
+        }
+    }
+
+    function is_equal(aa, bb) {
+        let aa_value;
+        let bb_value;
+
+// cause: "0&&0"
+
+        assert_or_throw(!(aa === bb), `Expected !(aa === bb).`);
+
+// Probably deadcode.
+// if (aa === bb) {
+//     return true;
+// }
+
+        if (Array.isArray(aa)) {
+            return (
+                Array.isArray(bb)
+                && aa.length === bb.length
+                && aa.every(function (value, index) {
+
+// cause: "`${0}`&&`${0}`"
+
+                    return is_equal(value, bb[index]);
+                })
+            );
+        }
+        assert_or_throw(!Array.isArray(bb), `Expected !Array.isArray(bb).`);
+
+// Probably deadcode.
+// if (Array.isArray(bb)) {
+//     return false;
+// }
+
+        if (aa.id === "(number)" && bb.id === "(number)") {
+            return aa.value === bb.value;
+        }
+        if (aa.id === "(string)") {
+            aa_value = aa.value;
+        } else if (aa.id === "`" && aa.constant) {
+            aa_value = aa.value[0];
+        }
+        if (bb.id === "(string)") {
+            bb_value = bb.value;
+        } else if (bb.id === "`" && bb.constant) {
+            bb_value = bb.value[0];
+        }
+        if (typeof aa_value === "string") {
+            return aa_value === bb_value;
+        }
+        if (is_weird(aa) || is_weird(bb)) {
+            return false;
+        }
+        if (aa.arity === bb.arity && aa.id === bb.id) {
+
+// cause: "aa.bb&&aa.bb"
+
+            if (aa.id === ".") {
+                return (
+                    is_equal(aa.expression, bb.expression)
+                    && is_equal(aa.name, bb.name)
+                );
+            }
+
+// cause: "+0&&+0"
+
+            if (aa.arity === "unary") {
+                return is_equal(aa.expression, bb.expression);
+            }
+            if (aa.arity === "binary") {
+
+// cause: "aa[0]&&aa[0]"
+
+                return (
+                    aa.id !== "("
+                    && is_equal(aa.expression[0], bb.expression[0])
+                    && is_equal(aa.expression[1], bb.expression[1])
+                );
+            }
+            if (aa.arity === "ternary") {
+
+// cause: "aa=(``?``:``)&&(``?``:``)"
+
+                return (
+                    is_equal(aa.expression[0], bb.expression[0])
+                    && is_equal(aa.expression[1], bb.expression[1])
+                    && is_equal(aa.expression[2], bb.expression[2])
+                );
+            }
+            assert_or_throw(
+                !(aa.arity === "function" || aa.arity === "regexp"),
+                `Expected !(aa.arity === "function" || aa.arity === "regexp").`
+            );
+
+// Probably deadcode.
+// if (aa.arity === "function" || aa.arity === "regexp") {
+//     return false;
+// }
+
+// cause: "undefined&&undefined"
+
+            return true;
+        }
+
+// cause: "null&&undefined"
+
+        return false;
+    }
+
+    function warn_at(code, line, column, a, b, c, d) {
+
+// Report an error at some line and column of the program. The warning object
+// resembles an exception.
+
+        const warning = Object.assign(empty(), {
+            a,
+            b,
+            c,
+            code,
+
+// Fudge column numbers in warning message.
+
+            column: column || line_fudge,
+            d,
+            line,
+            line_source: "",
+            name: "JSLintError"
+        }, line_list[line]);
+        let mm;
+        switch (code) {
+
+// The bundle contains the raw text messages that are generated by jslint. It
+// seems that they are all error messages and warnings. There are no "Atta
+// boy!" or "You are so awesome!" messages. There is no positive reinforcement
+// or encouragement. This relentless negativity can undermine self-esteem and
+// wound the inner child. But if you accept it as sound advice rather than as
+// personal criticism, it can make your programs better.
+
+        case "and":
+            mm = `The '&&' subexpression should be wrapped in parens.`;
+            break;
+        case "bad_assignment_a":
+            mm = `Bad assignment to '${a}'.`;
+            break;
+        case "bad_directive_a":
+            mm = `Bad directive '${a}'.`;
+            break;
+        case "bad_get":
+            mm = `A get function takes no parameters.`;
+            break;
+        case "bad_module_name_a":
+            mm = `Bad module name '${a}'.`;
+            break;
+        case "bad_option_a":
+            mm = `Bad option '${a}'.`;
+            break;
+        case "bad_property_a":
+            mm = `Bad property name '${a}'.`;
+            break;
+        case "bad_set":
+            mm = `A set function takes one parameter.`;
+            break;
+        case "duplicate_a":
+            mm = `Duplicate '${a}'.`;
+            break;
+        case "empty_block":
+            mm = `Empty block.`;
+            break;
+        case "expected_a":
+            mm = `Expected '${a}'.`;
+            break;
+        case "expected_a_at_b_c":
+            mm = `Expected '${a}' at column ${b}, not column ${c}.`;
+            break;
+        case "expected_a_b":
+            mm = `Expected '${a}' and instead saw '${b}'.`;
+            break;
+        case "expected_a_b_from_c_d":
+            mm = (
+                `Expected '${a}' to match '${b}' from line ${c}`
+                + ` and instead saw '${d}'.`
+            );
+            break;
+        case "expected_a_before_b":
+            mm = `Expected '${a}' before '${b}'.`;
+            break;
+        case "expected_digits_after_a":
+            mm = `Expected digits after '${a}'.`;
+            break;
+        case "expected_four_digits":
+            mm = `Expected four digits after '\\u'.`;
+            break;
+        case "expected_identifier_a":
+            mm = `Expected an identifier and instead saw '${a}'.`;
+            break;
+        case "expected_line_break_a_b":
+            mm = `Expected a line break between '${a}' and '${b}'.`;
+            break;
+        case "expected_regexp_factor_a":
+            mm = `Expected a regexp factor and instead saw '${a}'.`;
+            break;
+        case "expected_space_a_b":
+            mm = `Expected one space between '${a}' and '${b}'.`;
+            break;
+        case "expected_statements_a":
+            mm = `Expected statements before '${a}'.`;
+            break;
+        case "expected_string_a":
+            mm = `Expected a string and instead saw '${a}'.`;
+            break;
+        case "expected_type_string_a":
+            mm = `Expected a type string and instead saw '${a}'.`;
+            break;
+        case "freeze_exports":
+            mm = (
+                `Expected 'Object.freeze('. All export values should be frozen.`
+            );
+            break;
+        case "function_in_loop":
+            mm = `Don't create functions within a loop.`;
+            break;
+        case "infix_in":
+            mm = (
+                `Unexpected 'in'. Compare with undefined,`
+                + ` or use the hasOwnProperty method instead.`
+            );
+            break;
+        case "label_a":
+            mm = `'${a}' is a statement label.`;
+            break;
+        case "misplaced_a":
+            mm = `Place '${a}' at the outermost level.`;
+            break;
+        case "misplaced_directive_a":
+            mm = `Place the '/*${a}*/' directive before the first statement.`;
+            break;
+        case "missing_await_statement":
+            mm = `Expected await statement in async function.`;
+            break;
+        case "missing_browser":
+            mm = `/*global*/ requires the Assume a browser option.`;
+            break;
+        case "missing_m":
+            mm = `Expected 'm' flag on a multiline regular expression.`;
+            break;
+        case "naked_block":
+            mm = `Naked block.`;
+            break;
+        case "nested_comment":
+            mm = `Nested comment.`;
+            break;
+        case "not_label_a":
+            mm = `'${a}' is not a label.`;
+            break;
+        case "number_isNaN":
+            mm = `Use Number.isNaN function to compare with NaN.`;
+            break;
+        case "out_of_scope_a":
+            mm = `'${a}' is out of scope.`;
+            break;
+        case "redefinition_a_b":
+            mm = `Redefinition of '${a}' from line ${b}.`;
+            break;
+        case "required_a_optional_b":
+            mm = `Required parameter '${a}' after optional parameter '${b}'.`;
+            break;
+        case "reserved_a":
+            mm = `Reserved name '${a}'.`;
+            break;
+        case "subscript_a":
+            mm = `['${a}'] is better written in dot notation.`;
+            break;
+        case "todo_comment":
+            mm = `Unexpected TODO comment.`;
+            break;
+        case "too_long":
+            mm = `Line is longer than 80 characters.`;
+            break;
+        case "too_many_digits":
+            mm = `Too many digits.`;
+            break;
+        case "unclosed_comment":
+            mm = `Unclosed comment.`;
+            break;
+        case "unclosed_disable":
+            mm = (
+                `Directive '/*jslint-disable*/' was not closed`
+                + ` with '/*jslint-enable*/'.`
+            );
+            break;
+        case "unclosed_mega":
+            mm = `Unclosed mega literal.`;
+            break;
+        case "unclosed_string":
+            mm = `Unclosed string.`;
+            break;
+        case "undeclared_a":
+            mm = `Undeclared '${a}'.`;
+            break;
+        case "unexpected_a":
+            mm = `Unexpected '${a}'.`;
+            break;
+        case "unexpected_a_after_b":
+            mm = `Unexpected '${a}' after '${b}'.`;
+            break;
+        case "unexpected_a_before_b":
+            mm = `Unexpected '${a}' before '${b}'.`;
+            break;
+        case "unexpected_at_top_level_a":
+            mm = `Expected '${a}' to be in a function.`;
+            break;
+        case "unexpected_char_a":
+            mm = `Unexpected character '${a}'.`;
+            break;
+        case "unexpected_comment":
+            mm = `Unexpected comment.`;
+            break;
+        case "unexpected_directive_a":
+            mm = `When using modules, don't use directive '/\u002a${a}'.`;
+            break;
+        case "unexpected_expression_a":
+            mm = `Unexpected expression '${a}' in statement position.`;
+            break;
+        case "unexpected_label_a":
+            mm = `Unexpected label '${a}'.`;
+            break;
+        case "unexpected_parens":
+            mm = `Don't wrap function literals in parens.`;
+            break;
+        case "unexpected_space_a_b":
+            mm = `Unexpected space between '${a}' and '${b}'.`;
+            break;
+        case "unexpected_statement_a":
+            mm = `Unexpected statement '${a}' in expression position.`;
+            break;
+        case "unexpected_trailing_space":
+            mm = `Unexpected trailing space.`;
+            break;
+        case "unexpected_typeof_a":
+            mm = (
+                `Unexpected 'typeof'. Use '===' to compare directly with ${a}.`
+            );
+            break;
+        case "uninitialized_a":
+            mm = `Uninitialized '${a}'.`;
+            break;
+        case "unopened_enable":
+            mm = (
+                `Directive '/*jslint-enable*/' was not opened`
+                + ` with '/*jslint-disable*/'.`
+            );
+            break;
+        case "unreachable_a":
+            mm = `Unreachable '${a}'.`;
+            break;
+        case "unregistered_property_a":
+            mm = `Unregistered property name '${a}'.`;
+            break;
+        case "unused_a":
+            mm = `Unused '${a}'.`;
+            break;
+        case "use_double":
+            mm = `Use double quotes, not single quotes.`;
+            break;
+        case "use_open":
+            mm = (
+                `Wrap a ternary expression in parens,`
+                + ` with a line break after the left paren.`
+            );
+            break;
+        case "use_spaces":
+            mm = `Use spaces, not tabs.`;
+            break;
+        case "var_loop":
+            mm = `Don't declare variables in a loop.`;
+            break;
+        case "var_switch":
+            mm = `Don't declare variables in a switch.`;
+            break;
+        case "weird_condition_a":
+            mm = `Weird condition '${a}'.`;
+            break;
+        case "weird_expression_a":
+            mm = `Weird expression '${a}'.`;
+            break;
+        case "weird_loop":
+            mm = `Weird loop.`;
+            break;
+        case "weird_relation_a":
+            mm = `Weird relation '${a}'.`;
+            break;
+        case "wrap_condition":
+            mm = `Wrap the condition in parens.`;
+            break;
+        case "wrap_immediate":
+            mm = (
+                `Wrap an immediate function invocation in parentheses to assist`
+                + ` the reader in understanding that the expression is the`
+                + ` result of a function, and not the function itself.`
+            );
+            break;
+        case "wrap_parameter":
+            mm = `Wrap the parameter in parens.`;
+            break;
+        case "wrap_regexp":
+            mm = `Wrap this regexp in parens to avoid confusion.`;
+            break;
+        case "wrap_unary":
+            mm = `Wrap the unary expression in parens.`;
+            break;
+        }
+        warning.message = mm;
+
+// Include stack_trace for jslint to debug itself for errors.
+
+        if (option_dict.debug) {
+            warning.stack_trace = new Error().stack;
+        }
+        if (warning.directive_quiet) {
+
+// cause: "0 //jslint-quiet"
+
+            return warning;
+        }
+        warning_list.push(warning);
+        return warning;
+    }
+
+    function stop_at(code, line, column, a, b, c, d) {
+
+// Same as warn_at, except that it stops the analysis.
+
+        throw warn_at(code, line, column, a, b, c, d);
+    }
+
+    function warn(code, the_token, a, b, c, d) {
+
+// Same as warn_at, except the warning will be associated with a specific token.
+// If there is already a warning on this token, suppress the new one. It is
+// likely that the first warning will be the most meaningful.
+
+        assert_or_throw(
+            the_token !== undefined,
+            "Expected the_token !== undefined."
+        );
+// Probably deadcode.
+// if (the_token === undefined) {
+//     the_token = token_nxt;
+// }
+        if (the_token.warning === undefined) {
+            the_token.warning = warn_at(
+                code,
+                the_token.line,
+                (the_token.from || 0) + line_fudge,
+                a || artifact(the_token),
+                b,
+                c,
+                d
+            );
+            return the_token.warning;
+        }
+    }
+
+    function stop(code, the_token, a, b, c, d) {
+
+// Similar to warn and stop_at. If the token already had a warning, that
+// warning will be replaced with this new one. It is likely that the stopping
+// warning will be the more meaningful.
+
+        assert_or_throw(
+            the_token !== undefined,
+            "Expected the_token !== undefined."
+        );
+// Probably deadcode.
+// if (the_token === undefined) {
+//     the_token = token_nxt;
+// }
+        delete the_token.warning;
+        throw warn(code, the_token, a, b, c, d);
+    }
 
     try {
 
@@ -6645,11 +6696,15 @@ function jslint(
         });
 
         Object.assign(state, {
+            allowed_option,
+            artifact,
             directive_list,
             export_dict,
             function_list,
             global_list,
             import_list,
+            is_equal,
+            is_weird,
             line_list,
             mode_json: false,           // true if parsing JSON.
             mode_module: false,         // true if import or export was used.
@@ -6659,37 +6714,41 @@ function jslint(
             option_dict,
             property_dict,
             source,
+            stop,
+            stop_at,
             syntax_dict,
             tenure,
             token_global,
             token_list,
+            warn,
+            warn_at,
             warning_list
         });
 
 // PHASE 1. Split <source> by newlines into <line_list>.
 
-        phase1_split(state);
+        jslint_phase1_split(state);
 
 // PHASE 2. Lex <line_list> into <token_list>.
 
-        phase2_lex(state);
+        jslint_phase2_lex(state);
 
 // PHASE 3. Parse <token_list> into <token_tree> using the Pratt-parser.
 
-        phase3_parse(state);
+        jslint_phase3_parse(state);
 
 // PHASE 4. Walk <token_tree>, traversing all of the nodes of the tree. It is a
 //          recursive traversal. Each node may be processed on the way down
 //          (preaction) and on the way up (postaction).
 
         if (!state.mode_json) {
-            phase4_walk(state);
+            jslint_phase4_walk(state);
         }
 
 // PHASE 5. Check whitespace between tokens in <token_list>.
 
         if (!state.mode_json && warning_list.length === 0) {
-            phase5_whitage(state);
+            jslint_phase5_whitage(state);
         }
 
         if (!option_dict.browser) {
@@ -6698,7 +6757,7 @@ function jslint(
 
 // cause: "/*global aa*/"
 
-                    warn("missing_browser", state, comment);
+                    warn("missing_browser", comment);
                 }
             });
         }
@@ -6724,14 +6783,14 @@ function jslint(
 
 // Sort warning_list by mode_stop first, line, column respectively.
 
-    warning_list.sort(function (a, b) {
+    warning_list.sort(function (aa, bb) {
         return (
-            Boolean(b.mode_stop) - Boolean(a.mode_stop)
-            || a.line - b.line
-            || a.column - b.column
+            Boolean(bb.mode_stop) - Boolean(aa.mode_stop)
+            || aa.line - bb.line
+            || aa.column - bb.column
         );
 
-// Update each warning with a formatted_message ready for use by cli.
+// Update each warning with formatted_message ready-for-use by jslint_cli.
 
     }).map(function ({
         column,
@@ -6776,7 +6835,7 @@ function jslint(
     };
 }
 
-async function cli({
+async function jslint_cli({
     console_error,
     file,
     option,
@@ -6920,7 +6979,7 @@ async function cli({
         return;
     }
 
-// cli - jslint directory.
+// jslint_cli - jslint directory.
 
     try {
         data = await fs.promises.readdir(file, "utf8");
@@ -6967,7 +7026,7 @@ async function cli({
         return exit_code;
     }
 
-// cli - jslint file.
+// jslint_cli - jslint file.
 
     try {
         data = await fs.promises.readFile(file, "utf8");
@@ -6982,7 +7041,7 @@ async function cli({
     });
     return exit_code;
 }
-jslint.cli = Object.freeze(cli);
+jslint.jslint_cli = Object.freeze(jslint_cli);
 jslint.jslint = Object.freeze(jslint.bind(undefined));
 export default Object.freeze(jslint);
 
@@ -7004,9 +7063,9 @@ if (
     )
 ) {
 
-// run cli
+// run jslint_cli
 
-    cli({
+    jslint_cli({
         file: process.argv[2]
     }).then(function (exit_code) {
         process.exit(exit_code);

--- a/jslint.js
+++ b/jslint.js
@@ -70,15 +70,13 @@
 
 // Phases:
 
-// PHASE 1. split the <source> by newlines into <line_array>.
-// PHASE 2. lex <line_array> into an array of <token_array>.
-// PHASE 3. Furcate the <token_array> into a parse <tree>.
-// PHASE 4. Walk the <tree>, traversing all of the nodes of the tree. It is a
+// PHASE 1. Split <source> by newlines into <line_array>.
+// PHASE 2. Lex <line_array> into <token_array>.
+// PHASE 3. Parse <token_array> into <token_tree> using Pratt parsing.
+// PHASE 4. Walk <token_tree>, traversing all of the nodes of the tree. It is a
 //          recursive traversal. Each node may be processed on the way down
 //          (preaction) and on the way up (postaction).
-// PHASE 5. Check the whitespace between the <token_array>.
-// PHASE 6: sort and format <warnings>.
-// PHASE 7: return jslint result.
+// PHASE 5. Check whitespace between tokens in <token_array>.
 
 // jslint can also examine JSON text. It decides that a file is JSON text if
 // the first token is "[" or "{". Processing of JSON text is much simpler than
@@ -480,14 +478,14 @@ function jslint(
     $ `;
 // initial cap
     const rx_cap = /^[A-Z]/;
-// The stack of blocks.
-    const block_stack = [];
+
+
 // The directive comments.
     const directives = [];
 // The exported names and values.
     const export_object = empty();
 // The array containing all of the functions.
-    const functions = [];
+    const function_array = [];
 // The global object; the outermost context.
     const global = {
         async: 0,
@@ -505,79 +503,39 @@ function jslint(
         try: 0
     };
 // The array collecting all import-from strings.
-    const import_from_array = [];
+    const import_array = [];
 // Fudge starting line and starting column to 1.
     const line_fudge = 1;
 // The object containing the tallied property names.
     const property = empty();
+// The object containing the parser.
+    const syntax_object = empty();
 // The array of tokens.
     const token_array = [];
 // The array collecting all generated warnings.
-    const warnings = [];
-// The guessed name for anonymous functions.
-    let anon = "anonymous";
-// The current block.
-    let blockage = global;
-// A popular character.
-    let char;
-// The column number of the next character.
-    let column = 0;
-// The starting column number of the token.
-    let from;
-// The starting column of megastring.
-    let from_mega;
-// The current function.
-    let functionage = global;
-// The line number of the next character.
-    let line = 0;
+    const warning_array = [];
+// The stack of functions.
+    let function_stack = [];
 // The array containing source lines.
     let line_array;
-// The starting line of "/*jslint-disable*/".
-    let line_disable;
-// The starting line of megastring.
-    let line_mega;
-// The remaining line source string.
-    let line_source = "";
-// The whole line source string.
-    let line_whole = "";
-// true if directives are still allowed.
-    let mode_directive = true;
 // true if parsing JSON.
     let mode_json = false;
 // true if currently parsing a megastring literal.
     let mode_mega = false;
 // true if import or export was used.
     let mode_module = false;
-// true if regular expression literal seen on this line.
-    let mode_regexp;
 // true if a #! was seen on the first line.
     let mode_shebang = false;
 // true if JSLint cannot finish.
     let mode_stop = true;
 // "var" if using var; "let" if using let.
     let mode_var;
-// A piece of string.
-    let snippet = "";
-// The stack of functions.
-    let stack = [];
-// The object containing the parser.
-    let syntax;
 // The predefined property registry.
     let tenure;
-// The first token.
-    let token_1;
-// The previous token excluding comments.
-    let token_before_slash = global;
-// The current token being examined in the parse.
-    let token_now = global;
-// The number of the next token.
-    let token_nr = 0;
-// The next token to be examined in the parse.
+// The next token to be examined in <token_array>.
     let token_nxt = global;
-// The previous token including comments.
-    let token_prv = global;
 // The abstract parse tree.
-    let tree;
+    let token_tree;
 
 // Error reportage functions:
 
@@ -642,7 +600,7 @@ function jslint(
 
             return warning;
         }
-        warnings.push(warning);
+        warning_array.push(warning);
         return warning;
     }
 
@@ -689,505 +647,6 @@ function jslint(
         throw warn(code, the_token, a, b, c, d);
     }
 
-// Parsing:
-
-// Parsing weaves the tokens into an abstract syntax tree. During that process,
-// a token may be given any of these properties:
-
-//      arity       string
-//      label       identifier
-//      name        identifier
-//      expression  expressions
-//      block       statements
-//      else        statements (else, default, catch)
-
-// Specialized tokens may have additional properties.
-
-    function survey(name) {
-        let id = name.id;
-
-// Tally the property name. If it is a string, only tally strings that conform
-// to the identifier rules.
-
-        if (id === "(string)") {
-            id = name.value;
-            if (!rx_identifier.test(id)) {
-                return id;
-            }
-        } else if (id === "`") {
-            if (name.value.length === 1) {
-                id = name.value[0].value;
-                if (!rx_identifier.test(id)) {
-                    return id;
-                }
-            }
-        } else if (!name.identifier) {
-
-// cause: "let aa={0:0}"
-
-            return stop("expected_identifier_a", name);
-        }
-
-// If we have seen this name before, increment its count.
-
-        if (typeof property[id] === "number") {
-            property[id] += 1;
-
-// If this is the first time seeing this property name, and if there is a
-// tenure list, then it must be on the list. Otherwise, it must conform to
-// the rules for good property names.
-
-        } else {
-            if (tenure !== undefined) {
-                if (tenure[id] !== true) {
-
-// cause: "/*property aa*/\naa.bb"
-
-                    warn("unregistered_property_a", name);
-                }
-            } else if (
-                !option_object.name
-                && name.identifier
-                && (
-                    // rx_bad_property
-                    /^_|\$|Sync$|_$/m
-                ).test(id)
-            ) {
-
-// cause: "aa.$"
-// cause: "aa._"
-// cause: "aa._aa"
-// cause: "aa.aaSync"
-// cause: "aa.aa_"
-
-                warn("bad_property_a", name);
-            }
-            property[id] = 1;
-        }
-        return id;
-    }
-
-    function dispense() {
-
-// Deliver the next token, skipping the comments.
-
-        const cadet = token_array[token_nr];
-        token_nr += 1;
-        if (cadet.id === "(comment)") {
-            if (mode_json) {
-
-// cause: "[//]"
-
-                warn("unexpected_a", cadet);
-            }
-            return dispense();
-        } else {
-            return cadet;
-        }
-    }
-
-    function lookahead() {
-
-// Look ahead one token without advancing.
-
-        const old_token_nr = token_nr;
-        const cadet = dispense(true);
-        token_nr = old_token_nr;
-        return cadet;
-    }
-
-    function advance(id, match) {
-
-// Produce the next token.
-
-// Attempt to give helpful names to anonymous functions.
-
-        if (token_now.identifier && token_now.id !== "function") {
-            anon = token_now.id;
-        } else if (
-            token_now.id === "(string)"
-            && rx_identifier.test(token_now.value)
-        ) {
-            anon = token_now.value;
-        }
-
-// Attempt to match token_nxt with an expected id.
-
-        if (id !== undefined && token_nxt.id !== id) {
-            return (
-                match === undefined
-
-// cause: "()"
-
-                ? stop("expected_a_b", token_nxt, id, artifact())
-
-// cause: "{\"aa\":0"
-
-                : stop(
-                    "expected_a_b_from_c_d",
-                    token_nxt,
-                    id,
-                    artifact(match),
-                    match.line,
-                    artifact(token_nxt)
-                )
-            );
-        }
-
-// Promote the tokens, skipping comments.
-
-        token_now = token_nxt;
-        token_nxt = dispense();
-        if (token_nxt.id === "(end)") {
-            token_nr -= 1;
-        }
-    }
-
-// Parsing of JSON is simple:
-
-    function json_value() {
-        let negative;
-        switch (token_nxt.id) {
-        case "{":
-            return (function json_object() {
-                const brace = token_nxt;
-
-// Explicit empty-object required to detect "__proto__".
-
-                const object = empty();
-                const properties = [];
-                brace.expression = properties;
-                advance("{");
-                if (token_nxt.id !== "}") {
-
-// JSON
-// Parse/loop through each property in {...}.
-
-                    while (true) {
-                        let name;
-                        let value;
-                        if (token_nxt.quote !== "\"") {
-
-// cause: "{0:0}"
-
-                            warn(
-                                "unexpected_a",
-                                token_nxt,
-                                token_nxt.quote
-                            );
-                        }
-                        name = token_nxt;
-                        advance("(string)");
-                        if (object[token_now.value] !== undefined) {
-
-// cause: "{\"aa\":0,\"aa\":0}"
-
-                            warn("duplicate_a", token_now);
-                        } else if (token_now.value === "__proto__") {
-
-// cause: "{\"__proto__\":0}"
-
-                            warn("bad_property_a", token_now);
-                        } else {
-                            object[token_now.value] = token_now;
-                        }
-                        advance(":");
-                        value = json_value();
-                        value.label = name;
-                        properties.push(value);
-                        if (token_nxt.id !== ",") {
-                            break;
-                        }
-                        advance(",");
-                    }
-                }
-                advance("}", brace);
-                return brace;
-            }());
-        case "[":
-
-// cause: "[]"
-
-            return (function json_array() {
-                const bracket = token_nxt;
-                const elements = [];
-                bracket.expression = elements;
-                advance("[");
-                if (token_nxt.id !== "]") {
-                    while (true) {
-                        elements.push(json_value());
-                        if (token_nxt.id !== ",") {
-
-// cause: "[0,0]"
-
-                            break;
-                        }
-                        advance(",");
-                    }
-                }
-                advance("]", bracket);
-                return bracket;
-            }());
-        case "true":
-        case "false":
-        case "null":
-
-// cause: "[false]"
-// cause: "[null]"
-// cause: "[true]"
-
-            advance();
-            return token_now;
-        case "(number)":
-            if (!rx_JSON_number.test(token_nxt.value)) {
-
-// cause: "[0x0]"
-
-                warn("unexpected_a");
-            }
-            advance();
-            return token_now;
-        case "(string)":
-            if (token_nxt.quote !== "\"") {
-
-// cause: "['']"
-
-                warn("unexpected_a", token_nxt, token_nxt.quote);
-            }
-            advance();
-            return token_now;
-        case "-":
-            negative = token_nxt;
-            negative.arity = "unary";
-            advance("-");
-            advance("(number)");
-            if (!rx_JSON_number.test(token_now.value)) {
-
-// cause: "[-0x0]"
-
-                warn("unexpected_a", token_now);
-            }
-            negative.expression = token_now;
-            return negative;
-        default:
-
-// cause: "[undefined]"
-
-            stop("unexpected_a");
-        }
-    }
-
-// Now we parse JavaScript.
-
-    function enroll(name, role, readonly) {
-
-// Enroll a name into the current function context. The role can be exception,
-// function, label, parameter, or variable. We look for variable redefinition
-// because it causes confusion.
-
-        const id = name.id;
-
-// Reserved words may not be enrolled.
-
-        if (syntax[id] !== undefined && id !== "ignore") {
-
-// cause: "let undefined"
-
-            warn("reserved_a", name);
-        } else {
-
-// Has the name been enrolled in this context?
-
-            let earlier = functionage.context[id];
-            if (earlier) {
-
-// cause: "let aa;let aa"
-
-                warn(
-                    "redefinition_a_b",
-                    name,
-                    name.id,
-                    earlier.line
-                );
-
-// Has the name been enrolled in an outer context?
-
-            } else {
-                stack.forEach(function (value) {
-                    const item = value.context[id];
-                    if (item !== undefined) {
-                        earlier = item;
-                    }
-                });
-                if (earlier) {
-                    if (id === "ignore") {
-                        if (earlier.role === "variable") {
-
-// cause: "let ignore;function aa(ignore){}"
-
-                            warn("unexpected_a", name);
-                        }
-                    } else {
-                        if (
-                            (
-                                role !== "exception"
-                                || earlier.role !== "exception"
-                            )
-                            && role !== "parameter"
-                            && role !== "function"
-                        ) {
-
-// cause: "function aa(){try{aa();}catch(aa){aa();}}"
-// cause: "function aa(){var aa;}"
-
-                            warn(
-                                "redefinition_a_b",
-                                name,
-                                name.id,
-                                earlier.line
-                            );
-                        }
-                    }
-                }
-
-// Enroll it.
-
-                functionage.context[id] = name;
-                name.dead = true;
-                name.parent = functionage;
-                name.init = false;
-                name.role = role;
-                name.used = 0;
-                name.writable = !readonly;
-            }
-        }
-    }
-
-    function expression(rbp, initial) {
-
-// This is the heart of the Pratt parser. I retained Pratt's nomenclature.
-// They are elements of the parsing method called Top Down Operator Precedence.
-
-// nud     Null denotation
-// led     Left denotation
-// lbp     Left binding power
-// rbp     Right binding power
-
-// It processes a nud (variable, constant, prefix operator). It will then
-// process leds (infix operators) until the bind powers cause it to stop. It
-// returns the expression's parse tree.
-
-        let left;
-        let the_symbol;
-
-// Statements will have already advanced, so advance now only if the token is
-// not the first of a statement,
-
-        if (!initial) {
-            advance();
-        }
-        the_symbol = syntax[token_now.id];
-        if (the_symbol !== undefined && the_symbol.nud !== undefined) {
-
-// cause: "0"
-
-            left = the_symbol.nud();
-        } else if (token_now.identifier) {
-
-// cause: "aa"
-
-            left = token_now;
-            left.arity = "variable";
-        } else {
-
-// cause: "!"
-// cause: "let aa=`${}`;"
-
-            return stop("unexpected_a", token_now);
-        }
-
-// Parse/loop through each symbol in expression.
-
-        while (true) {
-            the_symbol = syntax[token_nxt.id];
-            if (
-                the_symbol === undefined
-                || the_symbol.led === undefined
-                || the_symbol.lbp <= rbp
-            ) {
-                break;
-            }
-            advance();
-            left = the_symbol.led(left);
-        }
-        return left;
-    }
-
-    function condition() {
-
-// Parse the condition part of a do, if, while.
-
-        const the_paren = token_nxt;
-        let the_value;
-
-// cause: "do{}while()"
-// cause: "if(){}"
-// cause: "while(){}"
-
-        the_paren.free = true;
-        advance("(");
-        the_value = expression(0);
-        advance(")");
-        if (the_value.wrapped === true) {
-
-// cause: "while((0)){}"
-
-            warn("unexpected_a", the_paren);
-        }
-
-// Check for anticondition.
-
-        switch (the_value.id) {
-        case "%":
-        case "&":
-        case "(number)":
-        case "(string)":
-        case "*":
-        case "+":
-        case "-":
-        case "/":
-        case "<<":
-        case ">>":
-        case ">>>":
-        case "?":
-        case "^":
-        case "typeof":
-        case "|":
-        case "~":
-
-// cause: "if(\"aa\"){}"
-// cause: "if(0%0){}"
-// cause: "if(0&0){}"
-// cause: "if(0){}"
-// cause: "if(0*0){}"
-// cause: "if(0+0){}"
-// cause: "if(0-0){}"
-// cause: "if(0/0){}"
-// cause: "if(0<<0){}"
-// cause: "if(0>>0){}"
-// cause: "if(0>>>0){}"
-// cause: "if(0?0:0){}"
-// cause: "if(0^0){}"
-// cause: "if(0|0){}"
-// cause: "if(typeof 0){}"
-// cause: "if(~0){}"
-
-            warn("unexpected_a", the_value);
-            break;
-        }
-        return the_value;
-    }
-
     function is_weird(thing) {
         return (
             thing.id === "(regexp)"
@@ -1199,6 +658,8 @@ function jslint(
     }
 
     function are_similar(a, b) {
+        let a_string;
+        let b_string;
 
 // cause: "0&&0"
 
@@ -1227,8 +688,6 @@ function jslint(
         if (a.id === "(number)" && b.id === "(number)") {
             return a.value === b.value;
         }
-        let a_string;
-        let b_string;
         if (a.id === "(string)") {
             a_string = a.value;
         } else if (a.id === "`" && a.constant) {
@@ -1300,160 +759,1677 @@ function jslint(
         return false;
     }
 
-    function semicolon() {
 
-// Try to match a semicolon.
+    function phase1_split() {
 
-        if (token_nxt.id === ";") {
-            advance(";");
-        } else {
+// PHASE 1. Split <source> by newlines into <line_array>.
+
+        line_array = String("\n" + source).split(
+            // rx_crlf
+            /\n|\r\n?/
+        ).map(function (line_source) {
+            return {
+                line_source
+            };
+        });
+    }
+
+
+    function phase2_lex() {
+
+// PHASE 2. Lex <line_array> into <token_array>.
+
+// A popular character.
+        let char;
+// The column number of the next character.
+        let column = 0;
+// The starting column number of the token.
+        let from;
+// The starting column of megastring.
+        let from_mega;
+// The line number of the next character.
+        let line = 0;
+// The starting line of "/*jslint-disable*/".
+        let line_disable;
+// The starting line of megastring.
+        let line_mega;
+// The remaining line source string.
+        let line_source = "";
+// The whole line source string.
+        let line_whole = "";
+// true if directives are still allowed.
+        let mode_directive = true;
+// true if regular expression literal seen on this line.
+        let mode_regexp;
+// A piece of string.
+        let snippet = "";
+// The first token.
+        let token_1;
+// The previous token excluding comments.
+        let token_before_slash = global;
+// The previous token including comments.
+        let token_prv = global;
+
+        function line_next() {
+
+// Put the next line of source in line_source. If the line contains tabs,
+// replace them with spaces and give a warning. Also warn if the line contains
+// unsafe characters or is too damn long.
+
+            let at;
+            if (
+                !option_object.long
+                && line_whole.length > 80
+                && line_disable === undefined
+                && !mode_json
+                && token_1
+                && !mode_regexp
+            ) {
+
+// cause: "too_long"
+
+                warn_at("too_long", line);
+            }
+            column = 0;
+            line += 1;
+            mode_regexp = false;
+            line_source = undefined;
+            line_whole = "";
+            if (line_array[line] === undefined) {
+                return line_source;
+            }
+            line_source = line_array[line].line_source;
+            line_whole = line_source;
+
+// Scan each line for following ignore-directives:
+// "/*jslint-disable*/"
+// "/*jslint-enable*/"
+// "//jslint-quiet"
+
+            if (line_source === "/*jslint-disable*/") {
+
+// cause: "/*jslint-disable*/"
+
+                line_disable = line;
+            } else if (line_source === "/*jslint-enable*/") {
+                if (line_disable === undefined) {
+
+// cause: "/*jslint-enable*/"
+
+                    stop_at("unopened_enable", line);
+                }
+                line_disable = undefined;
+            } else if (line_source.endsWith(" //jslint-quiet")) {
+
+// cause: "0 //jslint-quiet"
+
+                line_array[line].directive_quiet = true;
+            }
+            if (line_disable !== undefined) {
+
+// cause: "/*jslint-disable*/\n0"
+
+                line_source = "";
+            }
+            at = line_source.search(rx_tab);
+            if (at >= 0) {
+                if (!option_object.white) {
+
+// cause: "\t"
+
+                    warn_at("use_spaces", line, at);
+                }
+                line_source = line_source.replace(rx_tab, " ");
+            }
+            if (!option_object.white && line_source.endsWith(" ")) {
+
+// cause: " "
+
+                warn_at(
+                    "unexpected_trailing_space",
+                    line,
+                    line_source.length - 1
+                );
+            }
+            return line_source;
+        }
+
+// Most tokens, including the identifiers, operators, and punctuators, can be
+// found with a regular expression. Regular expressions cannot correctly match
+// regular expression literals, so we will match those the hard way. String
+// literals and number literals can be matched by regular expressions, but they
+// don't provide good warnings. The functions char_after, char_before,
+// read_some_digits, and char_after_escape help in the parsing of literals.
+
+        function char_after(match) {
+
+// Get the next character from the source line. Remove it from the line_source,
+// and append it to the snippet. Optionally check that the previous character
+// matched an expected value.
+
+            if (match !== undefined && char !== match) {
+                return (
+                    char === ""
+
+// cause: "aa=/[/"
+
+                    ? stop_at("expected_a", line, column - 1, match, char)
+
+// cause: "aa=/aa{/"
+
+                    : stop_at("expected_a_b", line, column, match, char)
+                );
+            }
+            char = line_source.slice(0, 1);
+            line_source = line_source.slice(1);
+            snippet += char || " ";
+            column += 1;
+            return char;
+        }
+
+        function char_before() {
+
+// Back up one character by moving a character from the end of the snippet to
+// the front of the line_source.
+
+            char = snippet.slice(-1);
+            line_source = char + line_source;
+            column -= char.length;
+
+// Remove last character from snippet.
+
+            snippet = snippet.slice(0, -1);
+            return char;
+        }
+
+        function read_some_digits(rx, quiet) {
+            const digits = line_source.match(rx)[0];
+            const length = digits.length;
+            if (!quiet && length === 0) {
+
+// cause: "0x"
+
+                warn_at("expected_digits_after_a", line, column, snippet);
+            }
+            column += length;
+            line_source = line_source.slice(length);
+            snippet += digits;
+            char_after();
+            return length;
+        }
+
+        function char_after_escape(extra) {
+
+// Validate char after escape "\\".
+
+            char_after("\\");
+            switch (char) {
+            case "":
+
+// cause: "\"\\"
+
+                return stop_at("unclosed_string", line, column);
+            case "/":
+            case "\\":
+            case "`":
+            case "b":
+            case "f":
+            case "n":
+            case "r":
+            case "t":
+                return char_after();
+            case "u":
+                if (char_after("u") === "{") {
+                    if (mode_json) {
+
+// cause: "[\"\\u{12345}\"]"
+
+                        warn_at("unexpected_a", line, column, char);
+                    }
+                    if (read_some_digits(rx_hexs) > 5) {
+
+// cause: "\"\\u{123456}\""
+
+                        warn_at("too_many_digits", line, column);
+                    }
+                    if (char !== "}") {
+
+// cause: "\"\\u{12345\""
+
+                        stop_at("expected_a_before_b", line, column, "}", char);
+                    }
+                    return char_after();
+                }
+                char_before();
+                if (read_some_digits(rx_hexs, true) < 4) {
+
+// cause: "\"\\u0\""
+
+                    warn_at("expected_four_digits", line, column);
+                }
+                return;
+            default:
+                if (extra && extra.indexOf(char) >= 0) {
+                    return char_after();
+                }
+
+// cause: "\"\\0\""
+
+                warn_at("unexpected_a_before_b", line, column, "\\", char);
+            }
+        }
+
+        function token_create(id, value, identifier) {
+
+// Create the token object and append it to token_array.
+
+            const the_token = {
+                from,
+                id,
+                identifier: Boolean(identifier),
+                line,
+                nr: token_array.length,
+                thru: column
+            };
+            token_array.push(the_token);
+
+// Directives must appear before the first statement.
+
+            if (id !== "(comment)" && id !== ";") {
+                mode_directive = false;
+            }
+
+// If the token is to have a value, give it one.
+
+            if (value !== undefined) {
+                the_token.value = value;
+            }
+
+// If this token is an identifier that touches a preceding number, or
+// a "/", comment, or regular expression literal that touches a preceding
+// comment or regular expression literal, then give a missing space warning.
+// This warning is not suppressed by option_object.white.
+
+            if (
+                token_prv.line === line
+                && token_prv.thru === from
+                && (id === "(comment)" || id === "(regexp)" || id === "/")
+                && (token_prv.id === "(comment)" || token_prv.id === "(regexp)")
+            ) {
+
+// cause: "/**//**/"
+
+                warn(
+                    "expected_space_a_b",
+                    the_token,
+                    artifact(token_prv),
+                    artifact(the_token)
+                );
+            }
+            if (token_prv.id === "." && id === "(number)") {
+
+// cause: ".0"
+
+                warn("expected_a_before_b", token_prv, "0", ".");
+            }
+            if (token_before_slash.id === "." && the_token.identifier) {
+                the_token.dot = true;
+            }
+
+// The previous token is used to detect adjacency problems.
+
+            token_prv = the_token;
+
+// The token_before_slash token is a previous token that was not a comment.
+// The token_before_slash token
+// is used to disambiguate "/", which can mean division or regular expression
+// literal.
+
+            if (token_prv.id !== "(comment)") {
+                token_before_slash = token_prv;
+            }
+            return the_token;
+        }
+
+        function parse_directive(the_comment, body) {
+
+// JSLint recognizes three directives that can be encoded in comments. This
+// function processes one item, and calls itself recursively to process the
+// next one.
+
+            const result = body.match(rx_directive_part);
+            if (result) {
+                let allowed;
+                const name = result[1];
+                const value = result[2];
+                if (the_comment.directive === "jslint") {
+                    allowed = allowed_option[name];
+                    if (
+                        typeof allowed === "boolean"
+                        || typeof allowed === "object"
+                    ) {
+                        if (value === "true" || value === undefined) {
+                            option_object[name] = true;
+                            if (Array.isArray(allowed)) {
+                                populate(allowed, global_array, false);
+                            }
+                        } else {
+                            assert_or_throw(
+                                value === "false",
+                                `Expected value === "false".`
+                            );
+                            option_object[name] = false;
+//                  Probably deadcode.
+//                  } else if (value === "false") {
+//                      option_object[name] = false;
+//                  } else {
+//                      warn("bad_option_a", the_comment, name + ":" + value);
+                        }
+                    } else {
+
+// cause: "/*jslint undefined*/"
+
+                        warn("bad_option_a", the_comment, name);
+                    }
+                } else if (the_comment.directive === "property") {
+                    if (tenure === undefined) {
+                        tenure = empty();
+                    }
+                    tenure[name] = true;
+                } else if (the_comment.directive === "global") {
+                    if (value) {
+
+// cause: "/*global aa:false*/"
+
+                        warn("bad_option_a", the_comment, name + ":" + value);
+                    }
+                    global_array[name] = false;
+                    mode_module = the_comment;
+                }
+                return parse_directive(the_comment, result[3]);
+            }
+            if (body) {
+
+// cause: "/*jslint !*/"
+
+                return stop("bad_directive_a", the_comment, body);
+            }
+        }
+
+        function comment(snippet) {
+
+// Create a comment object. Comments are not allowed in JSON text. Comments can
+// include directives and notices of incompletion.
+
+            const the_comment = token_create("(comment)", snippet);
+            let result;
+            if (Array.isArray(snippet)) {
+                snippet = snippet.join(" ");
+            }
+            if (!option_object.devel && rx_todo.test(snippet)) {
+
+// cause: "//\u0074odo"
+
+                warn("todo_comment", the_comment);
+            }
+            result = snippet.match(rx_directive);
+            if (result) {
+                if (!mode_directive) {
+
+// cause: "0\n/*global aa*/"
+
+                    warn_at("misplaced_directive_a", line, from, result[1]);
+                } else {
+                    the_comment.directive = result[1];
+                    parse_directive(the_comment, result[2]);
+                }
+                directives.push(the_comment);
+            }
+            return the_comment;
+        }
+
+        function regexp() {
+
+// Regexp
+// Parse a regular expression literal.
+
+            let flag;
+            let mode_multi = false;
+            let result;
+            let value;
+            mode_regexp = true;
+
+            function regexp_subklass() {
+
+// RegExp
+// Match a character in a character class.
+
+                switch (char) {
+                case "\\":
+                    char_after_escape("BbDdSsWw-[]^");
+                    return true;
+                case "":
+                case "[":
+                case "]":
+                case "/":
+                case "^":
+                case "-":
+                    return false;
+                case " ":
+
+// cause: "aa=/[ ]/"
+
+                    warn_at("expected_a_b", line, column, "\\u0020", " ");
+                    char_after();
+                    return true;
+                case "`":
+                    if (mode_mega) {
+
+// cause: "`${/[`]/}`"
+
+                        warn_at("unexpected_a", line, column, "`");
+                    }
+                    char_after();
+                    return true;
+                default:
+                    char_after();
+                    return true;
+                }
+            }
+
+            function regexp_choice() {
+                let follow;
+
+// RegExp
+// Parse sequence of characters in regexp.
+
+                while (true) {
+                    switch (char) {
+                    case "":
+                    case "/":
+                    case "]":
+                    case ")":
+
+// RegExp
+// Break while-loop in regexp_choice().
+
+                        if (!follow) {
+
+// cause: "/ /"
+
+                            warn_at(
+                                "expected_regexp_factor_a",
+                                line,
+                                column,
+                                char
+                            );
+                        }
+
+// RegExp
+// Match a choice (a sequence that can be followed by | and another choice).
+
+                        assert_or_throw(
+                            !(char === "|"),
+                            `Expected !(char === "|").`
+                        );
+//                  Probably deadcode.
+//                  if (char === "|") {
+//                      char_after("|");
+//                      return regexp_choice();
+//                  }
+                        return;
+                    case "(":
+
+// RegExp
+// Match a group that starts with left paren.
+
+                        char_after("(");
+                        if (char === "?") {
+                            char_after("?");
+                            if (char === "=" || char === "!") {
+                                char_after();
+                            } else {
+                                char_after(":");
+                            }
+                        } else if (char === ":") {
+
+// cause: "aa=/(:)/"
+// cause: "aa=/?/"
+
+                            warn_at(
+                                "expected_a_before_b",
+                                line,
+                                column,
+                                "?",
+                                ":"
+                            );
+                        }
+
+// RegExp
+// Recurse regexp_choice().
+
+                        regexp_choice();
+                        char_after(")");
+                        break;
+                    case "[":
+
+// RegExp
+// Match a class.
+
+                        char_after("[");
+                        if (char === "^") {
+                            char_after("^");
+                        }
+                        while (true) {
+
+// RegExp
+// Match a range of subclasses.
+
+                            while (regexp_subklass()) {
+                                if (char === "-") {
+                                    char_after("-");
+                                    if (!regexp_subklass()) {
+
+// cause: "aa=/[0-]/"
+
+                                        return stop_at(
+                                            "unexpected_a",
+                                            line,
+                                            column - 1,
+                                            "-"
+                                        );
+                                    }
+                                }
+                            }
+                            if (char === "]" || char === "") {
+                                break;
+                            }
+
+// cause: "aa=/[/"
+
+                            warn_at(
+                                "expected_a_before_b",
+                                line,
+                                column,
+                                "\\",
+                                char
+                            );
+                            char_after();
+                        }
+                        char_after("]");
+                        break;
+                    case "\\":
+                        char_after_escape("BbDdSsWw^${}[]():=!.|*+?");
+                        break;
+                    case "?":
+                    case "+":
+                    case "*":
+                    case "}":
+                    case "{":
+                        warn_at(
+                            "expected_a_before_b",
+                            line,
+                            column,
+                            "\\",
+                            char
+                        );
+                        char_after();
+                        break;
+                    case "`":
+                        if (mode_mega) {
+
+// cause: "`${/`/}`"
+
+                            warn_at("unexpected_a", line, column, "`");
+                        }
+                        char_after();
+                        break;
+                    case " ":
+
+// cause: "aa=/ /"
+
+                        warn_at("expected_a_b", line, column, "\\s", " ");
+                        char_after();
+                        break;
+                    case "$":
+                        if (line_source[0] !== "/") {
+                            mode_multi = true;
+                        }
+                        char_after();
+                        break;
+                    case "^":
+                        if (snippet !== "^") {
+                            mode_multi = true;
+                        }
+                        char_after();
+                        break;
+                    default:
+                        char_after();
+                    }
+
+// RegExp
+// Match an optional quantifier.
+
+                    switch (char) {
+                    case "?":
+                    case "*":
+                    case "+":
+                        if (char_after() === "?") {
+                            char_after("?");
+                        }
+                        break;
+                    case "{":
+                        if (read_some_digits(rx_digits, true) === 0) {
+
+// cause: "aa=/aa{/"
+
+                            warn_at(
+                                "expected_a_before_b",
+                                line,
+                                column,
+                                "0",
+                                ","
+                            );
+                        }
+                        if (char === ",") {
+
+// cause: "aa=/.{,/"
+
+                            read_some_digits(rx_digits, true);
+                        }
+                        if (char_after("}") === "?") {
+
+// cause: "aa=/.{0}?/"
+
+                            warn_at("unexpected_a", line, column, char);
+                            char_after("?");
+                        }
+                        break;
+                    }
+                    follow = true;
+                }
+            }
+
+// RegExp
+// Scan the regexp literal. Give a warning if the first character is = because
+// /= looks like a division assignment operator.
+
+            snippet = "";
+            char_after();
+            if (char === "=") {
+
+// cause: "aa=/=/"
+
+                warn_at("expected_a_before_b", line, column, "\\", "=");
+            }
+            regexp_choice();
+
+// RegExp
+// Remove last character from snippet.
+
+            snippet = snippet.slice(0, -1);
+
+// RegExp
+// Make sure there is a closing slash.
+
+            value = snippet;
+            char_after("/");
+
+// RegExp
+// Create flag.
+
+            flag = empty();
+            while (
+
+// Regexp
+// char is a letter.
+
+                (char >= "a" && char <= "z\uffff")
+                || (char >= "A" && char <= "Z\uffff")
+            ) {
+
+// RegExp
+// Process dangling flag letters.
+
+                switch (!flag[char] && char) {
+                case "g":
+                case "i":
+                case "m":
+                case "u":
+                case "y":
+
+// cause: "aa=/./gimuy"
+
+                    break;
+                default:
+
+// cause: "aa=/./gg"
+// cause: "aa=/./z"
+
+                    warn_at("unexpected_a", line, column, char);
+                }
+                flag[char] = true;
+                char_after();
+            }
+            char_before();
+            if (char === "/" || char === "*") {
+
+// cause: "aa=/.//"
+
+                return stop_at("unexpected_a", line, from, char);
+            }
+            result = token_create("(regexp)", char);
+            result.flag = flag;
+            result.value = value;
+            if (mode_multi && !flag.m) {
+
+// cause: "aa=/$^/"
+
+                warn_at("missing_m", line, column);
+            }
+            return result;
+        }
+
+        function string(quote) {
+
+// Create a string token.
+
+            let the_token;
+            snippet = "";
+            char_after();
+
+// Parse/loop through each character in "...".
+
+            while (true) {
+                switch (char) {
+                case quote:
+
+// Remove last character from snippet.
+
+                    snippet = snippet.slice(0, -1);
+                    the_token = token_create("(string)", snippet);
+                    the_token.quote = quote;
+                    return the_token;
+                case "":
+
+// cause: "\""
+
+                    return stop_at("unclosed_string", line, column);
+                case "\\":
+                    char_after_escape(quote);
+                    break;
+                case "`":
+                    if (mode_mega) {
+
+// cause: "`${\"`\"}`"
+
+                        warn_at("unexpected_a", line, column, "`");
+                    }
+                    char_after("`");
+                    break;
+                default:
+                    char_after();
+                }
+            }
+        }
+
+        function frack() {
+            if (char === ".") {
+                read_some_digits(rx_digits);
+            }
+            if (char === "E" || char === "e") {
+                char_after();
+                if (char !== "+" && char !== "-") {
+                    char_before();
+                }
+                read_some_digits(rx_digits);
+            }
+        }
+
+        function number() {
+            if (snippet === "0") {
+                char_after();
+                if (char === ".") {
+                    frack();
+                } else if (char === "b") {
+                    read_some_digits(rx_bits);
+                } else if (char === "o") {
+                    read_some_digits(rx_octals);
+                } else if (char === "x") {
+                    read_some_digits(rx_hexs);
+                }
+            } else {
+                char_after();
+                frack();
+            }
+
+// If the next character after a number is a digit or letter, then something
+// unexpected is going on.
+
+            if (
+                (char >= "0" && char <= "9")
+                || (char >= "a" && char <= "z")
+                || (char >= "A" && char <= "Z")
+            ) {
+
+// cause: "0a"
+
+                return stop_at(
+                    "unexpected_a_after_b",
+                    line,
+                    column,
+                    snippet.slice(-1),
+                    snippet.slice(0, -1)
+                );
+            }
+            char_before();
+            return token_create("(number)", snippet);
+        }
+
+        function lex() {
+            let comment_array;
+            let i = 0;
+            let j = 0;
+            let result;
+            let the_token;
+
+// This should properly be a tail recursive function, but sadly, conformant
+// implementations of ES6 are still rare. This is the ideal code:
+
+//      if (!line_source) {
+//          line_source = line_next();
+//          from = 0;
+//          return (
+//              line_source === undefined
+//              ? (
+//                  mode_mega
+//                  ? stop_at("unclosed_mega", line_mega, from_mega)
+//                  : token_create("(end)")
+//              )
+//              : lex()
+//          );
+//      }
+
+// Unfortunately, incompetent JavaScript engines will sometimes fail to execute
+// it correctly. So for now, we do it the old fashioned way.
+
+// Loop through blank lines.
+
+            while (!line_source) {
+                line_source = line_next();
+                from = 0;
+                if (line_source === undefined) {
+                    return (
+                        mode_mega
+
+// cause: "`${//}`"
+
+                        ? stop_at("unclosed_mega", line_mega, from_mega)
+                        : line_disable !== undefined
+
+// cause: "/*jslint-disable*/"
+
+                        ? stop_at("unclosed_disable", line_disable)
+                        : token_create("(end)")
+                    );
+                }
+            }
+
+            from = column;
+            result = line_source.match(rx_token);
+
+// result[1] token
+// result[2] whitespace
+// result[3] identifier
+// result[4] number
+// result[5] rest
+
+            if (!result) {
+
+// cause: "#"
+
+                return stop_at(
+                    "unexpected_char_a",
+                    line,
+                    column,
+                    line_source[0]
+                );
+            }
+
+            snippet = result[1];
+            column += snippet.length;
+            line_source = result[5];
+
+// Whitespace was matched. Call lex again to get more.
+
+            if (result[2]) {
+                return lex();
+            }
+
+// The token is an identifier.
+
+            if (result[3]) {
+                return token_create(snippet, undefined, true);
+            }
+
+// Create token from number.
+
+            if (result[4]) {
+                return number(snippet);
+            }
+
+// Create token from string.
+
+            if (snippet === "\"") {
+                return string(snippet);
+            }
+            if (snippet === "'") {
+                if (!option_object.single) {
+
+// cause: "''"
+
+                    warn_at("use_double", line, column);
+                }
+                return string(snippet);
+            }
+
+// The token is a megastring. We don't allow any kind of mega nesting.
+
+            if (snippet === "`") {
+                if (mode_mega) {
+
+// cause: "`${`"
+
+                    return stop_at("expected_a_b", line, column, "}", "`");
+                }
+                snippet = "";
+                from_mega = from;
+                line_mega = line;
+                mode_mega = true;
+
+// Parsing a mega literal is tricky. First create a ` token.
+
+                token_create("`");
+                from += 1;
+
+// Then loop, building up a string, possibly from many lines, until seeing
+// the end of file, a closing `, or a ${ indicting an expression within the
+// string.
+
+                (function part() {
+                    const at = line_source.search(rx_mega);
+
+// If neither ` nor ${ is seen, then the whole line joins the snippet.
+
+                    if (at < 0) {
+                        snippet += line_source + "\n";
+                        return (
+                            line_next() === undefined
+
+// cause: "`"
+
+                            ? stop_at("unclosed_mega", line_mega, from_mega)
+                            : part()
+                        );
+                    }
+                    snippet += line_source.slice(0, at);
+                    column += at;
+                    line_source = line_source.slice(at);
+                    if (line_source[0] === "\\") {
+                        snippet += line_source.slice(0, 2);
+                        line_source = line_source.slice(2);
+                        column += 2;
+                        return part();
+                    }
+
+// if either ` or ${ was found, then the preceding joins the snippet to become
+// a string token.
+
+                    token_create("(string)", snippet).quote = "`";
+                    snippet = "";
+
+// If ${, then create tokens that will become part of an expression until
+// a } token is made.
+
+                    if (line_source[0] === "$") {
+                        column += 2;
+                        token_create("${");
+                        line_source = line_source.slice(2);
+                        (function expr() {
+                            const id = lex().id;
+                            if (id === "{") {
+
+// cause: "`${{"
+
+                                return stop_at(
+                                    "expected_a_b",
+                                    line,
+                                    column,
+                                    "}",
+                                    "{"
+                                );
+                            }
+                            if (id !== "}") {
+                                return expr();
+                            }
+                        }());
+                        return part();
+                    }
+                }());
+                line_source = line_source.slice(1);
+                column += 1;
+                mode_mega = false;
+                return token_create("`");
+            }
+
+// The token is a // comment.
+
+            if (snippet === "//") {
+                snippet = line_source;
+                line_source = "";
+                the_token = comment(snippet);
+                if (mode_mega) {
+
+// cause: "`${//}`"
+
+                    warn("unexpected_comment", the_token, "`");
+                }
+                return the_token;
+            }
+
+// The token is a /* comment.
+
+            if (snippet === "/*") {
+                comment_array = [];
+                if (line_source[0] === "/") {
+
+// cause: "/*/"
+
+                    warn_at("unexpected_a", line, column + i, "/");
+                }
+                (function next() {
+                    if (line_source > "") {
+                        i = line_source.search(rx_star_slash);
+                        if (i >= 0) {
+                            return;
+                        }
+                        j = line_source.search(rx_slash_star);
+                        if (j >= 0) {
+
+// cause: "/*/*"
+
+                            warn_at("nested_comment", line, column + j);
+                        }
+                    }
+                    comment_array.push(line_source);
+                    line_source = line_next();
+                    if (line_source === undefined) {
+
+// cause: "/*"
+
+                        return stop_at("unclosed_comment", line, column);
+                    }
+                    return next();
+                }());
+                snippet = line_source.slice(0, i);
+                j = snippet.search(rx_slash_star_or_slash);
+                if (j >= 0) {
+
+// cause: "/*/**/"
+
+                    warn_at("nested_comment", line, column + j);
+                }
+                comment_array.push(snippet);
+                column += i + 2;
+                line_source = line_source.slice(i + 2);
+                return comment(comment_array);
+            }
+
+// The token is a slash.
+
+            if (snippet === "/") {
+
+// The / can be a division operator or the beginning of a regular expression
+// literal. It is not possible to know which without doing a complete parse.
+// We want to complete the tokenization before we begin to parse, so we will
+// estimate. This estimator can fail in some cases. For example, it cannot
+// know if "}" is ending a block or ending an object literal, so it can
+// behave incorrectly in that case; it is not meaningful to divide an
+// object, so it is likely that we can get away with it. We avoided the worst
+// cases by eliminating automatic semicolon insertion.
+
+                if (token_before_slash.identifier) {
+                    if (!token_before_slash.dot) {
+                        if (token_before_slash.id === "return") {
+                            return regexp();
+                        }
+                        if (
+                            token_before_slash.id === "(begin)"
+                            || token_before_slash.id === "case"
+                            || token_before_slash.id === "delete"
+                            || token_before_slash.id === "in"
+                            || token_before_slash.id === "instanceof"
+                            || token_before_slash.id === "new"
+                            || token_before_slash.id === "typeof"
+                            || token_before_slash.id === "void"
+                            || token_before_slash.id === "yield"
+                        ) {
+                            the_token = regexp();
+
+// cause: "/./"
+// cause: "case /./"
+// cause: "delete /./"
+// cause: "in /./"
+// cause: "instanceof /./"
+// cause: "new /./"
+// cause: "typeof /./"
+// cause: "void /./"
+// cause: "yield /./"
+
+                            return stop("unexpected_a", the_token);
+                        }
+                    }
+                } else {
+                    if ("(,=:?[".indexOf(
+                        token_before_slash.id.slice(-1)
+                    ) >= 0) {
+                        return regexp();
+                    }
+                    if ("!&|{};~+-*%/^<>".indexOf(
+                        token_before_slash.id.slice(-1)
+                    ) >= 0) {
+                        the_token = regexp();
+
+// cause: "!/./"
+
+                        warn("wrap_regexp", the_token);
+                        return the_token;
+                    }
+                }
+                if (line_source[0] === "=") {
+                    column += 1;
+                    line_source = line_source.slice(1);
+                    snippet = "/=";
+                    warn_at("unexpected_a", line, column, "/=");
+                }
+            }
+            return token_create(snippet);
+        }
+
+// Scan first line for "#!" and ignore it.
+
+        if (line_array[line_fudge].line_source.startsWith("#!")) {
+            line += 1;
+            mode_shebang = true;
+        }
+        token_1 = lex();
+        mode_json = token_1.id === "{" || token_1.id === "[";
+
+// This loop will be replaced with a recursive call to lex when ES6 has been
+// finished and widely deployed and adopted.
+
+        while (true) {
+            if (lex().id === "(end)") {
+                break;
+            }
+        }
+    }
+
+
+    function phase3_parse() {
+
+// PHASE 3. Parse <token_array> into <token_tree> using Pratt parsing.
+
+// Parsing:
+
+// Parsing weaves the tokens into an abstract syntax tree. During that process,
+// a token may be given any of these properties:
+
+//      arity       string
+//      label       identifier
+//      name        identifier
+//      expression  expressions
+//      block       statements
+//      else        statements (else, default, catch)
+
+// Specialized tokens may have additional properties.
+
+// The guessed name for anonymous functions.
+        let anon = "anonymous";
+// The current function.
+        let functionage = global;
+// The number of the next token.
+        let token_array_ii = 0;
+// The current token being examined in the parse.
+        let token_now = global;
+
+        function advance(id, match) {
+
+// Produce the next token.
+
+// Attempt to give helpful names to anonymous functions.
+
+            if (token_now.identifier && token_now.id !== "function") {
+                anon = token_now.id;
+            } else if (
+                token_now.id === "(string)"
+                && rx_identifier.test(token_now.value)
+            ) {
+                anon = token_now.value;
+            }
+
+// Attempt to match token_nxt with an expected id.
+
+            if (id !== undefined && token_nxt.id !== id) {
+                return (
+                    match === undefined
+
+// cause: "()"
+
+                    ? stop("expected_a_b", token_nxt, id, artifact())
+
+// cause: "{\"aa\":0"
+
+                    : stop(
+                        "expected_a_b_from_c_d",
+                        token_nxt,
+                        id,
+                        artifact(match),
+                        match.line,
+                        artifact(token_nxt)
+                    )
+                );
+            }
+
+// Promote the tokens, skipping comments.
+
+            token_now = token_nxt;
+            while (true) {
+                token_nxt = token_array[token_array_ii];
+                token_array_ii += 1;
+                if (token_nxt.id !== "(comment)") {
+                    if (token_nxt.id === "(end)") {
+                        token_array_ii -= 1;
+                    }
+                    break;
+                }
+                if (mode_json) {
+
+// cause: "[//]"
+
+                    warn("unexpected_a", token_nxt);
+                }
+            }
+        }
+
+        function lookahead() {
+
+// Look ahead one token without advancing, skipping comments.
+
+            let cadet;
+            let ii = token_array_ii;
+            while (true) {
+                cadet = token_array[ii];
+                if (cadet.id !== "(comment)") {
+                    return cadet;
+                }
+                ii += 1;
+            }
+        }
+
+// Now we parse JavaScript.
+
+        function enroll(name, role, readonly) {
+
+// Enroll a name into the current function context. The role can be exception,
+// function, label, parameter, or variable. We look for variable redefinition
+// because it causes confusion.
+
+            const id = name.id;
+
+// Reserved words may not be enrolled.
+
+            if (syntax_object[id] !== undefined && id !== "ignore") {
+
+// cause: "let undefined"
+
+                warn("reserved_a", name);
+            } else {
+
+// Has the name been enrolled in this context?
+
+                let earlier = functionage.context[id];
+                if (earlier) {
+
+// cause: "let aa;let aa"
+
+                    warn(
+                        "redefinition_a_b",
+                        name,
+                        name.id,
+                        earlier.line
+                    );
+
+// Has the name been enrolled in an outer context?
+
+                } else {
+                    function_stack.forEach(function (value) {
+                        const item = value.context[id];
+                        if (item !== undefined) {
+                            earlier = item;
+                        }
+                    });
+                    if (earlier) {
+                        if (id === "ignore") {
+                            if (earlier.role === "variable") {
+
+// cause: "let ignore;function aa(ignore){}"
+
+                                warn("unexpected_a", name);
+                            }
+                        } else {
+                            if (
+                                (
+                                    role !== "exception"
+                                    || earlier.role !== "exception"
+                                )
+                                && role !== "parameter"
+                                && role !== "function"
+                            ) {
+
+// cause: "function aa(){try{aa();}catch(aa){aa();}}"
+// cause: "function aa(){var aa;}"
+
+                                warn(
+                                    "redefinition_a_b",
+                                    name,
+                                    name.id,
+                                    earlier.line
+                                );
+                            }
+                        }
+                    }
+
+// Enroll it.
+
+                    functionage.context[id] = name;
+                    name.dead = true;
+                    name.parent = functionage;
+                    name.init = false;
+                    name.role = role;
+                    name.used = 0;
+                    name.writable = !readonly;
+                }
+            }
+        }
+
+        function parse_expression(rbp, initial) {
+
+// This is the heart of the Pratt parser. I retained Pratt's nomenclature.
+// They are elements of the parsing method called Top Down Operator Precedence.
+
+// nud     Null denotation
+// led     Left denotation
+// lbp     Left binding power
+// rbp     Right binding power
+
+// It processes a nud (variable, constant, prefix operator). It will then
+// process leds (infix operators) until the bind powers cause it to stop. It
+// returns the expression's parse tree.
+
+            let left;
+            let the_symbol;
+
+// Statements will have already advanced, so advance now only if the token is
+// not the first of a statement,
+
+            if (!initial) {
+                advance();
+            }
+            the_symbol = syntax_object[token_now.id];
+            if (the_symbol !== undefined && the_symbol.nud !== undefined) {
 
 // cause: "0"
 
-            warn_at(
-                "expected_a_b",
-                token_now.line,
-                token_now.thru + 1,
-                ";",
-                artifact(token_nxt)
-            );
-        }
-        anon = "anonymous";
-    }
+                left = the_symbol.nud();
+            } else if (token_now.identifier) {
 
-    function statement() {
+// cause: "aa"
+
+                left = token_now;
+                left.arity = "variable";
+            } else {
+
+// cause: "!"
+// cause: "let aa=`${}`;"
+
+                return stop("unexpected_a", token_now);
+            }
+
+// Parse/loop through each symbol in expression.
+
+            while (true) {
+                the_symbol = syntax_object[token_nxt.id];
+                if (
+                    the_symbol === undefined
+                    || the_symbol.led === undefined
+                    || the_symbol.lbp <= rbp
+                ) {
+                    break;
+                }
+                advance();
+                left = the_symbol.led(left);
+            }
+            return left;
+        }
+
+        function condition() {
+
+// Parse the condition part of a do, if, while.
+
+            const the_paren = token_nxt;
+            let the_value;
+
+// cause: "do{}while()"
+// cause: "if(){}"
+// cause: "while(){}"
+
+            the_paren.free = true;
+            advance("(");
+            the_value = parse_expression(0);
+            advance(")");
+            if (the_value.wrapped === true) {
+
+// cause: "while((0)){}"
+
+                warn("unexpected_a", the_paren);
+            }
+
+// Check for anticondition.
+
+            switch (the_value.id) {
+            case "%":
+            case "&":
+            case "(number)":
+            case "(string)":
+            case "*":
+            case "+":
+            case "-":
+            case "/":
+            case "<<":
+            case ">>":
+            case ">>>":
+            case "?":
+            case "^":
+            case "typeof":
+            case "|":
+            case "~":
+
+// cause: "if(\"aa\"){}"
+// cause: "if(0%0){}"
+// cause: "if(0&0){}"
+// cause: "if(0){}"
+// cause: "if(0*0){}"
+// cause: "if(0+0){}"
+// cause: "if(0-0){}"
+// cause: "if(0/0){}"
+// cause: "if(0<<0){}"
+// cause: "if(0>>0){}"
+// cause: "if(0>>>0){}"
+// cause: "if(0?0:0){}"
+// cause: "if(0^0){}"
+// cause: "if(0|0){}"
+// cause: "if(typeof 0){}"
+// cause: "if(~0){}"
+
+                warn("unexpected_a", the_value);
+                break;
+            }
+            return the_value;
+        }
+
+        function semicolon() {
+
+// Try to match a semicolon.
+
+            if (token_nxt.id === ";") {
+                advance(";");
+            } else {
+
+// cause: "0"
+
+                warn_at(
+                    "expected_a_b",
+                    token_now.line,
+                    token_now.thru + 1,
+                    ";",
+                    artifact(token_nxt)
+                );
+            }
+            anon = "anonymous";
+        }
+
+        function parse_statement() {
 
 // Parse a statement. Any statement may have a label, but only four statements
 // have use for one. A statement can be one of the standard statements, or
 // an assignment expression, or an invocation expression.
 
-        let first;
-        let the_label;
-        let the_statement;
-        let the_symbol;
-        advance();
-        if (token_now.identifier && token_nxt.id === ":") {
-            the_label = token_now;
-            if (the_label.id === "ignore") {
+            let first;
+            let the_label;
+            let the_statement;
+            let the_symbol;
+            advance();
+            if (token_now.identifier && token_nxt.id === ":") {
+                the_label = token_now;
+                if (the_label.id === "ignore") {
 
 // cause: "ignore:"
 
-                warn("unexpected_a", the_label);
-            }
-            advance(":");
-            if (
-                token_nxt.id === "do"
-                || token_nxt.id === "for"
-                || token_nxt.id === "switch"
-                || token_nxt.id === "while"
-            ) {
-                enroll(the_label, "label", true);
-                the_label.init = true;
-                the_label.dead = false;
-                the_statement = statement();
-                the_statement.label = the_label;
-                the_statement.statement = true;
-                return the_statement;
-            }
-            advance();
+                    warn("unexpected_a", the_label);
+                }
+                advance(":");
+                if (
+                    token_nxt.id === "do"
+                    || token_nxt.id === "for"
+                    || token_nxt.id === "switch"
+                    || token_nxt.id === "while"
+                ) {
+                    enroll(the_label, "label", true);
+                    the_label.init = true;
+                    the_label.dead = false;
+                    the_statement = parse_statement();
+                    the_statement.label = the_label;
+                    the_statement.statement = true;
+                    return the_statement;
+                }
+                advance();
 
 // cause: "aa:"
 
-            warn("unexpected_label_a", the_label);
-        }
+                warn("unexpected_label_a", the_label);
+            }
 
 // Parse the statement.
 
-        first = token_now;
-        first.statement = true;
-        the_symbol = syntax[first.id];
-        if (
-            the_symbol !== undefined
-            && the_symbol.fud !== undefined
+            first = token_now;
+            first.statement = true;
+            the_symbol = syntax_object[first.id];
+            if (
+                the_symbol !== undefined
+                && the_symbol.fud !== undefined
 
 // Fixes issues #316, #317 - dynamic-import().
 
-            && !(the_symbol.id === "import" && token_nxt.id === "(")
-        ) {
-            the_symbol.disrupt = false;
-            the_symbol.statement = true;
-            the_statement = the_symbol.fud();
-        } else {
+                && !(the_symbol.id === "import" && token_nxt.id === "(")
+            ) {
+                the_symbol.disrupt = false;
+                the_symbol.statement = true;
+                the_statement = the_symbol.fud();
+            } else {
 
 // It is an expression statement.
 
-            the_statement = expression(0, true);
-            if (the_statement.wrapped && the_statement.id !== "(") {
+                the_statement = parse_expression(0, true);
+                if (the_statement.wrapped && the_statement.id !== "(") {
 
 // cause: "(0)"
 
-                warn("unexpected_a", first);
+                    warn("unexpected_a", first);
+                }
+                semicolon();
             }
-            semicolon();
+            if (the_label !== undefined) {
+                the_label.dead = true;
+            }
+            return the_statement;
         }
-        if (the_label !== undefined) {
-            the_label.dead = true;
-        }
-        return the_statement;
-    }
 
-    function statements() {
+        function parse_statements() {
 
 // Parse a list of statements. Give a warning if an unreachable statement
 // follows a disruptive statement.
 
-        const statement_array = [];
-        let a_statement;
-        let disrupt = false;
+            const statement_array = [];
+            let a_statement;
+            let disrupt = false;
 
 // Parse/loop each statement until a statement-terminator is reached.
 
-        while (true) {
-            switch (token_nxt.id) {
-            case "}":
-            case "case":
-            case "default":
-            case "else":
-            case "(end)":
-                return statement_array;
-            }
-            a_statement = statement();
-            statement_array.push(a_statement);
-            if (disrupt) {
+            while (true) {
+                switch (token_nxt.id) {
+                case "}":
+                case "case":
+                case "default":
+                case "else":
+                case "(end)":
+                    return statement_array;
+                }
+                a_statement = parse_statement();
+                statement_array.push(a_statement);
+                if (disrupt) {
 
 // cause: "while(0){break;0;}"
 
-                warn("unreachable_a", a_statement);
+                    warn("unreachable_a", a_statement);
+                }
+                disrupt = a_statement.disrupt;
             }
-            disrupt = a_statement.disrupt;
         }
-    }
 
-    function not_top_level(thing) {
+        function not_top_level(thing) {
 
 // Some features should not be at the outermost level.
 
-        if (functionage === global) {
+            if (functionage === global) {
 
 // cause: "while(0){}"
 
-            warn("unexpected_at_top_level_a", thing);
+                warn("unexpected_at_top_level_a", thing);
+            }
         }
-    }
 
-    function top_level_only(the_thing) {
-
-// Some features must be at the most outermost level.
-
-        if (blockage !== global) {
-
-// cause: "if(0){import aa from \"aa\";}"
-
-            warn("misplaced_a", the_thing);
-        }
-    }
-
-    function block(special) {
+        function block(special) {
 
 // Parse a block, a sequence of statements wrapped in braces.
 //  special "body"      The block is a function body.
@@ -1461,44 +2437,44 @@ function jslint(
 //          "naked"     No advance.
 //          undefined   An ordinary block.
 
-        let stmts;
-        let the_block;
-        if (special !== "naked") {
-            advance("{");
-        }
-        the_block = token_now;
-        the_block.arity = "statement";
-        the_block.body = special === "body";
+            let stmts;
+            let the_block;
+            if (special !== "naked") {
+                advance("{");
+            }
+            the_block = token_now;
+            the_block.arity = "statement";
+            the_block.body = special === "body";
 
 // Top level function bodies may include the "use strict" pragma.
 
-        if (
-            special === "body"
-            && stack.length === 1
-            && token_nxt.value === "use strict"
-        ) {
-            token_nxt.statement = true;
-            advance("(string)");
-            advance(";");
-        }
-        stmts = statements();
-        the_block.block = stmts;
-        if (stmts.length === 0) {
-            if (!option_object.devel && special !== "ignore") {
+            if (
+                special === "body"
+                && function_stack.length === 1
+                && token_nxt.value === "use strict"
+            ) {
+                token_nxt.statement = true;
+                advance("(string)");
+                advance(";");
+            }
+            stmts = parse_statements();
+            the_block.block = stmts;
+            if (stmts.length === 0) {
+                if (!option_object.devel && special !== "ignore") {
 
 // cause: "function aa(){}"
 
-                warn("empty_block", the_block);
+                    warn("empty_block", the_block);
+                }
+                the_block.disrupt = false;
+            } else {
+                the_block.disrupt = stmts[stmts.length - 1].disrupt;
             }
-            the_block.disrupt = false;
-        } else {
-            the_block.disrupt = stmts[stmts.length - 1].disrupt;
+            advance("}");
+            return the_block;
         }
-        advance("}");
-        return the_block;
-    }
 
-    function mutation_check(the_thing) {
+        function mutation_check(the_thing) {
 
 // The only expressions that may be assigned to are
 //      e.b
@@ -1507,22 +2483,22 @@ function jslint(
 //      [destructure]
 //      {destructure}
 
-        if (
-            the_thing.arity !== "variable"
-            && the_thing.id !== "."
-            && the_thing.id !== "["
-            && the_thing.id !== "{"
-        ) {
+            if (
+                the_thing.arity !== "variable"
+                && the_thing.id !== "."
+                && the_thing.id !== "["
+                && the_thing.id !== "{"
+            ) {
 
 // cause: "0=0"
 
-            warn("bad_assignment_a", the_thing);
-            return false;
+                warn("bad_assignment_a", the_thing);
+                return false;
+            }
+            return true;
         }
-        return true;
-    }
 
-    function left_check(left, right) {
+        function left_check(left, right) {
 
 // Warn if the left is not one of these:
 //      ?.
@@ -1532,787 +2508,725 @@ function jslint(
 //      e[b]
 //      identifier
 
-        const id = left.id;
-        if (
-            !left.identifier
-            && (
-                left.arity !== "ternary"
-                || (
-                    !left_check(left.expression[1])
-                    && !left_check(left.expression[2])
+            const id = left.id;
+            if (
+                !left.identifier
+                && (
+                    left.arity !== "ternary"
+                    || (
+                        !left_check(left.expression[1])
+                        && !left_check(left.expression[2])
+                    )
                 )
-            )
-            && (
-                left.arity !== "binary"
-                || (id !== "." && id !== "?." && id !== "(" && id !== "[")
-            )
-        ) {
-            warn("unexpected_a", right);
-            return false;
+                && (
+                    left.arity !== "binary"
+                    || (id !== "." && id !== "?." && id !== "(" && id !== "[")
+                )
+            ) {
+                warn("unexpected_a", right);
+                return false;
+            }
+            return true;
         }
-        return true;
-    }
 
 // These functions are used to specify the grammar of our language:
 
-    function symbol(id, bp) {
+        function symbol(id, bp) {
 
 // Create a symbol if it does not already exist in the language's syntax.
 
-        let the_symbol = syntax[id];
-        if (the_symbol === undefined) {
-            the_symbol = empty();
-            the_symbol.id = id;
-            the_symbol.lbp = bp || 0;
-            syntax[id] = the_symbol;
+            let the_symbol = syntax_object[id];
+            if (the_symbol === undefined) {
+                the_symbol = empty();
+                the_symbol.id = id;
+                the_symbol.lbp = bp || 0;
+                syntax_object[id] = the_symbol;
+            }
+            return the_symbol;
         }
-        return the_symbol;
-    }
 
-    function assignment(id) {
+        function assignment(id) {
 
 // Create an assignment operator. The one true assignment is different because
 // its left side, when it is a variable, is not treated as an expression.
 // That case is special because that is when a variable gets initialized. The
 // other assignment operators can modify, but they cannot initialize.
 
-        const the_symbol = symbol(id, 20);
-        the_symbol.led = function (left) {
-            const the_token = token_now;
-            let right;
-            the_token.arity = "assignment";
-            right = expression(20 - 1);
-            if (id === "=" && left.arity === "variable") {
-                the_token.names = left;
-                the_token.expression = right;
-            } else {
-                the_token.expression = [left, right];
-            }
-            if (
-                right.arity === "assignment"
-                || right.arity === "pre"
-                || right.arity === "post"
-            ) {
-                warn("unexpected_a", right);
-            }
-            mutation_check(left);
-            return the_token;
-        };
-        return the_symbol;
-    }
+            const the_symbol = symbol(id, 20);
+            the_symbol.led = function (left) {
+                const the_token = token_now;
+                let right;
+                the_token.arity = "assignment";
+                right = parse_expression(20 - 1);
+                if (id === "=" && left.arity === "variable") {
+                    the_token.names = left;
+                    the_token.expression = right;
+                } else {
+                    the_token.expression = [left, right];
+                }
+                if (
+                    right.arity === "assignment"
+                    || right.arity === "pre"
+                    || right.arity === "post"
+                ) {
+                    warn("unexpected_a", right);
+                }
+                mutation_check(left);
+                return the_token;
+            };
+            return the_symbol;
+        }
 
-    function constant(id, type, value) {
+        function constant(id, type, value) {
 
 // Create a constant symbol.
 
-        const the_symbol = symbol(id);
-        the_symbol.constant = true;
-        the_symbol.nud = (
-            typeof value === "function"
-            ? value
-            : function () {
-                token_now.constant = true;
-                if (value !== undefined) {
-                    token_now.value = value;
+            const the_symbol = symbol(id);
+            the_symbol.constant = true;
+            the_symbol.nud = (
+                typeof value === "function"
+                ? value
+                : function () {
+                    token_now.constant = true;
+                    if (value !== undefined) {
+                        token_now.value = value;
+                    }
+                    return token_now;
                 }
-                return token_now;
-            }
-        );
-        the_symbol.type = type;
-        the_symbol.value = value;
-        return the_symbol;
-    }
+            );
+            the_symbol.type = type;
+            the_symbol.value = value;
+            return the_symbol;
+        }
 
-    function infix(id, bp, f) {
+        function infix(id, bp, f) {
 
 // Create an infix operator.
 
-        const the_symbol = symbol(id, bp);
-        the_symbol.led = function (left) {
-            const the_token = token_now;
-            the_token.arity = "binary";
-            if (f !== undefined) {
-                return f(left);
-            }
-            the_token.expression = [left, expression(bp)];
-            return the_token;
-        };
-        return the_symbol;
-    }
+            const the_symbol = symbol(id, bp);
+            the_symbol.led = function (left) {
+                const the_token = token_now;
+                the_token.arity = "binary";
+                if (f !== undefined) {
+                    return f(left);
+                }
+                the_token.expression = [left, parse_expression(bp)];
+                return the_token;
+            };
+            return the_symbol;
+        }
 
-    function infixr(id, bp) {
+        function infixr(id, bp) {
 
 // Create a right associative infix operator.
 
-        const the_symbol = symbol(id, bp);
-        the_symbol.led = function (left) {
+            const the_symbol = symbol(id, bp);
+            the_symbol.led = function (left) {
 
 // cause: "0**0"
 
-            const the_token = token_now;
-            the_token.arity = "binary";
-            the_token.expression = [left, expression(bp - 1)];
-            return the_token;
-        };
-        return the_symbol;
-    }
+                const the_token = token_now;
+                the_token.arity = "binary";
+                the_token.expression = [left, parse_expression(bp - 1)];
+                return the_token;
+            };
+            return the_symbol;
+        }
 
-    function post(id) {
+        function post(id) {
 
 // Create one of the post operators.
 
-        const the_symbol = symbol(id, 150);
-        the_symbol.led = function (left) {
-            token_now.expression = left;
-            token_now.arity = "post";
-            mutation_check(token_now.expression);
-            return token_now;
-        };
-        return the_symbol;
-    }
+            const the_symbol = symbol(id, 150);
+            the_symbol.led = function (left) {
+                token_now.expression = left;
+                token_now.arity = "post";
+                mutation_check(token_now.expression);
+                return token_now;
+            };
+            return the_symbol;
+        }
 
-    function pre(id) {
+        function pre(id) {
 
 // Create one of the pre operators.
 
-        const the_symbol = symbol(id);
-        the_symbol.nud = function () {
-            const the_token = token_now;
-            the_token.arity = "pre";
-            the_token.expression = expression(150);
-            mutation_check(the_token.expression);
-            return the_token;
-        };
-        return the_symbol;
-    }
+            const the_symbol = symbol(id);
+            the_symbol.nud = function () {
+                const the_token = token_now;
+                the_token.arity = "pre";
+                the_token.expression = parse_expression(150);
+                mutation_check(the_token.expression);
+                return the_token;
+            };
+            return the_symbol;
+        }
 
-    function prefix(id, f) {
+        function prefix(id, f) {
 
 // Create a prefix operator.
 
-        const the_symbol = symbol(id);
-        the_symbol.nud = function () {
-            const the_token = token_now;
-            the_token.arity = "unary";
-            if (typeof f === "function") {
-                return f();
-            }
-            the_token.expression = expression(150);
-            return the_token;
-        };
-        return the_symbol;
-    }
+            const the_symbol = symbol(id);
+            the_symbol.nud = function () {
+                const the_token = token_now;
+                the_token.arity = "unary";
+                if (typeof f === "function") {
+                    return f();
+                }
+                the_token.expression = parse_expression(150);
+                return the_token;
+            };
+            return the_symbol;
+        }
 
-    function stmt(id, f) {
+        function stmt(id, f) {
 
 // Create a statement.
 
-        const the_symbol = symbol(id);
-        the_symbol.fud = function () {
-            token_now.arity = "statement";
-            return f();
-        };
-        return the_symbol;
-    }
+            const the_symbol = symbol(id);
+            the_symbol.fud = function () {
+                token_now.arity = "statement";
+                return f();
+            };
+            return the_symbol;
+        }
 
-    function ternary(id1, id2) {
+        function survey(name) {
+            let id = name.id;
+
+// Tally the property name. If it is a string, only tally strings that conform
+// to the identifier rules.
+
+            if (id === "(string)") {
+                id = name.value;
+                if (!rx_identifier.test(id)) {
+                    return id;
+                }
+            } else if (id === "`") {
+                if (name.value.length === 1) {
+                    id = name.value[0].value;
+                    if (!rx_identifier.test(id)) {
+                        return id;
+                    }
+                }
+            } else if (!name.identifier) {
+
+// cause: "let aa={0:0}"
+
+                return stop("expected_identifier_a", name);
+            }
+
+// If we have seen this name before, increment its count.
+
+            if (typeof property[id] === "number") {
+                property[id] += 1;
+
+// If this is the first time seeing this property name, and if there is a
+// tenure list, then it must be on the list. Otherwise, it must conform to
+// the rules for good property names.
+
+            } else {
+                if (tenure !== undefined) {
+                    if (tenure[id] !== true) {
+
+// cause: "/*property aa*/\naa.bb"
+
+                        warn("unregistered_property_a", name);
+                    }
+                } else if (
+                    !option_object.name
+                    && name.identifier
+                    && (
+                        // rx_bad_property
+                        /^_|\$|Sync$|_$/m
+                    ).test(id)
+                ) {
+
+// cause: "aa.$"
+// cause: "aa._"
+// cause: "aa._aa"
+// cause: "aa.aaSync"
+// cause: "aa.aa_"
+
+                    warn("bad_property_a", name);
+                }
+                property[id] = 1;
+            }
+            return id;
+        }
+
+        function ternary(id1, id2) {
 
 // Create a ternary operator.
 
-        const the_symbol = symbol(id1, 30);
-        the_symbol.led = function (left) {
-            const the_token = token_now;
-            const second = expression(20);
-            advance(id2);
-            token_now.arity = "ternary";
-            the_token.arity = "ternary";
-            the_token.expression = [left, second, expression(10)];
-            if (token_nxt.id !== ")") {
+            const the_symbol = symbol(id1, 30);
+            the_symbol.led = function (left) {
+                const the_token = token_now;
+                const second = parse_expression(20);
+                advance(id2);
+                token_now.arity = "ternary";
+                the_token.arity = "ternary";
+                the_token.expression = [left, second, parse_expression(10)];
+                if (token_nxt.id !== ")") {
 
 // cause: "0?0:0"
 
-                warn("use_open", the_token);
-            }
-            return the_token;
-        };
-        return the_symbol;
-    }
+                    warn("use_open", the_token);
+                }
+                return the_token;
+            };
+            return the_symbol;
+        }
 
 // Begin defining the language.
 
-    syntax = empty();
+        symbol("}");
+        symbol(")");
+        symbol("]");
+        symbol(",");
+        symbol(";");
+        symbol(":");
+        symbol("*/");
+        symbol("async");
+        symbol("await");
+        symbol("case");
+        symbol("catch");
+        symbol("class");
+        symbol("default");
+        symbol("else");
+        symbol("enum");
+        symbol("finally");
+        symbol("implements");
+        symbol("interface");
+        symbol("package");
+        symbol("private");
+        symbol("protected");
+        symbol("public");
+        symbol("static");
+        symbol("super");
+        symbol("void");
+        symbol("yield");
 
-    symbol("}");
-    symbol(")");
-    symbol("]");
-    symbol(",");
-    symbol(";");
-    symbol(":");
-    symbol("*/");
-    symbol("async");
-    symbol("await");
-    symbol("case");
-    symbol("catch");
-    symbol("class");
-    symbol("default");
-    symbol("else");
-    symbol("enum");
-    symbol("finally");
-    symbol("implements");
-    symbol("interface");
-    symbol("package");
-    symbol("private");
-    symbol("protected");
-    symbol("public");
-    symbol("static");
-    symbol("super");
-    symbol("void");
-    symbol("yield");
-
-    constant("(number)", "number");
-    constant("(regexp)", "regexp");
-    constant("(string)", "string");
-    constant("arguments", "object", function () {
+        constant("(number)", "number");
+        constant("(regexp)", "regexp");
+        constant("(string)", "string");
+        constant("arguments", "object", function () {
 
 // cause: "arguments"
 
-        warn("unexpected_a", token_now);
-        return token_now;
-    });
-    constant("eval", "function", function () {
-        if (!option_object.eval) {
+            warn("unexpected_a", token_now);
+            return token_now;
+        });
+        constant("eval", "function", function () {
+            if (!option_object.eval) {
 
 // cause: "eval"
 
-            warn("unexpected_a", token_now);
-        } else if (token_nxt.id !== "(") {
+                warn("unexpected_a", token_now);
+            } else if (token_nxt.id !== "(") {
 
 // cause: "/*jslint eval*/\neval"
 
-            warn("expected_a_before_b", token_nxt, "(", artifact());
-        }
-        return token_now;
-    });
-    constant("false", "boolean", false);
-    constant("Function", "function", function () {
-        if (!option_object.eval) {
+                warn("expected_a_before_b", token_nxt, "(", artifact());
+            }
+            return token_now;
+        });
+        constant("false", "boolean", false);
+        constant("Function", "function", function () {
+            if (!option_object.eval) {
 
 // cause: "Function()"
 
-            warn("unexpected_a", token_now);
-        } else if (token_nxt.id !== "(") {
+                warn("unexpected_a", token_now);
+            } else if (token_nxt.id !== "(") {
 
 // cause: "/*jslint eval*/\nFunction"
 
-            warn("expected_a_before_b", token_nxt, "(", artifact());
-        }
-        return token_now;
-    });
-    constant("ignore", "undefined", function () {
+                warn("expected_a_before_b", token_nxt, "(", artifact());
+            }
+            return token_now;
+        });
+        constant("ignore", "undefined", function () {
 
 // cause: "ignore"
 
-        warn("unexpected_a", token_now);
-        return token_now;
-    });
-    constant("Infinity", "number", Infinity);
-    constant("isFinite", "function", function () {
+            warn("unexpected_a", token_now);
+            return token_now;
+        });
+        constant("Infinity", "number", Infinity);
+        constant("isFinite", "function", function () {
 
 // cause: "isFinite"
 
-        warn("expected_a_b", token_now, "Number.isFinite", "isFinite");
-        return token_now;
-    });
-    constant("isNaN", "function", function () {
+            warn("expected_a_b", token_now, "Number.isFinite", "isFinite");
+            return token_now;
+        });
+        constant("isNaN", "function", function () {
 
 // cause: "isNaN(0)"
 
-        warn("number_isNaN", token_now);
-        return token_now;
-    });
-    constant("NaN", "number", NaN);
-    constant("null", "null", null);
-    constant("this", "object", function () {
-        if (!option_object.this) {
+            warn("number_isNaN", token_now);
+            return token_now;
+        });
+        constant("NaN", "number", NaN);
+        constant("null", "null", null);
+        constant("this", "object", function () {
+            if (!option_object.this) {
 
 // cause: "this"
 
-            warn("unexpected_a", token_now);
-        }
-        return token_now;
-    });
-    constant("true", "boolean", true);
-    constant("undefined", "undefined");
+                warn("unexpected_a", token_now);
+            }
+            return token_now;
+        });
+        constant("true", "boolean", true);
+        constant("undefined", "undefined");
 
-    assignment("=");
-    assignment("+=");
-    assignment("-=");
-    assignment("*=");
-    assignment("/=");
-    assignment("%=");
-    assignment("&=");
-    assignment("|=");
-    assignment("^=");
-    assignment("<<=");
-    assignment(">>=");
-    assignment(">>>=");
+        assignment("=");
+        assignment("+=");
+        assignment("-=");
+        assignment("*=");
+        assignment("/=");
+        assignment("%=");
+        assignment("&=");
+        assignment("|=");
+        assignment("^=");
+        assignment("<<=");
+        assignment(">>=");
+        assignment(">>>=");
 
-    infix("??", 35);
-    infix("||", 40);
-    infix("&&", 50);
-    infix("|", 70);
-    infix("^", 80);
-    infix("&", 90);
-    infix("==", 100);
-    infix("===", 100);
-    infix("!=", 100);
-    infix("!==", 100);
-    infix("<", 110);
-    infix(">", 110);
-    infix("<=", 110);
-    infix(">=", 110);
-    infix("in", 110);
-    infix("instanceof", 110);
-    infix("<<", 120);
-    infix(">>", 120);
-    infix(">>>", 120);
-    infix("+", 130);
-    infix("-", 130);
-    infix("*", 140);
-    infix("/", 140);
-    infix("%", 140);
-    infixr("**", 150);
-    infix("(", 160, function (left) {
-        const the_paren = token_now;
-        let ellipsis;
-        let the_argument;
-        if (left.id !== "function") {
+        infix("??", 35);
+        infix("||", 40);
+        infix("&&", 50);
+        infix("|", 70);
+        infix("^", 80);
+        infix("&", 90);
+        infix("==", 100);
+        infix("===", 100);
+        infix("!=", 100);
+        infix("!==", 100);
+        infix("<", 110);
+        infix(">", 110);
+        infix("<=", 110);
+        infix(">=", 110);
+        infix("in", 110);
+        infix("instanceof", 110);
+        infix("<<", 120);
+        infix(">>", 120);
+        infix(">>>", 120);
+        infix("+", 130);
+        infix("-", 130);
+        infix("*", 140);
+        infix("/", 140);
+        infix("%", 140);
+        infixr("**", 150);
+        infix("(", 160, function (left) {
+            const the_paren = token_now;
+            let ellipsis;
+            let the_argument;
+            if (left.id !== "function") {
 
 // cause: "(0?0:0)()"
 // cause: "0()"
 
-            left_check(left, the_paren);
-        }
-        if (functionage.arity === "statement" && left.identifier) {
-            functionage.name.calls[left.id] = left;
-        }
-        the_paren.expression = [left];
-        if (token_nxt.id !== ")") {
+                left_check(left, the_paren);
+            }
+            if (functionage.arity === "statement" && left.identifier) {
+                functionage.name.calls[left.id] = left;
+            }
+            the_paren.expression = [left];
+            if (token_nxt.id !== ")") {
 
 // Parse/loop through each token in expression (...).
 
-            while (true) {
-                if (token_nxt.id === "...") {
-                    ellipsis = true;
-                    advance("...");
+                while (true) {
+                    if (token_nxt.id === "...") {
+                        ellipsis = true;
+                        advance("...");
+                    }
+                    the_argument = parse_expression(10);
+                    if (ellipsis) {
+                        the_argument.ellipsis = true;
+                    }
+                    the_paren.expression.push(the_argument);
+                    if (token_nxt.id !== ",") {
+                        break;
+                    }
+                    advance(",");
                 }
-                the_argument = expression(10);
-                if (ellipsis) {
-                    the_argument.ellipsis = true;
-                }
-                the_paren.expression.push(the_argument);
-                if (token_nxt.id !== ",") {
-                    break;
-                }
-                advance(",");
             }
-        }
-        advance(")", the_paren);
-        if (the_paren.expression.length === 2) {
+            advance(")", the_paren);
+            if (the_paren.expression.length === 2) {
 
 // cause: "aa(0)"
 
-            the_paren.free = true;
-            if (the_argument.wrapped === true) {
+                the_paren.free = true;
+                if (the_argument.wrapped === true) {
 
 // cause: "aa((0))"
 
-                warn("unexpected_a", the_paren);
-            }
-            if (the_argument.id === "(") {
-                the_argument.wrapped = true;
-            }
-        } else {
+                    warn("unexpected_a", the_paren);
+                }
+                if (the_argument.id === "(") {
+                    the_argument.wrapped = true;
+                }
+            } else {
 
 // cause: "aa()"
 // cause: "aa(0,0)"
 
-            the_paren.free = false;
-        }
-        return the_paren;
-    });
-    infix(".", 170, function (left) {
-        const the_token = token_now;
-        const name = token_nxt;
-        if (
-            (
-                left.id !== "(string)"
-                || (name.id !== "indexOf" && name.id !== "repeat")
-            )
-            && (
-                left.id !== "["
-                || (
-                    name.id !== "concat"
-                    && name.id !== "forEach"
-                    && name.id !== "join"
-                    && name.id !== "map"
+                the_paren.free = false;
+            }
+            return the_paren;
+        });
+        infix(".", 170, function (left) {
+            const the_token = token_now;
+            const name = token_nxt;
+            if (
+                (
+                    left.id !== "(string)"
+                    || (name.id !== "indexOf" && name.id !== "repeat")
                 )
-            )
-            && (left.id !== "+" || name.id !== "slice")
-            && (
-                left.id !== "(regexp)"
-                || (name.id !== "exec" && name.id !== "test")
-            )
-        ) {
+                && (
+                    left.id !== "["
+                    || (
+                        name.id !== "concat"
+                        && name.id !== "forEach"
+                        && name.id !== "join"
+                        && name.id !== "map"
+                    )
+                )
+                && (left.id !== "+" || name.id !== "slice")
+                && (
+                    left.id !== "(regexp)"
+                    || (name.id !== "exec" && name.id !== "test")
+                )
+            ) {
 
 // cause: "\"\".aa"
 
-            left_check(left, the_token);
-        }
-        if (!name.identifier) {
+                left_check(left, the_token);
+            }
+            if (!name.identifier) {
 
 // cause: "aa.0"
 
-            stop("expected_identifier_a");
-        }
-        advance();
-        survey(name);
+                stop("expected_identifier_a");
+            }
+            advance();
+            survey(name);
 
 // The property name is not an expression.
 
-        the_token.name = name;
-        the_token.expression = left;
-        return the_token;
-    });
-    infix("?.", 170, function (left) {
-        const the_token = token_now;
-        const name = token_nxt;
-        if (
-            (
-                left.id !== "(string)"
-                || (name.id !== "indexOf" && name.id !== "repeat")
-            )
-            && (
-                left.id !== "["
-                || (
-                    name.id !== "concat"
-                    && name.id !== "forEach"
-                    && name.id !== "join"
-                    && name.id !== "map"
+            the_token.name = name;
+            the_token.expression = left;
+            return the_token;
+        });
+        infix("?.", 170, function (left) {
+            const the_token = token_now;
+            const name = token_nxt;
+            if (
+                (
+                    left.id !== "(string)"
+                    || (name.id !== "indexOf" && name.id !== "repeat")
                 )
-            )
+                && (
+                    left.id !== "["
+                    || (
+                        name.id !== "concat"
+                        && name.id !== "forEach"
+                        && name.id !== "join"
+                        && name.id !== "map"
+                    )
+                )
 
 // cause: "(0+0)?.0"
 
-            && (left.id !== "+" || name.id !== "slice")
-            && (
-                left.id !== "(regexp)"
-                || (name.id !== "exec" && name.id !== "test")
-            )
-        ) {
+                && (left.id !== "+" || name.id !== "slice")
+                && (
+                    left.id !== "(regexp)"
+                    || (name.id !== "exec" && name.id !== "test")
+                )
+            ) {
 
 // cause: "\"aa\"?.0"
 // cause: "(/./)?.0"
 // cause: "aa=[]?.aa"
 
-            left_check(left, the_token);
-        }
-        if (!name.identifier) {
+                left_check(left, the_token);
+            }
+            if (!name.identifier) {
 
 // cause: "aa?.0"
 
-            stop("expected_identifier_a");
-        }
-        advance();
-        survey(name);
+                stop("expected_identifier_a");
+            }
+            advance();
+            survey(name);
 
 // The property name is not an expression.
 
-        the_token.name = name;
-        the_token.expression = left;
-        return the_token;
-    });
-    infix("[", 170, function (left) {
-        const the_token = token_now;
-        const the_subscript = expression(0);
-        if (the_subscript.id === "(string)" || the_subscript.id === "`") {
-            const name = survey(the_subscript);
-            if (rx_identifier.test(name)) {
+            the_token.name = name;
+            the_token.expression = left;
+            return the_token;
+        });
+        infix("[", 170, function (left) {
+            const the_token = token_now;
+            const the_subscript = parse_expression(0);
+            if (the_subscript.id === "(string)" || the_subscript.id === "`") {
+                const name = survey(the_subscript);
+                if (rx_identifier.test(name)) {
 
 // cause: "aa[`aa`]"
 
-                warn("subscript_a", the_subscript, name);
+                    warn("subscript_a", the_subscript, name);
+                }
             }
-        }
 
 // cause: "0[0]"
 
-        left_check(left, the_token);
-        the_token.expression = [left, the_subscript];
-        advance("]");
-        return the_token;
-    });
-    infix("=>", 170, function (left) {
+            left_check(left, the_token);
+            the_token.expression = [left, the_subscript];
+            advance("]");
+            return the_token;
+        });
+        infix("=>", 170, function (left) {
 
 // cause: "aa=>0"
 
-        return stop("wrap_parameter", left);
-    });
+            return stop("wrap_parameter", left);
+        });
 
-    function do_tick() {
-        const the_tick = token_now;
-        the_tick.value = [];
-        the_tick.expression = [];
-        if (token_nxt.id !== "`") {
+        function do_tick() {
+            const the_tick = token_now;
+            the_tick.value = [];
+            the_tick.expression = [];
+            if (token_nxt.id !== "`") {
 
 // Parse/loop through each token in `${...}`.
 
-            while (true) {
-                advance("(string)");
-                the_tick.value.push(token_now);
-                if (token_nxt.id !== "${") {
-                    break;
-                }
-                advance("${");
+                while (true) {
+                    advance("(string)");
+                    the_tick.value.push(token_now);
+                    if (token_nxt.id !== "${") {
+                        break;
+                    }
+                    advance("${");
 
 // cause: "let aa=`${}`;"
 
-                the_tick.expression.push(expression(0));
-                advance("}");
+                    the_tick.expression.push(parse_expression(0));
+                    advance("}");
+                }
             }
+            advance("`");
+            return the_tick;
         }
-        advance("`");
-        return the_tick;
-    }
 
-    infix("`", 160, function (left) {
-        const the_tick = do_tick();
+        infix("`", 160, function (left) {
+            const the_tick = do_tick();
 
 // cause: "0``"
 
-        left_check(left, the_tick);
-        the_tick.expression = [left].concat(the_tick.expression);
-        return the_tick;
-    });
+            left_check(left, the_tick);
+            the_tick.expression = [left].concat(the_tick.expression);
+            return the_tick;
+        });
 
-    post("++");
-    post("--");
-    pre("++");
-    pre("--");
+        post("++");
+        post("--");
+        pre("++");
+        pre("--");
 
-    prefix("+");
-    prefix("-");
-    prefix("~");
-    prefix("!");
-    prefix("!!");
-    prefix("[", function () {
-        const the_token = token_now;
-        let element;
-        let ellipsis;
-        the_token.expression = [];
-        if (token_nxt.id !== "]") {
+        prefix("+");
+        prefix("-");
+        prefix("~");
+        prefix("!");
+        prefix("!!");
+        prefix("[", function () {
+            const the_token = token_now;
+            let element;
+            let ellipsis;
+            the_token.expression = [];
+            if (token_nxt.id !== "]") {
 
 // Parse/loop through each element in [...].
 
-            while (true) {
-                ellipsis = false;
-                if (token_nxt.id === "...") {
-                    ellipsis = true;
-                    advance("...");
+                while (true) {
+                    ellipsis = false;
+                    if (token_nxt.id === "...") {
+                        ellipsis = true;
+                        advance("...");
+                    }
+                    element = parse_expression(10);
+                    if (ellipsis) {
+                        element.ellipsis = true;
+                    }
+                    the_token.expression.push(element);
+                    if (token_nxt.id !== ",") {
+                        break;
+                    }
+                    advance(",");
                 }
-                element = expression(10);
-                if (ellipsis) {
-                    element.ellipsis = true;
-                }
-                the_token.expression.push(element);
-                if (token_nxt.id !== ",") {
-                    break;
-                }
-                advance(",");
             }
-        }
-        advance("]");
-        return the_token;
-    });
-    prefix("/=", function () {
+            advance("]");
+            return the_token;
+        });
+        prefix("/=", function () {
 
 // cause: "/="
 
-        stop("expected_a_b", token_now, "/\\=", "/=");
-    });
-    prefix("=>", function () {
+            stop("expected_a_b", token_now, "/\\=", "/=");
+        });
+        prefix("=>", function () {
 
 // cause: "=>0"
 
-        return stop("expected_a_before_b", token_now, "()", "=>");
-    });
-    prefix("new", function () {
-        const the_new = token_now;
-        const right = expression(160);
-        if (token_nxt.id !== "(") {
+            return stop("expected_a_before_b", token_now, "()", "=>");
+        });
+        prefix("new", function () {
+            const the_new = token_now;
+            const right = parse_expression(160);
+            if (token_nxt.id !== "(") {
 
 // cause: "new aa"
 
-            warn("expected_a_before_b", token_nxt, "()", artifact(token_nxt));
-        }
-        the_new.expression = right;
-        return the_new;
-    });
-    prefix("typeof");
-    prefix("void", function () {
-        const the_void = token_now;
+                warn(
+                    "expected_a_before_b",
+                    token_nxt,
+                    "()",
+                    artifact(token_nxt)
+                );
+            }
+            the_new.expression = right;
+            return the_new;
+        });
+        prefix("typeof");
+        prefix("void", function () {
+            const the_void = token_now;
 
 // cause: "void"
 // cause: "void 0"
 
-        warn("unexpected_a", the_void);
-        the_void.expression = expression(0);
-        return the_void;
-    });
+            warn("unexpected_a", the_void);
+            the_void.expression = parse_expression(0);
+            return the_void;
+        });
 
-    function parameter_list() {
-        const list = [];
-        let optional;
-        const signature = ["("];
-        if (token_nxt.id !== ")" && token_nxt.id !== "(end)") {
-            (function parameter() {
-                let ellipsis = false;
-                let param;
-                if (token_nxt.id === "{") {
-                    let artifact_now;
-                    let artifact_nxt = "";
-                    if (optional !== undefined) {
-
-// cause: "function aa(aa=0,{}){}"
-
-                        warn(
-                            "required_a_optional_b",
-                            token_nxt,
-                            token_nxt.id,
-                            optional.id
-                        );
-                    }
-                    param = token_nxt;
-                    param.names = [];
-                    advance("{");
-                    signature.push("{");
-                    (function subparameter() {
-                        let subparam = token_nxt;
-                        if (!subparam.identifier) {
-
-// cause: "function aa(aa=0,{}){}"
-// cause: "function aa({0}){}"
-
-                            return stop("expected_identifier_a");
-                        }
-                        survey(subparam);
-                        artifact_now = artifact_nxt;
-                        artifact_nxt = artifact(subparam);
-                        if (
-                            !option_object.unordered
-                            && artifact_now > artifact_nxt
-                        ) {
-
-// cause: "function aa({bb,aa}){}"
-
-                            warn(
-                                "expected_a_before_b",
-                                subparam,
-                                artifact_nxt,
-                                artifact_now
-                            );
-                        }
-                        advance();
-                        signature.push(subparam.id);
-                        if (token_nxt.id === ":") {
-                            advance(":");
-                            advance();
-                            token_now.label = subparam;
-                            subparam = token_now;
-                            if (!subparam.identifier) {
-
-// cause: "function aa({aa:0}){}"
-
-                                return stop("expected_identifier_a");
-                            }
-                        }
-
-// cause: "function aa({aa=aa},aa){}"
-
-                        if (token_nxt.id === "=") {
-                            advance("=");
-                            subparam.expression = expression();
-                            param.open = true;
-                        }
-                        param.names.push(subparam);
-                        if (token_nxt.id === ",") {
-                            advance(",");
-                            signature.push(", ");
-                            return subparameter();
-                        }
-                    }());
-                    list.push(param);
-                    advance("}");
-                    signature.push("}");
-                    if (token_nxt.id === ",") {
-                        advance(",");
-                        signature.push(", ");
-                        return parameter();
-                    }
-                } else if (token_nxt.id === "[") {
-                    if (optional !== undefined) {
-
-// cause: "function aa(aa=0,[]){}"
-
-                        warn(
-                            "required_a_optional_b",
-                            token_nxt,
-                            token_nxt.id,
-                            optional.id
-                        );
-                    }
-                    param = token_nxt;
-                    param.names = [];
-                    advance("[");
-                    signature.push("[]");
-                    (function subparameter() {
-                        const subparam = token_nxt;
-                        if (!subparam.identifier) {
-
-// cause: "function aa(aa=0,[]){}"
-
-                            return stop("expected_identifier_a");
-                        }
-                        advance();
-                        param.names.push(subparam);
-
-// cause: "function aa([aa=aa],aa){}"
-
-                        if (token_nxt.id === "=") {
-                            advance("=");
-                            subparam.expression = expression();
-                            param.open = true;
-                        }
-                        if (token_nxt.id === ",") {
-                            advance(",");
-                            return subparameter();
-                        }
-                    }());
-                    list.push(param);
-                    advance("]");
-                    if (token_nxt.id === ",") {
-                        advance(",");
-                        signature.push(", ");
-                        return parameter();
-                    }
-                } else {
-                    if (token_nxt.id === "...") {
-                        ellipsis = true;
-                        signature.push("...");
-                        advance("...");
+        function parameter_list() {
+            const list = [];
+            const signature = ["("];
+            let optional;
+            if (token_nxt.id !== ")" && token_nxt.id !== "(end)") {
+                (function parameter() {
+                    let ellipsis = false;
+                    let param;
+                    if (token_nxt.id === "{") {
+                        let artifact_now;
+                        let artifact_nxt = "";
                         if (optional !== undefined) {
 
-// cause: "function aa(aa=0,...){}"
+// cause: "function aa(aa=0,{}){}"
 
                             warn(
                                 "required_a_optional_b",
@@ -2321,87 +3235,216 @@ function jslint(
                                 optional.id
                             );
                         }
-                    }
-                    if (!token_nxt.identifier) {
+                        param = token_nxt;
+                        param.names = [];
+                        advance("{");
+                        signature.push("{");
+                        (function subparameter() {
+                            let subparam = token_nxt;
+                            if (!subparam.identifier) {
 
-// cause: "function aa(0){}"
+// cause: "function aa(aa=0,{}){}"
+// cause: "function aa({0}){}"
 
-                        return stop("expected_identifier_a");
-                    }
-                    param = token_nxt;
-                    list.push(param);
-                    advance();
-                    signature.push(param.id);
-                    if (ellipsis) {
-                        param.ellipsis = true;
-                    } else {
-                        if (token_nxt.id === "=") {
-                            optional = param;
-                            advance("=");
-                            param.expression = expression(0);
-                        } else {
-                            if (optional !== undefined) {
+                                return stop("expected_identifier_a");
+                            }
+                            survey(subparam);
+                            artifact_now = artifact_nxt;
+                            artifact_nxt = artifact(subparam);
+                            if (
+                                !option_object.unordered
+                                && artifact_now > artifact_nxt
+                            ) {
 
-// cause: "function aa(aa=0,bb){}"
+// cause: "function aa({bb,aa}){}"
 
                                 warn(
-                                    "required_a_optional_b",
-                                    param,
-                                    param.id,
-                                    optional.id
+                                    "expected_a_before_b",
+                                    subparam,
+                                    artifact_nxt,
+                                    artifact_now
                                 );
                             }
-                        }
+                            advance();
+                            signature.push(subparam.id);
+                            if (token_nxt.id === ":") {
+                                advance(":");
+                                advance();
+                                token_now.label = subparam;
+                                subparam = token_now;
+                                if (!subparam.identifier) {
+
+// cause: "function aa({aa:0}){}"
+
+                                    return stop("expected_identifier_a");
+                                }
+                            }
+
+// cause: "function aa({aa=aa},aa){}"
+
+                            if (token_nxt.id === "=") {
+                                advance("=");
+                                subparam.expression = parse_expression();
+                                param.open = true;
+                            }
+                            param.names.push(subparam);
+                            if (token_nxt.id === ",") {
+                                advance(",");
+                                signature.push(", ");
+                                return subparameter();
+                            }
+                        }());
+                        list.push(param);
+                        advance("}");
+                        signature.push("}");
                         if (token_nxt.id === ",") {
                             advance(",");
                             signature.push(", ");
                             return parameter();
                         }
-                    }
-                }
-            }());
-        }
-        advance(")");
-        signature.push(")");
-        return [list, signature.join("")];
-    }
+                    } else if (token_nxt.id === "[") {
+                        if (optional !== undefined) {
 
-    function do_function(the_function) {
-        let name = the_function && the_function.name;
-        if (the_function === undefined) {
-            the_function = token_now;
+// cause: "function aa(aa=0,[]){}"
+
+                            warn(
+                                "required_a_optional_b",
+                                token_nxt,
+                                token_nxt.id,
+                                optional.id
+                            );
+                        }
+                        param = token_nxt;
+                        param.names = [];
+                        advance("[");
+                        signature.push("[]");
+                        (function subparameter() {
+                            const subparam = token_nxt;
+                            if (!subparam.identifier) {
+
+// cause: "function aa(aa=0,[]){}"
+
+                                return stop("expected_identifier_a");
+                            }
+                            advance();
+                            param.names.push(subparam);
+
+// cause: "function aa([aa=aa],aa){}"
+
+                            if (token_nxt.id === "=") {
+                                advance("=");
+                                subparam.expression = parse_expression();
+                                param.open = true;
+                            }
+                            if (token_nxt.id === ",") {
+                                advance(",");
+                                return subparameter();
+                            }
+                        }());
+                        list.push(param);
+                        advance("]");
+                        if (token_nxt.id === ",") {
+                            advance(",");
+                            signature.push(", ");
+                            return parameter();
+                        }
+                    } else {
+                        if (token_nxt.id === "...") {
+                            ellipsis = true;
+                            signature.push("...");
+                            advance("...");
+                            if (optional !== undefined) {
+
+// cause: "function aa(aa=0,...){}"
+
+                                warn(
+                                    "required_a_optional_b",
+                                    token_nxt,
+                                    token_nxt.id,
+                                    optional.id
+                                );
+                            }
+                        }
+                        if (!token_nxt.identifier) {
+
+// cause: "function aa(0){}"
+
+                            return stop("expected_identifier_a");
+                        }
+                        param = token_nxt;
+                        list.push(param);
+                        advance();
+                        signature.push(param.id);
+                        if (ellipsis) {
+                            param.ellipsis = true;
+                        } else {
+                            if (token_nxt.id === "=") {
+                                optional = param;
+                                advance("=");
+                                param.expression = parse_expression(0);
+                            } else {
+                                if (optional !== undefined) {
+
+// cause: "function aa(aa=0,bb){}"
+
+                                    warn(
+                                        "required_a_optional_b",
+                                        param,
+                                        param.id,
+                                        optional.id
+                                    );
+                                }
+                            }
+                            if (token_nxt.id === ",") {
+                                advance(",");
+                                signature.push(", ");
+                                return parameter();
+                            }
+                        }
+                    }
+                }());
+            }
+            advance(")");
+            signature.push(")");
+            return [list, signature.join("")];
+        }
+
+        function do_function(the_function) {
+            let name = the_function && the_function.name;
+            if (the_function === undefined) {
+                the_function = token_now;
 
 // A function statement must have a name that will be in the parent's scope.
 
-            if (the_function.arity === "statement") {
-                if (!token_nxt.identifier) {
+                if (the_function.arity === "statement") {
+                    if (!token_nxt.identifier) {
 
 // cause: "function(){}"
 // cause: "function*aa(){}"
 
-                    return stop("expected_identifier_a", token_nxt);
-                }
-                name = token_nxt;
-                enroll(name, "variable", true);
-                the_function.name = Object.assign(name, {
-                    calls: empty(),
-                    init: true
-                });
-                advance();
-            } else if (name === undefined) {
+                        return stop("expected_identifier_a", token_nxt);
+                    }
+                    name = token_nxt;
+                    enroll(name, "variable", true);
+                    the_function.name = Object.assign(name, {
+                        calls: empty(),
+                        init: true
+                    });
+                    advance();
+                } else if (name === undefined) {
 
 // A function expression may have an optional name.
 
-                the_function.name = anon;
-                if (token_nxt.identifier) {
-                    name = token_nxt;
-                    the_function.name = name;
-                    advance();
+                    the_function.name = anon;
+                    if (token_nxt.identifier) {
+                        name = token_nxt;
+                        the_function.name = name;
+                        advance();
+                    }
                 }
             }
-        }
-        the_function.level = functionage.level + 1;
-        assert_or_throw(!mode_mega, `Expected !mode_mega.`);
+            the_function.level = functionage.level + 1;
+            assert_or_throw(!mode_mega, `Expected !mode_mega.`);
 //  Probably deadcode.
 //  if (mode_mega) {
 //      warn("unexpected_a", the_function);
@@ -2410,480 +3453,256 @@ function jslint(
 // Don't create functions in loops. It is inefficient, and it can lead to
 // scoping errors.
 
-        if (functionage.loop > 0) {
+            if (functionage.loop > 0) {
 
 // cause: "while(0){aa.map(function(){});}"
 
-            warn("function_in_loop", the_function);
-        }
+                warn("function_in_loop", the_function);
+            }
 
 // Give the function properties for storing its names and for observing the
 // depth of loops and switches.
 
-        Object.assign(the_function, {
-            async: the_function.async || 0,
-            context: empty(),
-            finally: 0,
-            loop: 0,
-            switch: 0,
-            try: 0
-        });
+            Object.assign(the_function, {
+                async: the_function.async || 0,
+                context: empty(),
+                finally: 0,
+                loop: 0,
+                switch: 0,
+                try: 0
+            });
 
 // Push the current function context and establish a new one.
 
-        stack.push(functionage);
-        functions.push(the_function);
-        functionage = the_function;
-        if (the_function.arity !== "statement" && typeof name === "object") {
+            function_stack.push(functionage);
+            function_array.push(the_function);
+            functionage = the_function;
+            if (
+                the_function.arity !== "statement"
+                && typeof name === "object"
+            ) {
 
 // cause: "let aa=function bb(){return;};"
 
-            enroll(name, "function", true);
-            name.dead = false;
-            name.init = true;
-            name.used = 1;
-        }
+                enroll(name, "function", true);
+                name.dead = false;
+                name.init = true;
+                name.used = 1;
+            }
 
 // Parse the parameter list.
 
-        advance("(");
+            advance("(");
 
 // cause: "function(){}"
 
-        token_now.free = false;
-        token_now.arity = "function";
-        [functionage.parameters, functionage.signature] = parameter_list();
-        functionage.parameters.forEach(function enroll_parameter(name) {
-            if (name.identifier) {
-                enroll(name, "parameter", false);
-            } else {
-                name.names.forEach(enroll_parameter);
-            }
-        });
+            token_now.free = false;
+            token_now.arity = "function";
+            [functionage.parameters, functionage.signature] = parameter_list();
+            functionage.parameters.forEach(function enroll_parameter(name) {
+                if (name.identifier) {
+                    enroll(name, "parameter", false);
+                } else {
+                    name.names.forEach(enroll_parameter);
+                }
+            });
 
 // The function's body is a block.
 
-        the_function.block = block("body");
-        if (
-            the_function.arity === "statement"
-            && token_nxt.line === token_now.line
-        ) {
+            the_function.block = block("body");
+            if (
+                the_function.arity === "statement"
+                && token_nxt.line === token_now.line
+            ) {
 
 // cause: "function aa(){}0"
 
-            return stop("unexpected_a", token_nxt);
-        }
-        if (
-            token_nxt.id === "."
-            || token_nxt.id === "?."
-            || token_nxt.id === "["
-        ) {
+                return stop("unexpected_a", token_nxt);
+            }
+            if (
+                token_nxt.id === "."
+                || token_nxt.id === "?."
+                || token_nxt.id === "["
+            ) {
 
 // cause: "function aa(){}\n[]"
 
-            warn("unexpected_a");
-        }
+                warn("unexpected_a");
+            }
 
 // Restore the previous context.
 
-        functionage = stack.pop();
-        return the_function;
-    }
+            functionage = function_stack.pop();
+            return the_function;
+        }
 
-    function do_async() {
-        let the_async;
-        let the_function;
-        the_async = token_now;
-        advance("function");
-        the_function = Object.assign(token_now, {
-            arity: the_async.arity,
-            async: 1
-        });
-        do_function();
-        if (the_function.async === 1) {
+        function do_async() {
+            let the_async;
+            let the_function;
+            the_async = token_now;
+            advance("function");
+            the_function = Object.assign(token_now, {
+                arity: the_async.arity,
+                async: 1
+            });
+            do_function();
+            if (the_function.async === 1) {
 
 // cause: "async function aa(){}"
 
-            warn("missing_await_statement", the_function);
+                warn("missing_await_statement", the_function);
+            }
+            return the_function;
         }
-        return the_function;
-    }
 
-    function do_await() {
-        const the_await = token_now;
-        if (functionage.async === 0) {
+        function do_await() {
+            const the_await = token_now;
+            if (functionage.async === 0) {
 
 // cause: "await"
 // cause: "function aa(){aa=await 0;}"
 // cause: "function aa(){await 0;}"
 
-            warn("unexpected_a", the_await);
-        } else {
-            functionage.async += 1;
+                warn("unexpected_a", the_await);
+            } else {
+                functionage.async += 1;
+            }
+            if (the_await.arity === "statement") {
+                the_await.block = parse_expression();
+                semicolon();
+            } else {
+                the_await.expression = parse_expression();
+            }
+            return the_await;
         }
-        if (the_await.arity === "statement") {
-            the_await.block = expression();
-            semicolon();
-        } else {
-            the_await.expression = expression();
-        }
-        return the_await;
-    }
 
-    prefix("async", do_async);
-    prefix("await", do_await);
-    prefix("function", do_function);
+        prefix("async", do_async);
+        prefix("await", do_await);
+        prefix("function", do_function);
 
-    function fart(pl) {
-        advance("=>");
-        const the_fart = token_now;
-        the_fart.arity = "binary";
-        the_fart.name = "=>";
-        the_fart.level = functionage.level + 1;
-        functions.push(the_fart);
-        if (functionage.loop > 0) {
+        function fart(pl) {
+            let the_fart;
+            advance("=>");
+            the_fart = token_now;
+            the_fart.arity = "binary";
+            the_fart.name = "=>";
+            the_fart.level = functionage.level + 1;
+            function_array.push(the_fart);
+            if (functionage.loop > 0) {
 
 // cause: "while(0){aa.map(()=>0);}"
 
-            warn("function_in_loop", the_fart);
-        }
+                warn("function_in_loop", the_fart);
+            }
 
 // Give the function properties storing its names and for observing the depth
 // of loops and switches.
 
-        the_fart.context = empty();
-        the_fart.finally = 0;
-        the_fart.loop = 0;
-        the_fart.switch = 0;
-        the_fart.try = 0;
+            the_fart.context = empty();
+            the_fart.finally = 0;
+            the_fart.loop = 0;
+            the_fart.switch = 0;
+            the_fart.try = 0;
 
 // Push the current function context and establish a new one.
 
-        stack.push(functionage);
-        functionage = the_fart;
-        the_fart.parameters = pl[0];
-        the_fart.signature = pl[1];
-        the_fart.parameters.forEach(function (name) {
+            function_stack.push(functionage);
+            functionage = the_fart;
+            the_fart.parameters = pl[0];
+            the_fart.signature = pl[1];
+            the_fart.parameters.forEach(function (name) {
 
 // cause: "(aa)=>{}"
 
-            enroll(name, "parameter", true);
-        });
-        if (token_nxt.id === "{") {
+                enroll(name, "parameter", true);
+            });
+            if (token_nxt.id === "{") {
 
 // cause: "()=>{}"
 
-            warn("expected_a_b", the_fart, "function", "=>");
-            the_fart.block = block("body");
-        } else {
-            the_fart.expression = expression(0);
+                warn("expected_a_b", the_fart, "function", "=>");
+                the_fart.block = block("body");
+            } else {
+                the_fart.expression = parse_expression(0);
+            }
+            functionage = function_stack.pop();
+            return the_fart;
         }
-        functionage = stack.pop();
-        return the_fart;
-    }
 
-    prefix("(", function () {
-        const the_paren = token_now;
-        let the_value;
-        const cadet = lookahead().id;
+        prefix("(", function () {
+            const cadet = lookahead().id;
+            const the_paren = token_now;
+            let the_value;
 
 // We can distinguish between a parameter list for => and a wrapped expression
 // with one token of lookahead.
 
-        if (
-            token_nxt.id === ")"
-            || token_nxt.id === "..."
-            || (token_nxt.identifier && (cadet === "," || cadet === "="))
-        ) {
+            if (
+                token_nxt.id === ")"
+                || token_nxt.id === "..."
+                || (token_nxt.identifier && (cadet === "," || cadet === "="))
+            ) {
 
 // cause: "()=>0"
 
-            the_paren.free = false;
-            return fart(parameter_list());
-        }
+                the_paren.free = false;
+                return fart(parameter_list());
+            }
 
 // cause: "(0)"
 
-        the_paren.free = true;
-        the_value = expression(0);
-        if (the_value.wrapped === true) {
+            the_paren.free = true;
+            the_value = parse_expression(0);
+            if (the_value.wrapped === true) {
 
 // cause: "((0))"
 
-            warn("unexpected_a", the_paren);
-        }
-        the_value.wrapped = true;
-        advance(")", the_paren);
-        if (token_nxt.id === "=>") {
-            if (the_value.arity !== "variable") {
-                if (the_value.id === "{" || the_value.id === "[") {
+                warn("unexpected_a", the_paren);
+            }
+            the_value.wrapped = true;
+            advance(")", the_paren);
+            if (token_nxt.id === "=>") {
+                if (the_value.arity !== "variable") {
+                    if (the_value.id === "{" || the_value.id === "[") {
 
 // cause: "([])=>0"
 // cause: "({})=>0"
 
-                    warn("expected_a_before_b", the_paren, "function", "(");
+                        warn("expected_a_before_b", the_paren, "function", "(");
 
 // cause: "([])=>0"
 // cause: "({})=>0"
 
-                    return stop("expected_a_b", token_nxt, "{", "=>");
-                }
+                        return stop("expected_a_b", token_nxt, "{", "=>");
+                    }
 
 // cause: "(0)=>0"
 
-                return stop("expected_identifier_a", the_value);
+                    return stop("expected_identifier_a", the_value);
+                }
+                the_paren.expression = [the_value];
+                return fart([the_paren.expression, "(" + the_value.id + ")"]);
             }
-            the_paren.expression = [the_value];
-            return fart([the_paren.expression, "(" + the_value.id + ")"]);
-        }
-        return the_value;
-    });
-    prefix("`", do_tick);
-    prefix("{", function () {
-        const the_brace = token_now;
-        const seen = empty();
-        the_brace.expression = [];
-        if (token_nxt.id !== "}") {
-            let artifact_now;
-            let artifact_nxt = "";
+            return the_value;
+        });
+        prefix("`", do_tick);
+        prefix("{", function () {
+            const seen = empty();
+            const the_brace = token_now;
+            the_brace.expression = [];
+            if (token_nxt.id !== "}") {
+                let artifact_now;
+                let artifact_nxt = "";
 
 // Parse/loop through each property in {...}.
 
-            while (true) {
-                let extra;
-                let full;
-                let id;
-                let name = token_nxt;
-                let value;
-                advance();
-                artifact_now = artifact_nxt;
-                artifact_nxt = artifact(name);
-                if (!option_object.unordered && artifact_now > artifact_nxt) {
-
-// cause: "aa={bb,aa}"
-
-                    warn(
-                        "expected_a_before_b",
-                        name,
-                        artifact_nxt,
-                        artifact_now
-                    );
-                }
-                if (
-                    (name.id === "get" || name.id === "set")
-                    && token_nxt.identifier
-                ) {
-                    if (!option_object.getset) {
-
-// cause: "aa={get aa(){}}"
-
-                        warn("unexpected_a", name);
-                    }
-                    extra = name.id;
-                    full = extra + " " + token_nxt.id;
-                    name = token_nxt;
+                while (true) {
+                    let extra;
+                    let full;
+                    let id;
+                    let name = token_nxt;
+                    let value;
                     advance();
-                    id = survey(name);
-                    if (seen[full] === true || seen[id] === true) {
-
-// cause: "aa={get aa(){},get aa(){}}"
-
-                        warn("duplicate_a", name);
-                    }
-                    seen[id] = false;
-                    seen[full] = true;
-                } else {
-                    id = survey(name);
-                    if (typeof seen[id] === "boolean") {
-
-// cause: "aa={aa,aa}"
-
-                        warn("duplicate_a", name);
-                    }
-                    seen[id] = true;
-                }
-                if (name.identifier) {
-                    if (token_nxt.id === "}" || token_nxt.id === ",") {
-                        if (typeof extra === "string") {
-
-// cause: "aa={get aa}"
-
-                            advance("(");
-                        }
-                        value = expression(Infinity, true);
-                    } else if (token_nxt.id === "(") {
-                        value = do_function({
-                            arity: "unary",
-                            from: name.from,
-                            id: "function",
-                            line: name.line,
-                            name: (
-                                typeof extra === "string"
-
-// cause: "aa={get aa(){}}"
-
-                                ? extra
-
-// cause: "aa={aa()}"
-
-                                : id
-                            ),
-                            thru: name.from
-                        });
-                    } else {
-                        if (typeof extra === "string") {
-
-// cause: "aa={get aa.aa}"
-
-                            advance("(");
-                        }
-                        let the_colon = token_nxt;
-                        advance(":");
-                        value = expression(0);
-                        if (value.id === name.id && value.id !== "function") {
-
-// cause: "aa={aa:aa}"
-
-                            warn("unexpected_a", the_colon, ": " + name.id);
-                        }
-                    }
-                    value.label = name;
-                    if (typeof extra === "string") {
-                        value.extra = extra;
-                    }
-                    the_brace.expression.push(value);
-                } else {
-
-// cause: aa={"aa":0}
-
-                    advance(":");
-                    value = expression(0);
-                    value.label = name;
-                    the_brace.expression.push(value);
-                }
-                if (token_nxt.id !== ",") {
-                    break;
-                }
-
-// cause: aa={"aa":0,"bb":0}
-
-                advance(",");
-            }
-        }
-        advance("}");
-        return the_brace;
-    });
-
-    stmt(";", function () {
-
-// cause: ";"
-
-        warn("unexpected_a", token_now);
-        return token_now;
-    });
-    stmt("{", function () {
-
-// cause: ";{}"
-// cause: "class aa{}"
-
-        warn("naked_block", token_now);
-        return block("naked");
-    });
-    stmt("async", do_async);
-    stmt("await", do_await);
-    stmt("break", function () {
-        const the_break = token_now;
-        let the_label;
-        if (
-            (functionage.loop < 1 && functionage.switch < 1)
-            || functionage.finally > 0
-        ) {
-
-// cause: "break"
-
-            warn("unexpected_a", the_break);
-        }
-        the_break.disrupt = true;
-        if (token_nxt.identifier && token_now.line === token_nxt.line) {
-            the_label = functionage.context[token_nxt.id];
-            if (
-                the_label === undefined
-                || the_label.role !== "label"
-                || the_label.dead
-            ) {
-                if (the_label !== undefined && the_label.dead) {
-
-// cause: "aa:{function aa(aa){break aa;}}"
-
-                    warn("out_of_scope_a");
-                } else {
-
-// cause: "aa:{break aa;}"
-
-                    warn("not_label_a");
-                }
-            } else {
-                the_label.used += 1;
-            }
-            the_break.label = token_nxt;
-            advance();
-        }
-        advance(";");
-        return the_break;
-    });
-
-    function do_var() {
-        const the_statement = token_now;
-        const mode_const = the_statement.id === "const";
-        the_statement.names = [];
-
-// A program may use var or let, but not both.
-
-        if (!mode_const) {
-            if (mode_var === undefined) {
-                mode_var = the_statement.id;
-            } else if (the_statement.id !== mode_var) {
-
-// cause: "let aa;var aa"
-
-                warn(
-                    "expected_a_b",
-                    the_statement,
-                    mode_var,
-                    the_statement.id
-                );
-            }
-        }
-
-// We don't expect to see variables created in switch statements.
-
-        if (functionage.switch > 0) {
-
-// cause: "switch(0){case 0:var aa}"
-
-            warn("var_switch", the_statement);
-        }
-        if (functionage.loop > 0 && the_statement.id === "var") {
-
-// cause: "while(0){var aa;}"
-
-            warn("var_loop", the_statement);
-        }
-        (function next() {
-            if (token_nxt.id === "{" && the_statement.id !== "var") {
-                let artifact_now;
-                let artifact_nxt = "";
-                const the_brace = token_nxt;
-                advance("{");
-                (function pair() {
-                    if (!token_nxt.identifier) {
-
-// cause: "let {0}"
-
-                        return stop("expected_identifier_a", token_nxt);
-                    }
-                    const name = token_nxt;
-                    survey(name);
                     artifact_now = artifact_nxt;
                     artifact_nxt = artifact(name);
                     if (
@@ -2891,7 +3710,7 @@ function jslint(
                         && artifact_now > artifact_nxt
                     ) {
 
-// cause: "let{bb,aa}"
+// cause: "aa={bb,aa}"
 
                         warn(
                             "expected_a_before_b",
@@ -2900,841 +3719,1276 @@ function jslint(
                             artifact_now
                         );
                     }
-                    advance();
-                    if (token_nxt.id === ":") {
+                    if (
+                        (name.id === "get" || name.id === "set")
+                        && token_nxt.identifier
+                    ) {
+                        if (!option_object.getset) {
+
+// cause: "aa={get aa(){}}"
+
+                            warn("unexpected_a", name);
+                        }
+                        extra = name.id;
+                        full = extra + " " + token_nxt.id;
+                        name = token_nxt;
+                        advance();
+                        id = survey(name);
+                        if (seen[full] === true || seen[id] === true) {
+
+// cause: "aa={get aa(){},get aa(){}}"
+
+                            warn("duplicate_a", name);
+                        }
+                        seen[id] = false;
+                        seen[full] = true;
+                    } else {
+                        id = survey(name);
+                        if (typeof seen[id] === "boolean") {
+
+// cause: "aa={aa,aa}"
+
+                            warn("duplicate_a", name);
+                        }
+                        seen[id] = true;
+                    }
+                    if (name.identifier) {
+                        if (token_nxt.id === "}" || token_nxt.id === ",") {
+                            if (typeof extra === "string") {
+
+// cause: "aa={get aa}"
+
+                                advance("(");
+                            }
+                            value = parse_expression(Infinity, true);
+                        } else if (token_nxt.id === "(") {
+                            value = do_function({
+                                arity: "unary",
+                                from: name.from,
+                                id: "function",
+                                line: name.line,
+                                name: (
+                                    typeof extra === "string"
+
+// cause: "aa={get aa(){}}"
+
+                                    ? extra
+
+// cause: "aa={aa()}"
+
+                                    : id
+                                ),
+                                thru: name.from
+                            });
+                        } else {
+                            if (typeof extra === "string") {
+
+// cause: "aa={get aa.aa}"
+
+                                advance("(");
+                            }
+                            let the_colon = token_nxt;
+                            advance(":");
+                            value = parse_expression(0);
+                            if (
+                                value.id === name.id
+                                && value.id !== "function"
+                            ) {
+
+// cause: "aa={aa:aa}"
+
+                                warn("unexpected_a", the_colon, ": " + name.id);
+                            }
+                        }
+                        value.label = name;
+                        if (typeof extra === "string") {
+                            value.extra = extra;
+                        }
+                        the_brace.expression.push(value);
+                    } else {
+
+// cause: aa={"aa":0}
+
                         advance(":");
+                        value = parse_expression(0);
+                        value.label = name;
+                        the_brace.expression.push(value);
+                    }
+                    if (token_nxt.id !== ",") {
+                        break;
+                    }
+
+// cause: aa={"aa":0,"bb":0}
+
+                    advance(",");
+                }
+            }
+            advance("}");
+            return the_brace;
+        });
+
+        stmt(";", function () {
+
+// cause: ";"
+
+            warn("unexpected_a", token_now);
+            return token_now;
+        });
+        stmt("{", function () {
+
+// cause: ";{}"
+// cause: "class aa{}"
+
+            warn("naked_block", token_now);
+            return block("naked");
+        });
+        stmt("async", do_async);
+        stmt("await", do_await);
+        stmt("break", function () {
+            const the_break = token_now;
+            let the_label;
+            if (
+                (functionage.loop < 1 && functionage.switch < 1)
+                || functionage.finally > 0
+            ) {
+
+// cause: "break"
+
+                warn("unexpected_a", the_break);
+            }
+            the_break.disrupt = true;
+            if (token_nxt.identifier && token_now.line === token_nxt.line) {
+                the_label = functionage.context[token_nxt.id];
+                if (
+                    the_label === undefined
+                    || the_label.role !== "label"
+                    || the_label.dead
+                ) {
+                    if (the_label !== undefined && the_label.dead) {
+
+// cause: "aa:{function aa(aa){break aa;}}"
+
+                        warn("out_of_scope_a");
+                    } else {
+
+// cause: "aa:{break aa;}"
+
+                        warn("not_label_a");
+                    }
+                } else {
+                    the_label.used += 1;
+                }
+                the_break.label = token_nxt;
+                advance();
+            }
+            advance(";");
+            return the_break;
+        });
+
+        function do_var() {
+            const the_statement = token_now;
+            const mode_const = the_statement.id === "const";
+            the_statement.names = [];
+
+// A program may use var or let, but not both.
+
+            if (!mode_const) {
+                if (mode_var === undefined) {
+                    mode_var = the_statement.id;
+                } else if (the_statement.id !== mode_var) {
+
+// cause: "let aa;var aa"
+
+                    warn(
+                        "expected_a_b",
+                        the_statement,
+                        mode_var,
+                        the_statement.id
+                    );
+                }
+            }
+
+// We don't expect to see variables created in switch statements.
+
+            if (functionage.switch > 0) {
+
+// cause: "switch(0){case 0:var aa}"
+
+                warn("var_switch", the_statement);
+            }
+            if (functionage.loop > 0 && the_statement.id === "var") {
+
+// cause: "while(0){var aa;}"
+
+                warn("var_loop", the_statement);
+            }
+            (function next() {
+                if (token_nxt.id === "{" && the_statement.id !== "var") {
+                    let artifact_now;
+                    let artifact_nxt = "";
+                    const the_brace = token_nxt;
+                    advance("{");
+                    (function pair() {
                         if (!token_nxt.identifier) {
+
+// cause: "let {0}"
+
+                            return stop("expected_identifier_a", token_nxt);
+                        }
+                        const name = token_nxt;
+                        survey(name);
+                        artifact_now = artifact_nxt;
+                        artifact_nxt = artifact(name);
+                        if (
+                            !option_object.unordered
+                            && artifact_now > artifact_nxt
+                        ) {
+
+// cause: "let{bb,aa}"
+
+                            warn(
+                                "expected_a_before_b",
+                                name,
+                                artifact_nxt,
+                                artifact_now
+                            );
+                        }
+                        advance();
+                        if (token_nxt.id === ":") {
+                            advance(":");
+                            if (!token_nxt.identifier) {
 
 // cause: "let {aa:0}"
 // cause: "let {aa:{aa}}"
 
-                            return stop("expected_identifier_a", token_nxt);
+                                return stop("expected_identifier_a", token_nxt);
+                            }
+                            token_nxt.label = name;
+                            the_statement.names.push(token_nxt);
+                            enroll(token_nxt, "variable", mode_const);
+                            advance();
+                            the_brace.open = true;
+                        } else {
+                            the_statement.names.push(name);
+                            enroll(name, "variable", mode_const);
                         }
-                        token_nxt.label = name;
-                        the_statement.names.push(token_nxt);
-                        enroll(token_nxt, "variable", mode_const);
-                        advance();
-                        the_brace.open = true;
-                    } else {
-                        the_statement.names.push(name);
-                        enroll(name, "variable", mode_const);
-                    }
-                    name.dead = false;
-                    name.init = true;
-                    if (token_nxt.id === "=") {
+                        name.dead = false;
+                        name.init = true;
+                        if (token_nxt.id === "=") {
 
 // cause: "let {aa=0}"
 
-                        advance("=");
-                        name.expression = expression();
-                        the_brace.open = true;
-                    }
-                    if (token_nxt.id === ",") {
-                        advance(",");
-                        return pair();
-                    }
-                }());
-                advance("}");
-                advance("=");
-                the_statement.expression = expression(0);
-            } else if (token_nxt.id === "[" && the_statement.id !== "var") {
-                const the_bracket = token_nxt;
-                advance("[");
-                (function element() {
-                    let ellipsis;
-                    if (token_nxt.id === "...") {
-                        ellipsis = true;
-                        advance("...");
-                    }
-                    if (!token_nxt.identifier) {
-
-// cause: "let[]"
-
-                        return stop("expected_identifier_a", token_nxt);
-                    }
-                    const name = token_nxt;
-                    advance();
-                    the_statement.names.push(name);
-                    enroll(name, "variable", mode_const);
-                    name.dead = false;
-                    name.init = true;
-                    if (ellipsis) {
-                        name.ellipsis = true;
-                    } else {
-                        if (token_nxt.id === "=") {
                             advance("=");
-                            name.expression = expression();
-                            the_bracket.open = true;
+                            name.expression = parse_expression();
+                            the_brace.open = true;
                         }
                         if (token_nxt.id === ",") {
                             advance(",");
-                            return element();
+                            return pair();
                         }
-                    }
-                }());
-                advance("]");
-                advance("=");
-                the_statement.expression = expression(0);
-            } else if (token_nxt.identifier) {
-                const name = token_nxt;
-                advance();
-                if (name.id === "ignore") {
+                    }());
+                    advance("}");
+                    advance("=");
+                    the_statement.expression = parse_expression(0);
+                } else if (token_nxt.id === "[" && the_statement.id !== "var") {
+                    const the_bracket = token_nxt;
+                    advance("[");
+                    (function element() {
+                        let ellipsis;
+                        if (token_nxt.id === "...") {
+                            ellipsis = true;
+                            advance("...");
+                        }
+                        if (!token_nxt.identifier) {
+
+// cause: "let[]"
+
+                            return stop("expected_identifier_a", token_nxt);
+                        }
+                        const name = token_nxt;
+                        advance();
+                        the_statement.names.push(name);
+                        enroll(name, "variable", mode_const);
+                        name.dead = false;
+                        name.init = true;
+                        if (ellipsis) {
+                            name.ellipsis = true;
+                        } else {
+                            if (token_nxt.id === "=") {
+                                advance("=");
+                                name.expression = parse_expression();
+                                the_bracket.open = true;
+                            }
+                            if (token_nxt.id === ",") {
+                                advance(",");
+                                return element();
+                            }
+                        }
+                    }());
+                    advance("]");
+                    advance("=");
+                    the_statement.expression = parse_expression(0);
+                } else if (token_nxt.identifier) {
+                    const name = token_nxt;
+                    advance();
+                    if (name.id === "ignore") {
 
 // cause: "let ignore;function aa(ignore) {}"
 
-                    warn("unexpected_a", name);
-                }
-                enroll(name, "variable", mode_const);
-                if (token_nxt.id === "=" || mode_const) {
-                    advance("=");
-                    name.dead = false;
-                    name.init = true;
-                    name.expression = expression(0);
-                }
-                the_statement.names.push(name);
-            } else {
+                        warn("unexpected_a", name);
+                    }
+                    enroll(name, "variable", mode_const);
+                    if (token_nxt.id === "=" || mode_const) {
+                        advance("=");
+                        name.dead = false;
+                        name.init = true;
+                        name.expression = parse_expression(0);
+                    }
+                    the_statement.names.push(name);
+                } else {
 
 // cause: "let 0"
 // cause: "var{aa:{aa}}"
 
-                return stop("expected_identifier_a", token_nxt);
-            }
-        }());
-        semicolon();
-        return the_statement;
-    }
+                    return stop("expected_identifier_a", token_nxt);
+                }
+            }());
+            semicolon();
+            return the_statement;
+        }
 
-    stmt("const", do_var);
-    stmt("continue", function () {
-        const the_continue = token_now;
-        if (functionage.loop < 1 || functionage.finally > 0) {
+        stmt("const", do_var);
+        stmt("continue", function () {
+            const the_continue = token_now;
+            if (functionage.loop < 1 || functionage.finally > 0) {
 
 // cause: "continue"
 // cause: "function aa(){while(0){try{}finally{continue}}}"
 
+                warn("unexpected_a", the_continue);
+            }
+            not_top_level(the_continue);
+            the_continue.disrupt = true;
             warn("unexpected_a", the_continue);
-        }
-        not_top_level(the_continue);
-        the_continue.disrupt = true;
-        warn("unexpected_a", the_continue);
-        advance(";");
-        return the_continue;
-    });
-    stmt("debugger", function () {
-        const the_debug = token_now;
-        if (!option_object.devel) {
+            advance(";");
+            return the_continue;
+        });
+        stmt("debugger", function () {
+            const the_debug = token_now;
+            if (!option_object.devel) {
 
 // cause: "debugger"
 
-            warn("unexpected_a", the_debug);
-        }
-        semicolon();
-        return the_debug;
-    });
-    stmt("delete", function () {
-        const the_token = token_now;
-        const the_value = expression(0);
-        if (
-            (the_value.id !== "." && the_value.id !== "[")
-            || the_value.arity !== "binary"
-        ) {
+                warn("unexpected_a", the_debug);
+            }
+            semicolon();
+            return the_debug;
+        });
+        stmt("delete", function () {
+            const the_token = token_now;
+            const the_value = parse_expression(0);
+            if (
+                (the_value.id !== "." && the_value.id !== "[")
+                || the_value.arity !== "binary"
+            ) {
 
 // cause: "delete 0"
 
-            stop("expected_a_b", the_value, ".", artifact(the_value));
-        }
-        the_token.expression = the_value;
-        semicolon();
-        return the_token;
-    });
-    stmt("do", function () {
-        const the_do = token_now;
-        not_top_level(the_do);
-        functionage.loop += 1;
-        the_do.block = block();
-        advance("while");
-        the_do.expression = condition();
-        semicolon();
-        if (the_do.block.disrupt === true) {
+                stop("expected_a_b", the_value, ".", artifact(the_value));
+            }
+            the_token.expression = the_value;
+            semicolon();
+            return the_token;
+        });
+        stmt("do", function () {
+            const the_do = token_now;
+            not_top_level(the_do);
+            functionage.loop += 1;
+            the_do.block = block();
+            advance("while");
+            the_do.expression = condition();
+            semicolon();
+            if (the_do.block.disrupt === true) {
 
 // cause: "function aa(){do{break;}while(0)}"
 
-            warn("weird_loop", the_do);
-        }
-        functionage.loop -= 1;
-        return the_do;
-    });
-    stmt("export", function () {
-        const the_export = token_now;
-        let the_id;
-        let the_name;
-        let the_thing;
+                warn("weird_loop", the_do);
+            }
+            functionage.loop -= 1;
+            return the_do;
+        });
+        stmt("export", function () {
+            const the_export = token_now;
+            let the_id;
+            let the_name;
+            let the_thing;
 
-        function export_id() {
-            if (!token_nxt.identifier) {
+            function export_id() {
+                if (!token_nxt.identifier) {
 
 // cause: "export {}"
 
-                stop("expected_identifier_a");
-            }
-            the_id = token_nxt.id;
-            the_name = global.context[the_id];
-            if (the_name === undefined) {
+                    stop("expected_identifier_a");
+                }
+                the_id = token_nxt.id;
+                the_name = global.context[the_id];
+                if (the_name === undefined) {
 
 // cause: "export {aa}"
 
-                warn("unexpected_a");
-            } else {
-                the_name.used += 1;
-                if (export_object[the_id] !== undefined) {
+                    warn("unexpected_a");
+                } else {
+                    the_name.used += 1;
+                    if (export_object[the_id] !== undefined) {
 
 // cause: "let aa;export{aa,aa}"
 
-                    warn("duplicate_a");
+                        warn("duplicate_a");
+                    }
+                    export_object[the_id] = the_name;
                 }
-                export_object[the_id] = the_name;
+                advance();
+                the_export.expression.push(the_thing);
             }
-            advance();
-            the_export.expression.push(the_thing);
-        }
 
-        the_export.expression = [];
-        if (token_nxt.id === "default") {
-            if (export_object.default !== undefined) {
+            the_export.expression = [];
+            if (token_nxt.id === "default") {
+                if (export_object.default !== undefined) {
 
 // cause: "export default 0;export default 0"
 
-                warn("duplicate_a");
-            }
-            advance("default");
-            the_thing = expression(0);
-            if (
-                the_thing.id !== "("
-                || the_thing.expression[0].id !== "."
-                || the_thing.expression[0].expression.id !== "Object"
-                || the_thing.expression[0].name.id !== "freeze"
-            ) {
+                    warn("duplicate_a");
+                }
+                advance("default");
+                the_thing = parse_expression(0);
+                if (
+                    the_thing.id !== "("
+                    || the_thing.expression[0].id !== "."
+                    || the_thing.expression[0].expression.id !== "Object"
+                    || the_thing.expression[0].name.id !== "freeze"
+                ) {
 
 // cause: "export default {}"
 
-                warn("freeze_exports", the_thing);
+                    warn("freeze_exports", the_thing);
 
 // Fixes issues #282 - optional-semicolon.
 
-            } else {
+                } else {
 
 // cause: "export default Object.freeze({})"
 
-                semicolon();
-            }
-            export_object.default = the_thing;
-            the_export.expression.push(the_thing);
-        } else {
-            if (token_nxt.id === "function") {
+                    semicolon();
+                }
+                export_object.default = the_thing;
+                the_export.expression.push(the_thing);
+            } else {
+                if (token_nxt.id === "function") {
 
 // cause: "export function aa(){}"
 
-                warn("freeze_exports");
-                the_thing = statement();
-                the_name = the_thing.name;
-                the_id = the_name.id;
-                the_name.used += 1;
+                    warn("freeze_exports");
+                    the_thing = parse_statement();
+                    the_name = the_thing.name;
+                    the_id = the_name.id;
+                    the_name.used += 1;
 
 // cause: "let aa;export{aa};export function aa(){}"
 
-                if (export_object[the_id] !== undefined) {
-                    warn("duplicate_a", the_name);
-                }
-                export_object[the_id] = the_thing;
-                the_export.expression.push(the_thing);
-                the_thing.statement = false;
-                the_thing.arity = "unary";
-            } else if (
-                token_nxt.id === "var"
-                || token_nxt.id === "let"
-                || token_nxt.id === "const"
-            ) {
+                    if (export_object[the_id] !== undefined) {
+                        warn("duplicate_a", the_name);
+                    }
+                    export_object[the_id] = the_thing;
+                    the_export.expression.push(the_thing);
+                    the_thing.statement = false;
+                    the_thing.arity = "unary";
+                } else if (
+                    token_nxt.id === "var"
+                    || token_nxt.id === "let"
+                    || token_nxt.id === "const"
+                ) {
 
 // cause: "export const"
 // cause: "export let"
 // cause: "export var"
 
-                warn("unexpected_a", token_nxt);
-                statement();
-            } else if (token_nxt.id === "{") {
+                    warn("unexpected_a", token_nxt);
+                    parse_statement();
+                } else if (token_nxt.id === "{") {
 
 // cause: "export {}"
 
-                advance("{");
-                (function loop() {
-                    export_id();
-                    if (token_nxt.id === ",") {
-                        advance(",");
-                        return loop();
-                    }
-                }());
-                advance("}");
-                semicolon();
-            } else {
+                    advance("{");
+                    (function loop() {
+                        export_id();
+                        if (token_nxt.id === ",") {
+                            advance(",");
+                            return loop();
+                        }
+                    }());
+                    advance("}");
+                    semicolon();
+                } else {
 
 // cause: "export"
 
-                stop("unexpected_a");
+                    stop("unexpected_a");
+                }
             }
-        }
-        mode_module = true;
-        return the_export;
-    });
-    stmt("for", function () {
-        let first;
-        const the_for = token_now;
-        if (!option_object.for) {
+            mode_module = true;
+            return the_export;
+        });
+        stmt("for", function () {
+            const the_for = token_now;
+            let first;
+            if (!option_object.for) {
 
 // cause: "for"
 
-            warn("unexpected_a", the_for);
-        }
-        not_top_level(the_for);
-        functionage.loop += 1;
-        advance("(");
+                warn("unexpected_a", the_for);
+            }
+            not_top_level(the_for);
+            functionage.loop += 1;
+            advance("(");
 
 // cause: "for(){}"
 
-        token_now.free = true;
-        if (token_nxt.id === ";") {
+            token_now.free = true;
+            if (token_nxt.id === ";") {
 
 // cause: "for(;;){}"
 
-            return stop("expected_a_b", the_for, "while (", "for (;");
-        }
-        if (
-            token_nxt.id === "var"
-            || token_nxt.id === "let"
-            || token_nxt.id === "const"
-        ) {
+                return stop("expected_a_b", the_for, "while (", "for (;");
+            }
+            if (
+                token_nxt.id === "var"
+                || token_nxt.id === "let"
+                || token_nxt.id === "const"
+            ) {
 
 // cause: "for(const aa in aa){}"
 
-            return stop("unexpected_a");
-        }
-        first = expression(0);
-        if (first.id === "in") {
-            if (first.expression[0].arity !== "variable") {
+                return stop("unexpected_a");
+            }
+            first = parse_expression(0);
+            if (first.id === "in") {
+                if (first.expression[0].arity !== "variable") {
 
 // cause: "for(0 in aa){}"
 
-                warn("bad_assignment_a", first.expression[0]);
-            }
-            the_for.name = first.expression[0];
-            the_for.expression = first.expression[1];
-            warn("expected_a_b", the_for, "Object.keys", "for in");
-        } else {
-            the_for.initial = first;
-            advance(";");
-            the_for.expression = expression(0);
-            advance(";");
-            the_for.inc = expression(0);
-            if (the_for.inc.id === "++") {
+                    warn("bad_assignment_a", first.expression[0]);
+                }
+                the_for.name = first.expression[0];
+                the_for.expression = first.expression[1];
+                warn("expected_a_b", the_for, "Object.keys", "for in");
+            } else {
+                the_for.initial = first;
+                advance(";");
+                the_for.expression = parse_expression(0);
+                advance(";");
+                the_for.inc = parse_expression(0);
+                if (the_for.inc.id === "++") {
 
 // cause: "for(aa;aa;aa++){}"
 
-                warn("expected_a_b", the_for.inc, "+= 1", "++");
+                    warn("expected_a_b", the_for.inc, "+= 1", "++");
+                }
             }
-        }
-        advance(")");
-        the_for.block = block();
-        if (the_for.block.disrupt === true) {
+            advance(")");
+            the_for.block = block();
+            if (the_for.block.disrupt === true) {
 
 // cause: "/*jslint for*/\nfunction aa(bb,cc){for(0;0;0){break;}}"
 
-            warn("weird_loop", the_for);
-        }
-        functionage.loop -= 1;
-        return the_for;
-    });
-    stmt("function", do_function);
-    stmt("if", function () {
-        let the_else;
-        const the_if = token_now;
-        the_if.expression = condition();
-        the_if.block = block();
-        if (token_nxt.id === "else") {
-            advance("else");
-            the_else = token_now;
-            the_if.else = (
-                token_nxt.id === "if"
+                warn("weird_loop", the_for);
+            }
+            functionage.loop -= 1;
+            return the_for;
+        });
+        stmt("function", do_function);
+        stmt("if", function () {
+            const the_if = token_now;
+            let the_else;
+            the_if.expression = condition();
+            the_if.block = block();
+            if (token_nxt.id === "else") {
+                advance("else");
+                the_else = token_now;
+                the_if.else = (
+                    token_nxt.id === "if"
 
 // cause: "if(0){0}else if(0){0}"
 
-                ? statement()
+                    ? parse_statement()
 
 // cause: "if(0){0}else{0}"
 
-                : block()
-            );
-            if (the_if.block.disrupt === true) {
-                if (the_if.else.disrupt === true) {
+                    : block()
+                );
+                if (the_if.block.disrupt === true) {
+                    if (the_if.else.disrupt === true) {
+
+// cause: "if(0){break;}else{break;}"
+
+                        the_if.disrupt = true;
+                    } else {
 
 // cause: "if(0){break;}else{}"
 
-                    the_if.disrupt = true;
-                } else {
-
-// cause: "if(0){break;}else{}"
-
-                    warn("unexpected_a", the_else);
+                        warn("unexpected_a", the_else);
+                    }
                 }
             }
-        }
-        return the_if;
-    });
-    stmt("import", function () {
-        const the_import = token_now;
-        let name;
-        if (typeof mode_module === "object") {
+            return the_if;
+        });
+        stmt("import", function () {
+            const the_import = token_now;
+            let name;
+            if (typeof mode_module === "object") {
 
 // cause: "/*global aa*/\nimport aa from \"aa\""
 
-            warn("unexpected_directive_a", mode_module, mode_module.directive);
-        }
-        mode_module = true;
-        if (token_nxt.identifier) {
-            name = token_nxt;
-            advance();
-            if (name.id === "ignore") {
+                warn(
+                    "unexpected_directive_a",
+                    mode_module,
+                    mode_module.directive
+                );
+            }
+            mode_module = true;
+            if (token_nxt.identifier) {
+                name = token_nxt;
+                advance();
+                if (name.id === "ignore") {
 
 // cause: "import ignore from \"aa\""
 
-                warn("unexpected_a", name);
-            }
-            enroll(name, "variable", true);
-            the_import.name = name;
-        } else {
-            const names = [];
-            advance("{");
-            if (token_nxt.id !== "}") {
-                while (true) {
-                    if (!token_nxt.identifier) {
+                    warn("unexpected_a", name);
+                }
+                enroll(name, "variable", true);
+                the_import.name = name;
+            } else {
+                const names = [];
+                advance("{");
+                if (token_nxt.id !== "}") {
+                    while (true) {
+                        if (!token_nxt.identifier) {
 
 // cause: "import {"
 
-                        stop("expected_identifier_a");
-                    }
-                    name = token_nxt;
-                    advance();
-                    if (name.id === "ignore") {
+                            stop("expected_identifier_a");
+                        }
+                        name = token_nxt;
+                        advance();
+                        if (name.id === "ignore") {
 
 // cause: "import {ignore} from \"aa\""
 
-                        warn("unexpected_a", name);
+                            warn("unexpected_a", name);
+                        }
+                        enroll(name, "variable", true);
+                        names.push(name);
+                        if (token_nxt.id !== ",") {
+                            break;
+                        }
+                        advance(",");
                     }
-                    enroll(name, "variable", true);
-                    names.push(name);
-                    if (token_nxt.id !== ",") {
-                        break;
-                    }
-                    advance(",");
                 }
+                advance("}");
+                the_import.name = names;
             }
-            advance("}");
-            the_import.name = names;
-        }
-        advance("from");
-        advance("(string)");
-        the_import.import = token_now;
-        if (!rx_module.test(token_now.value)) {
+            advance("from");
+            advance("(string)");
+            the_import.import = token_now;
+            if (!rx_module.test(token_now.value)) {
 
 // cause: "import aa from \"!aa\""
 
-            warn("bad_module_name_a", token_now);
-        }
-        import_from_array.push(token_now.value);
-        semicolon();
-        return the_import;
-    });
-    stmt("let", do_var);
-    stmt("return", function () {
-        const the_return = token_now;
-        not_top_level(the_return);
-        if (functionage.finally > 0) {
+                warn("bad_module_name_a", token_now);
+            }
+            import_array.push(token_now.value);
+            semicolon();
+            return the_import;
+        });
+        stmt("let", do_var);
+        stmt("return", function () {
+            const the_return = token_now;
+            not_top_level(the_return);
+            if (functionage.finally > 0) {
 
 // cause: "function aa(){try{}finally{return;}}"
 
-            warn("unexpected_a", the_return);
-        }
-        the_return.disrupt = true;
-        if (token_nxt.id !== ";" && the_return.line === token_nxt.line) {
-            the_return.expression = expression(10);
-        }
-        advance(";");
-        return the_return;
-    });
-    stmt("switch", function () {
-        let dups = [];
-        let last;
-        let stmts;
-        const the_cases = [];
-        let the_disrupt = true;
-        const the_switch = token_now;
-        not_top_level(the_switch);
-        if (functionage.finally > 0) {
+                warn("unexpected_a", the_return);
+            }
+            the_return.disrupt = true;
+            if (token_nxt.id !== ";" && the_return.line === token_nxt.line) {
+                the_return.expression = parse_expression(10);
+            }
+            advance(";");
+            return the_return;
+        });
+        stmt("switch", function () {
+            const the_cases = [];
+            const the_switch = token_now;
+            let dups = [];
+            let last;
+            let stmts;
+            let the_disrupt = true;
+            not_top_level(the_switch);
+            if (functionage.finally > 0) {
 
 // cause: "function aa(){try{}finally{switch(0){}}}"
 
-            warn("unexpected_a", the_switch);
-        }
-        functionage.switch += 1;
-        advance("(");
+                warn("unexpected_a", the_switch);
+            }
+            functionage.switch += 1;
+            advance("(");
 
 // cause: "switch(){}"
 
-        token_now.free = true;
-        the_switch.expression = expression(0);
-        the_switch.block = the_cases;
-        advance(")");
-        advance("{");
-        (function major() {
-            const the_case = token_nxt;
-            the_case.arity = "statement";
-            the_case.expression = [];
-            (function minor() {
-                advance("case");
-                token_now.switch = true;
-                const exp = expression(0);
-                if (dups.some(function (thing) {
-                    return are_similar(thing, exp);
-                })) {
+            token_now.free = true;
+            the_switch.expression = parse_expression(0);
+            the_switch.block = the_cases;
+            advance(")");
+            advance("{");
+            (function major() {
+                const the_case = token_nxt;
+                the_case.arity = "statement";
+                the_case.expression = [];
+                (function minor() {
+                    advance("case");
+                    token_now.switch = true;
+                    const exp = parse_expression(0);
+                    if (dups.some(function (thing) {
+                        return are_similar(thing, exp);
+                    })) {
 
 // cause: "switch(0){case 0:break;case 0:break}"
 
-                    warn("unexpected_a", exp);
-                }
-                dups.push(exp);
-                the_case.expression.push(exp);
-                advance(":");
-                if (token_nxt.id === "case") {
-                    return minor();
-                }
-            }());
-            stmts = statements();
-            if (stmts.length < 1) {
+                        warn("unexpected_a", exp);
+                    }
+                    dups.push(exp);
+                    the_case.expression.push(exp);
+                    advance(":");
+                    if (token_nxt.id === "case") {
+                        return minor();
+                    }
+                }());
+                stmts = parse_statements();
+                if (stmts.length < 1) {
 
 // cause: "switch(0){case 0:}"
 
-                warn("expected_statements_a");
-                return;
-            }
-            the_case.block = stmts;
-            the_cases.push(the_case);
-            last = stmts[stmts.length - 1];
-            if (last.disrupt) {
-                if (last.id === "break" && last.label === undefined) {
-                    the_disrupt = false;
+                    warn("expected_statements_a");
+                    return;
                 }
-            } else {
-                warn(
-                    "expected_a_before_b",
-                    token_nxt,
-                    "break;",
-                    artifact(token_nxt)
-                );
-            }
-            if (token_nxt.id === "case") {
-                return major();
-            }
-        }());
-        dups = undefined;
-        if (token_nxt.id === "default") {
-            const the_default = token_nxt;
-            advance("default");
-            token_now.switch = true;
-            advance(":");
-            the_switch.else = statements();
-            if (the_switch.else.length < 1) {
+                the_case.block = stmts;
+                the_cases.push(the_case);
+                last = stmts[stmts.length - 1];
+                if (last.disrupt) {
+                    if (last.id === "break" && last.label === undefined) {
+                        the_disrupt = false;
+                    }
+                } else {
+                    warn(
+                        "expected_a_before_b",
+                        token_nxt,
+                        "break;",
+                        artifact(token_nxt)
+                    );
+                }
+                if (token_nxt.id === "case") {
+                    return major();
+                }
+            }());
+            dups = undefined;
+            if (token_nxt.id === "default") {
+                const the_default = token_nxt;
+                advance("default");
+                token_now.switch = true;
+                advance(":");
+                the_switch.else = parse_statements();
+                if (the_switch.else.length < 1) {
 
 // cause: "switch(0){case 0:break;default:}"
 
-                warn("unexpected_a", the_default);
-                the_disrupt = false;
-            } else {
-                const the_last = the_switch.else[the_switch.else.length - 1];
-                if (the_last.id === "break" && the_last.label === undefined) {
+                    warn("unexpected_a", the_default);
+                    the_disrupt = false;
+                } else {
+                    const the_last = the_switch.else[
+                        the_switch.else.length - 1
+                    ];
+                    if (
+                        the_last.id === "break"
+                        && the_last.label === undefined
+                    ) {
 
 // cause: "switch(0){case 0:break;default:break;}"
 
-                    warn("unexpected_a", the_last);
-                    the_last.disrupt = false;
+                        warn("unexpected_a", the_last);
+                        the_last.disrupt = false;
+                    }
+                    the_disrupt = the_disrupt && the_last.disrupt;
                 }
-                the_disrupt = the_disrupt && the_last.disrupt;
+            } else {
+                the_disrupt = false;
             }
-        } else {
-            the_disrupt = false;
-        }
-        advance("}", the_switch);
-        functionage.switch -= 1;
-        the_switch.disrupt = the_disrupt;
-        return the_switch;
-    });
-    stmt("throw", function () {
-        const the_throw = token_now;
-        the_throw.disrupt = true;
-        the_throw.expression = expression(10);
-        semicolon();
-        if (functionage.try > 0) {
+            advance("}", the_switch);
+            functionage.switch -= 1;
+            the_switch.disrupt = the_disrupt;
+            return the_switch;
+        });
+        stmt("throw", function () {
+            const the_throw = token_now;
+            the_throw.disrupt = true;
+            the_throw.expression = parse_expression(10);
+            semicolon();
+            if (functionage.try > 0) {
 
 // cause: "try{throw 0}catch(){}"
 
-            warn("unexpected_a", the_throw);
-        }
-        return the_throw;
-    });
-    stmt("try", function () {
-        const the_try = token_now;
-        let ignored;
-        let the_catch;
-        let the_disrupt;
-        if (functionage.try > 0) {
+                warn("unexpected_a", the_throw);
+            }
+            return the_throw;
+        });
+        stmt("try", function () {
+            const the_try = token_now;
+            let ignored;
+            let the_catch;
+            let the_disrupt;
+            if (functionage.try > 0) {
 
 // cause: "try{try{}catch(){}}catch(){}"
 
-            warn("unexpected_a", the_try);
-        }
-        functionage.try += 1;
-        the_try.block = block();
-        the_disrupt = the_try.block.disrupt;
-        if (token_nxt.id === "catch") {
-            advance("catch");
-            the_catch = token_nxt;
-            the_catch.context = empty();
-            the_catch.async = functionage.async;
-            the_try.catch = the_catch;
+                warn("unexpected_a", the_try);
+            }
+            functionage.try += 1;
+            the_try.block = block();
+            the_disrupt = the_try.block.disrupt;
+            if (token_nxt.id === "catch") {
+                advance("catch");
+                the_catch = token_nxt;
+                the_catch.context = empty();
+                the_catch.async = functionage.async;
+                the_try.catch = the_catch;
 
 // Create new function-scope for catch-parameter.
 
-            stack.push(functionage);
-            functionage = the_catch;
-            ignored = "ignore";
-            if (token_nxt.id === "(") {
-                advance("(");
-                if (!token_nxt.identifier) {
+                function_stack.push(functionage);
+                functionage = the_catch;
+                ignored = "ignore";
+                if (token_nxt.id === "(") {
+                    advance("(");
+                    if (!token_nxt.identifier) {
 
 // cause: "try{}catch(){}"
 
-                    return stop("expected_identifier_a", token_nxt);
+                        return stop("expected_identifier_a", token_nxt);
+                    }
+                    if (token_nxt.id !== "ignore") {
+                        ignored = undefined;
+                        the_catch.name = token_nxt;
+                        enroll(token_nxt, "exception", true);
+                    }
+                    advance();
+                    advance(")");
                 }
-                if (token_nxt.id !== "ignore") {
-                    ignored = undefined;
-                    the_catch.name = token_nxt;
-                    enroll(token_nxt, "exception", true);
+                the_catch.block = block(ignored);
+                if (the_catch.block.disrupt !== true) {
+                    the_disrupt = false;
                 }
-                advance();
-                advance(")");
-            }
-            the_catch.block = block(ignored);
-            if (the_catch.block.disrupt !== true) {
-                the_disrupt = false;
-            }
 
 // Restore previous function-scope after catch-block.
 
-            functionage = stack.pop();
-            functionage.async = Math.max(functionage.async, the_catch.async);
-        } else {
+                functionage = function_stack.pop();
+                functionage.async = Math.max(
+                    functionage.async,
+                    the_catch.async
+                );
+            } else {
 
 // cause: "try{}finally{break;}"
 
-            warn(
-                "expected_a_before_b",
-                token_nxt,
-                "catch",
-                artifact(token_nxt)
-            );
+                warn(
+                    "expected_a_before_b",
+                    token_nxt,
+                    "catch",
+                    artifact(token_nxt)
+                );
 
-        }
-        if (token_nxt.id === "finally") {
-            functionage.finally += 1;
-            advance("finally");
-            the_try.else = block();
-            the_disrupt = the_try.else.disrupt;
-            functionage.finally -= 1;
-        }
-        the_try.disrupt = the_disrupt;
-        functionage.try -= 1;
-        return the_try;
-    });
-    stmt("var", do_var);
-    stmt("while", function () {
-        const the_while = token_now;
-        not_top_level(the_while);
-        functionage.loop += 1;
-        the_while.expression = condition();
-        the_while.block = block();
-        if (the_while.block.disrupt === true) {
+            }
+            if (token_nxt.id === "finally") {
+                functionage.finally += 1;
+                advance("finally");
+                the_try.else = block();
+                the_disrupt = the_try.else.disrupt;
+                functionage.finally -= 1;
+            }
+            the_try.disrupt = the_disrupt;
+            functionage.try -= 1;
+            return the_try;
+        });
+        stmt("var", do_var);
+        stmt("while", function () {
+            const the_while = token_now;
+            not_top_level(the_while);
+            functionage.loop += 1;
+            the_while.expression = condition();
+            the_while.block = block();
+            if (the_while.block.disrupt === true) {
 
 // cause: "function aa(){while(0){break;}}"
 
-            warn("weird_loop", the_while);
-        }
-        functionage.loop -= 1;
-        return the_while;
-    });
-    stmt("with", function () {
+                warn("weird_loop", the_while);
+            }
+            functionage.loop -= 1;
+            return the_while;
+        });
+        stmt("with", function () {
 
 // cause: "with"
 
-        stop("unexpected_a", token_now);
-    });
+            stop("unexpected_a", token_now);
+        });
 
-    ternary("?", ":");
+        ternary("?", ":");
+
+        advance();
+
+// Parsing of JSON is simple:
+
+        if (mode_json) {
+            token_tree = (function parse_json() {
+                let negative;
+                switch (token_nxt.id) {
+                case "{":
+                    return (function json_object() {
+                        const brace = token_nxt;
+
+// Explicit empty-object required to detect "__proto__".
+
+                        const object = empty();
+                        const properties = [];
+                        brace.expression = properties;
+                        advance("{");
+                        if (token_nxt.id !== "}") {
+
+// JSON
+// Parse/loop through each property in {...}.
+
+                            while (true) {
+                                let name;
+                                let value;
+                                if (token_nxt.quote !== "\"") {
+
+// cause: "{0:0}"
+
+                                    warn(
+                                        "unexpected_a",
+                                        token_nxt,
+                                        token_nxt.quote
+                                    );
+                                }
+                                name = token_nxt;
+                                advance("(string)");
+                                if (object[token_now.value] !== undefined) {
+
+// cause: "{\"aa\":0,\"aa\":0}"
+
+                                    warn("duplicate_a", token_now);
+                                } else if (token_now.value === "__proto__") {
+
+// cause: "{\"__proto__\":0}"
+
+                                    warn("bad_property_a", token_now);
+                                } else {
+                                    object[token_now.value] = token_now;
+                                }
+                                advance(":");
+                                value = parse_json();
+                                value.label = name;
+                                properties.push(value);
+                                if (token_nxt.id !== ",") {
+                                    break;
+                                }
+                                advance(",");
+                            }
+                        }
+                        advance("}", brace);
+                        return brace;
+                    }());
+                case "[":
+
+// cause: "[]"
+
+                    return (function json_array() {
+                        const bracket = token_nxt;
+                        const elements = [];
+                        bracket.expression = elements;
+                        advance("[");
+                        if (token_nxt.id !== "]") {
+                            while (true) {
+                                elements.push(parse_json());
+                                if (token_nxt.id !== ",") {
+
+// cause: "[0,0]"
+
+                                    break;
+                                }
+                                advance(",");
+                            }
+                        }
+                        advance("]", bracket);
+                        return bracket;
+                    }());
+                case "true":
+                case "false":
+                case "null":
+
+// cause: "[false]"
+// cause: "[null]"
+// cause: "[true]"
+
+                    advance();
+                    return token_now;
+                case "(number)":
+                    if (!rx_JSON_number.test(token_nxt.value)) {
+
+// cause: "[0x0]"
+
+                        warn("unexpected_a");
+                    }
+                    advance();
+                    return token_now;
+                case "(string)":
+                    if (token_nxt.quote !== "\"") {
+
+// cause: "['']"
+
+                        warn("unexpected_a", token_nxt, token_nxt.quote);
+                    }
+                    advance();
+                    return token_now;
+                case "-":
+                    negative = token_nxt;
+                    negative.arity = "unary";
+                    advance("-");
+                    advance("(number)");
+                    if (!rx_JSON_number.test(token_now.value)) {
+
+// cause: "[-0x0]"
+
+                        warn("unexpected_a", token_now);
+                    }
+                    negative.expression = token_now;
+                    return negative;
+                default:
+
+// cause: "[undefined]"
+
+                    stop("unexpected_a");
+                }
+            }());
+            advance("(end)");
+            return;
+        }
+
+// Because browsers encourage combining of script files, the first token might
+// be a semicolon to defend against a missing semicolon in the preceding file.
+
+        if (option_object.browser) {
+            if (token_nxt.id === ";") {
+                advance(";");
+            }
+            token_tree = parse_statements();
+            advance("(end)");
+            return;
+        }
+
+// If we are not in a browser, then the file form of strict pragma may be used.
+
+        if (
+            token_nxt.value === "use strict"
+        ) {
+            advance("(string)");
+            advance(";");
+        }
+        token_tree = parse_statements();
+        advance("(end)");
+    }
+
+
+    function phase4_walk() {
+
+// PHASE 4. Walk <token_tree>, traversing all of the nodes of the tree. It is a
+//          recursive traversal. Each node may be processed on the way down
+//          (preaction) and on the way up (postaction).
+
+// The stack of blocks.
+        const block_stack = [];
+        const posts = empty();
+        const pres = empty();
+// The current block.
+        let blockage = global;
+// The current function.
+        let functionage = global;
+        let postaction;
+        let postamble;
+        let preaction;
+        let preamble;
 
 // Ambulation of the parse tree.
 
-    function action(when) {
+        function action(when) {
 
 // Produce a function that will register task functions that will be called as
 // the tree is traversed.
 
-        return function (arity, id, task) {
-            let a_set = when[arity];
-            let i_set;
+            return function (arity, id, task) {
+                let a_set = when[arity];
+                let i_set;
 
 // The id parameter is optional. If excluded, the task will be applied to all
 // ids.
 
-            if (typeof id !== "string") {
-                task = id;
-                id = "(all)";
-            }
+                if (typeof id !== "string") {
+                    task = id;
+                    id = "(all)";
+                }
 
 // If this arity has no registrations yet, then create a set object to hold
 // them.
 
-            if (a_set === undefined) {
-                a_set = empty();
-                when[arity] = a_set;
-            }
+                if (a_set === undefined) {
+                    a_set = empty();
+                    when[arity] = a_set;
+                }
 
 // If this id has no registrations yet, then create a set array to hold them.
 
-            i_set = a_set[id];
-            if (i_set === undefined) {
-                i_set = [];
-                a_set[id] = i_set;
-            }
+                i_set = a_set[id];
+                if (i_set === undefined) {
+                    i_set = [];
+                    a_set[id] = i_set;
+                }
 
 // Register the task with the arity and the id.
 
-            i_set.push(task);
-        };
-    }
+                i_set.push(task);
+            };
+        }
 
-    function amble(when) {
+        function amble(when) {
 
 // Produce a function that will act on the tasks registered by an action
 // function while walking the tree.
 
-        return function (the_token) {
+            return function (the_token) {
 
 // Given a task set that was built by an action function, run all of the
 // relevant tasks on the token.
 
-            let a_set = when[the_token.arity];
-            let i_set;
+                let a_set = when[the_token.arity];
+                let i_set;
 
 // If there are tasks associated with the token's arity...
 
-            if (a_set !== undefined) {
+                if (a_set !== undefined) {
 
 // If there are tasks associated with the token's id...
 
-                i_set = a_set[the_token.id];
-                if (i_set !== undefined) {
-                    i_set.forEach(function (task) {
-                        return task(the_token);
-                    });
-                }
+                    i_set = a_set[the_token.id];
+                    if (i_set !== undefined) {
+                        i_set.forEach(function (task) {
+                            return task(the_token);
+                        });
+                    }
 
 // If there are tasks for all ids.
 
-                i_set = a_set["(all)"];
-                if (i_set !== undefined) {
-                    i_set.forEach(function (task) {
-                        return task(the_token);
-                    });
+                    i_set = a_set["(all)"];
+                    if (i_set !== undefined) {
+                        i_set.forEach(function (task) {
+                            return task(the_token);
+                        });
+                    }
                 }
+            };
+        }
+
+        function top_level_only(the_thing) {
+
+// Some features must be at the most outermost level.
+
+            if (blockage !== global) {
+
+// cause: "if(0){import aa from \"aa\";}"
+
+                warn("misplaced_a", the_thing);
             }
-        };
-    }
+        }
 
-    const posts = empty();
-    const pres = empty();
-    const preaction = action(pres);
-    const postaction = action(posts);
-    const preamble = amble(pres);
-    const postamble = amble(posts);
-
-    function walk_expression(thing) {
-        if (thing) {
-            if (Array.isArray(thing)) {
+        function walk_expression(thing) {
+            if (thing) {
+                if (Array.isArray(thing)) {
 
 // cause: "(function(){}())"
 // cause: "0&&0"
 
-                thing.forEach(walk_expression);
-            } else {
-                preamble(thing);
-                walk_expression(thing.expression);
-                if (thing.id === "function") {
+                    thing.forEach(walk_expression);
+                } else {
+                    preamble(thing);
+                    walk_expression(thing.expression);
+                    if (thing.id === "function") {
 
 // cause: "aa=function(){}"
 
-                    walk_statement(thing.block);
-                }
-                if (thing.arity === "pre" || thing.arity === "post") {
+                        walk_statement(thing.block);
+                    }
+                    if (thing.arity === "pre" || thing.arity === "post") {
 
 // cause: "aa=++aa"
 // cause: "aa=--aa"
 
-                    warn("unexpected_a", thing);
-                } else if (
+                        warn("unexpected_a", thing);
+                    } else if (
 
 // cause: "aa=0"
 
-                    thing.arity === "statement"
-                    || thing.arity === "assignment"
-                ) {
+                        thing.arity === "statement"
+                        || thing.arity === "assignment"
+                    ) {
 
 // cause: "aa[aa=0]"
 
-                    warn("unexpected_statement_a", thing);
+                        warn("unexpected_statement_a", thing);
+                    }
+                    postamble(thing);
                 }
-                postamble(thing);
             }
         }
-    }
 
-    function walk_statement(thing) {
-        if (thing) {
-            if (Array.isArray(thing)) {
+        function walk_statement(thing) {
+            if (thing) {
+                if (Array.isArray(thing)) {
 
 // cause: "+[]"
 
-                thing.forEach(walk_statement);
-            } else {
-                preamble(thing);
-                walk_expression(thing.expression);
-                if (thing.arity === "binary") {
-                    if (thing.id !== "(") {
+                    thing.forEach(walk_statement);
+                } else {
+                    preamble(thing);
+                    walk_expression(thing.expression);
+                    if (thing.arity === "binary") {
+                        if (thing.id !== "(") {
 
 // cause: "0&&0"
 
-                        warn("unexpected_expression_a", thing);
-                    }
-                } else if (
-                    thing.arity !== "statement"
-                    && thing.arity !== "assignment"
-                    && thing.id !== "import"
-                ) {
+                            warn("unexpected_expression_a", thing);
+                        }
+                    } else if (
+                        thing.arity !== "statement"
+                        && thing.arity !== "assignment"
+                        && thing.id !== "import"
+                    ) {
 
 // cause: "!0"
 // cause: "+[]"
@@ -3743,156 +4997,156 @@ function jslint(
 // cause: "async function aa(){await 0;}"
 // cause: "typeof 0"
 
-                    warn("unexpected_expression_a", thing);
+                        warn("unexpected_expression_a", thing);
+                    }
+                    walk_statement(thing.block);
+                    walk_statement(thing.else);
+                    postamble(thing);
                 }
-                walk_statement(thing.block);
-                walk_statement(thing.else);
-                postamble(thing);
             }
         }
-    }
 
-    function lookup(thing) {
-        if (thing.arity === "variable") {
+        function lookup(thing) {
+            if (thing.arity === "variable") {
 
 // Look up the variable in the current context.
 
-            let the_variable = functionage.context[thing.id];
+                let the_variable = functionage.context[thing.id];
 
 // If it isn't local, search all the other contexts. If there are name
 // collisions, take the most recent.
 
-            if (the_variable === undefined) {
-                stack.forEach(function (outer) {
-                    const a_variable = outer.context[thing.id];
-                    if (
-                        a_variable !== undefined
-                        && a_variable.role !== "label"
-                    ) {
-                        the_variable = a_variable;
-                    }
-                });
+                if (the_variable === undefined) {
+                    function_stack.forEach(function (outer) {
+                        const a_variable = outer.context[thing.id];
+                        if (
+                            a_variable !== undefined
+                            && a_variable.role !== "label"
+                        ) {
+                            the_variable = a_variable;
+                        }
+                    });
 
 // If it isn't in any of those either, perhaps it is a predefined global.
 // If so, add it to the global context.
 
-                if (the_variable === undefined) {
-                    if (global_array[thing.id] === undefined) {
+                    if (the_variable === undefined) {
+                        if (global_array[thing.id] === undefined) {
 
 // cause: "aa"
 // cause: "class aa{}"
 // cause: "let aa=0;try{aa();}catch(bb){bb();}bb();"
 
-                        warn("undeclared_a", thing);
-                        return;
+                            warn("undeclared_a", thing);
+                            return;
+                        }
+                        the_variable = {
+                            dead: false,
+                            id: thing.id,
+                            init: true,
+                            parent: global,
+                            role: "variable",
+                            used: 0,
+                            writable: false
+                        };
+                        global.context[thing.id] = the_variable;
                     }
-                    the_variable = {
-                        dead: false,
-                        id: thing.id,
-                        init: true,
-                        parent: global,
-                        role: "variable",
-                        used: 0,
-                        writable: false
-                    };
-                    global.context[thing.id] = the_variable;
-                }
-                the_variable.closure = true;
-                functionage.context[thing.id] = the_variable;
-            } else if (the_variable.role === "label") {
+                    the_variable.closure = true;
+                    functionage.context[thing.id] = the_variable;
+                } else if (the_variable.role === "label") {
 
 // cause: "aa:while(0){aa;}"
 
-                warn("label_a", thing);
-            }
-            if (
-                the_variable.dead
-                && (
-                    the_variable.calls === undefined
-                    || functionage.name === undefined
-                    || the_variable.calls[functionage.name.id] === undefined
-                )
-            ) {
+                    warn("label_a", thing);
+                }
+                if (
+                    the_variable.dead
+                    && (
+                        the_variable.calls === undefined
+                        || functionage.name === undefined
+                        || the_variable.calls[functionage.name.id] === undefined
+                    )
+                ) {
 
 // cause: "function aa(){bb();}\nfunction bb(){}"
 
-                warn("out_of_scope_a", thing);
+                    warn("out_of_scope_a", thing);
+                }
+                return the_variable;
             }
-            return the_variable;
         }
-    }
 
-    function subactivate(name) {
-        name.init = true;
-        name.dead = false;
-        blockage.live.push(name);
-    }
+        function subactivate(name) {
+            name.init = true;
+            name.dead = false;
+            blockage.live.push(name);
+        }
 
-    function preaction_function(thing) {
+        function preaction_function(thing) {
 
 // cause: "()=>0"
 // cause: "(function (){}())"
 // cause: "function aa(){}"
 
-        if (thing.arity === "statement" && blockage.body !== true) {
+            if (thing.arity === "statement" && blockage.body !== true) {
 
 // cause: "if(0){function aa(){}\n}"
 
-            warn("unexpected_a", thing);
-        }
-        stack.push(functionage);
-        block_stack.push(blockage);
-        functionage = thing;
-        blockage = thing;
-        thing.live = [];
-        if (typeof thing.name === "object") {
-            thing.name.dead = false;
-            thing.name.init = true;
-        }
-        if (thing.extra === "get") {
-            if (thing.parameters.length !== 0) {
+                warn("unexpected_a", thing);
+            }
+            function_stack.push(functionage);
+            block_stack.push(blockage);
+            functionage = thing;
+            blockage = thing;
+            thing.live = [];
+            if (typeof thing.name === "object") {
+                thing.name.dead = false;
+                thing.name.init = true;
+            }
+            if (thing.extra === "get") {
+                if (thing.parameters.length !== 0) {
 
 // cause: "/*jslint getset*/\naa={get aa(aa){}}"
 
-                warn("bad_get", thing);
-            }
-        } else if (thing.extra === "set") {
-            if (thing.parameters.length !== 1) {
+                    warn("bad_get", thing);
+                }
+            } else if (thing.extra === "set") {
+                if (thing.parameters.length !== 1) {
 
 // cause: "/*jslint getset*/\naa={set aa(){}}"
 
-                warn("bad_set", thing);
+                    warn("bad_set", thing);
+                }
             }
+            thing.parameters.forEach(function (name) {
+                walk_expression(name.expression);
+                if (name.id === "{" || name.id === "[") {
+                    name.names.forEach(subactivate);
+                } else {
+                    name.dead = false;
+                    name.init = true;
+                }
+            });
         }
-        thing.parameters.forEach(function (name) {
-            walk_expression(name.expression);
-            if (name.id === "{" || name.id === "[") {
-                name.names.forEach(subactivate);
-            } else {
-                name.dead = false;
-                name.init = true;
-            }
-        });
-    }
 
-    function bitwise_check(thing) {
+        function bitwise_check(thing) {
 
 // These are the bitwise operators.
 
-        switch (!option_object.bitwise && thing.id) {
-        case "&":
-        case "&=":
-        case "<<":
-        case "<<=":
-        case ">>":
-        case ">>=":
-        case ">>>":
-        case ">>>=":
-        case "^":
-        case "^=":
-        case "|":
-        case "|=":
-        case "~":
+            switch (!option_object.bitwise && thing.id) {
+            case "&":
+            case "&=":
+            case "<<":
+            case "<<=":
+            case ">>":
+            case ">>=":
+            case ">>>":
+            case ">>>=":
+            case "^":
+            case "^=":
+            case "|":
+            case "|=":
+            case "~":
 
 // cause: "0&0"
 // cause: "0&=0"
@@ -3908,435 +5162,441 @@ function jslint(
 // cause: "0|=0"
 // cause: "~0"
 
-            warn("unexpected_a", thing);
-            break;
-        }
-        if (
-            thing.id !== "("
-            && thing.id !== "&&"
-            && thing.id !== "||"
-            && thing.id !== "="
-            && Array.isArray(thing.expression)
-            && thing.expression.length === 2
-            && (
-                relationop[thing.expression[0].id] === true
-                || relationop[thing.expression[1].id] === true
-            )
-        ) {
+                warn("unexpected_a", thing);
+                break;
+            }
+            if (
+                thing.id !== "("
+                && thing.id !== "&&"
+                && thing.id !== "||"
+                && thing.id !== "="
+                && Array.isArray(thing.expression)
+                && thing.expression.length === 2
+                && (
+                    relationop[thing.expression[0].id] === true
+                    || relationop[thing.expression[1].id] === true
+                )
+            ) {
 
 // cause: "0<0<0"
 
-            warn("unexpected_a", thing);
+                warn("unexpected_a", thing);
+            }
         }
-    }
 
-    function pop_block() {
-        blockage.live.forEach(function (name) {
-            name.dead = true;
-        });
-        delete blockage.live;
-        blockage = block_stack.pop();
-    }
+        function pop_block() {
+            blockage.live.forEach(function (name) {
+                name.dead = true;
+            });
+            delete blockage.live;
+            blockage = block_stack.pop();
+        }
 
-    function action_var(thing) {
-        thing.names.forEach(function (name) {
-            name.dead = false;
-            if (name.expression !== undefined) {
-                walk_expression(name.expression);
-                assert_or_throw(
-                    !(name.id === "{" || name.id === "["),
-                    `Expected !(name.id === "{" || name.id === "[").`
-                );
+        function action_var(thing) {
+            thing.names.forEach(function (name) {
+                name.dead = false;
+                if (name.expression !== undefined) {
+                    walk_expression(name.expression);
+                    assert_or_throw(
+                        !(name.id === "{" || name.id === "["),
+                        `Expected !(name.id === "{" || name.id === "[").`
+                    );
 //          Probably deadcode.
 //          if (name.id === "{" || name.id === "[") {
 //              name.names.forEach(subactivate);
 //          } else {
 //              name.init = true;
 //          }
-                name.init = true;
-            }
-            blockage.live.push(name);
-        });
-    }
+                    name.init = true;
+                }
+                blockage.live.push(name);
+            });
+        }
 
-    preaction("assignment", bitwise_check);
-    preaction("binary", bitwise_check);
-    preaction("binary", function (thing) {
-        if (relationop[thing.id] === true) {
-            const left = thing.expression[0];
-            const right = thing.expression[1];
-            if (left.id === "NaN" || right.id === "NaN") {
+        function init_variable(name) {
+            const the_variable = lookup(name);
+            if (the_variable !== undefined) {
+                if (the_variable.writable) {
+                    the_variable.init = true;
+                    return;
+                }
+            }
+            warn("bad_assignment_a", name);
+        }
+
+        function postaction_function(thing) {
+            delete functionage.finally;
+            delete functionage.loop;
+            delete functionage.switch;
+            delete functionage.try;
+            functionage = function_stack.pop();
+            if (thing.wrapped) {
+
+// cause: "aa=(function(){})"
+
+                warn("unexpected_parens", thing);
+            }
+            return pop_block();
+        }
+
+        preaction = action(pres);
+        postaction = action(posts);
+        preamble = amble(pres);
+        postamble = amble(posts);
+
+        preaction("assignment", bitwise_check);
+        preaction("binary", bitwise_check);
+        preaction("binary", function (thing) {
+            if (relationop[thing.id] === true) {
+                const left = thing.expression[0];
+                const right = thing.expression[1];
+                if (left.id === "NaN" || right.id === "NaN") {
 
 // cause: "NaN===NaN"
 
-                warn("number_isNaN", thing);
-            } else if (left.id === "typeof") {
-                if (right.id !== "(string)") {
-                    if (right.id !== "typeof") {
+                    warn("number_isNaN", thing);
+                } else if (left.id === "typeof") {
+                    if (right.id !== "(string)") {
+                        if (right.id !== "typeof") {
 
 // cause: "typeof 0===0"
 
-                        warn("expected_string_a", right);
-                    }
-                } else {
-                    const value = right.value;
-                    if (value === "null" || value === "undefined") {
+                            warn("expected_string_a", right);
+                        }
+                    } else {
+                        const value = right.value;
+                        if (value === "null" || value === "undefined") {
 
 // cause: "typeof aa===\"undefined\""
 
-                        warn("unexpected_typeof_a", right, value);
-                    } else if (
-                        value !== "boolean"
-                        && value !== "function"
-                        && value !== "number"
-                        && value !== "object"
-                        && value !== "string"
-                        && value !== "symbol"
-                    ) {
+                            warn("unexpected_typeof_a", right, value);
+                        } else if (
+                            value !== "boolean"
+                            && value !== "function"
+                            && value !== "number"
+                            && value !== "object"
+                            && value !== "string"
+                            && value !== "symbol"
+                        ) {
 
 // cause: "typeof 0===\"aa\""
 
-                        warn("expected_type_string_a", right, value);
+                            warn("expected_type_string_a", right, value);
+                        }
                     }
                 }
             }
-        }
-    });
-    preaction("binary", "==", function (thing) {
+        });
+        preaction("binary", "==", function (thing) {
 
 // cause: "0==0"
 
-        warn("expected_a_b", thing, "===", "==");
-    });
-    preaction("binary", "!=", function (thing) {
+            warn("expected_a_b", thing, "===", "==");
+        });
+        preaction("binary", "!=", function (thing) {
 
 // cause: "0!=0"
 
-        warn("expected_a_b", thing, "!==", "!=");
-    });
-    preaction("binary", "=>", preaction_function);
-    preaction("binary", "||", function (thing) {
-        thing.expression.forEach(function (thang) {
-            if (thang.id === "&&" && !thang.wrapped) {
+            warn("expected_a_b", thing, "!==", "!=");
+        });
+        preaction("binary", "=>", preaction_function);
+        preaction("binary", "||", function (thing) {
+            thing.expression.forEach(function (thang) {
+                if (thang.id === "&&" && !thang.wrapped) {
 
 // cause: "0&&0||0"
 
-                warn("and", thang);
-            }
+                    warn("and", thang);
+                }
+            });
         });
-    });
-    preaction("binary", "(", function (thing) {
-        const left = thing.expression[0];
-        if (
-            left.identifier
-            && functionage.context[left.id] === undefined
-            && typeof functionage.name === "object"
-        ) {
-            const parent = functionage.name.parent;
-            if (parent) {
-                const left_variable = parent.context[left.id];
-                if (
-                    left_variable !== undefined
-                    && left_variable.dead
-                    && left_variable.parent === parent
-                    && left_variable.calls !== undefined
-                    && left_variable.calls[functionage.name.id] !== undefined
-                ) {
-                    left_variable.dead = false;
+        preaction("binary", "(", function (thing) {
+            const left = thing.expression[0];
+            if (
+                left.identifier
+                && functionage.context[left.id] === undefined
+                && typeof functionage.name === "object"
+            ) {
+                const parent = functionage.name.parent;
+                if (parent) {
+                    const left_variable = parent.context[left.id];
+                    if (
+                        left_variable !== undefined
+                        && left_variable.dead
+                        && left_variable.parent === parent
+                        && left_variable.calls !== undefined
+                        && left_variable.calls[functionage.name.id]
+                        !== undefined
+                    ) {
+                        left_variable.dead = false;
+                    }
                 }
             }
-        }
-    });
-    preaction("binary", "in", function (thing) {
+        });
+        preaction("binary", "in", function (thing) {
 
 // cause: "aa in aa"
 
-        warn("infix_in", thing);
-    });
-    preaction("binary", "instanceof", function (thing) {
+            warn("infix_in", thing);
+        });
+        preaction("binary", "instanceof", function (thing) {
 
 // cause: "0 instanceof 0"
 
-        warn("unexpected_a", thing);
-    });
-    preaction("statement", "{", function (thing) {
-        block_stack.push(blockage);
-        blockage = thing;
-        thing.live = [];
-    });
-    preaction("statement", "for", function (thing) {
-        if (thing.name !== undefined) {
-            const the_variable = lookup(thing.name);
-            if (the_variable !== undefined) {
-                the_variable.init = true;
-                if (!the_variable.writable) {
+            warn("unexpected_a", thing);
+        });
+        preaction("statement", "{", function (thing) {
+            block_stack.push(blockage);
+            blockage = thing;
+            thing.live = [];
+        });
+        preaction("statement", "for", function (thing) {
+            if (thing.name !== undefined) {
+                const the_variable = lookup(thing.name);
+                if (the_variable !== undefined) {
+                    the_variable.init = true;
+                    if (!the_variable.writable) {
 
 // cause: "const aa=0;for(aa in aa){}"
 
-                    warn("bad_assignment_a", thing.name);
+                        warn("bad_assignment_a", thing.name);
+                    }
                 }
             }
-        }
-        walk_statement(thing.initial);
-    });
-    preaction("statement", "function", preaction_function);
-    preaction("statement", "try", function (thing) {
-        if (thing.catch !== undefined) {
+            walk_statement(thing.initial);
+        });
+        preaction("statement", "function", preaction_function);
+        preaction("statement", "try", function (thing) {
+            if (thing.catch !== undefined) {
 
 // Create new function-scope for catch-parameter.
 
-            stack.push(functionage);
-            functionage = thing.catch;
-        }
-    });
-    preaction("unary", "~", bitwise_check);
-    preaction("unary", "function", preaction_function);
-    preaction("variable", function (thing) {
-        const the_variable = lookup(thing);
-        if (the_variable !== undefined) {
-            thing.variable = the_variable;
-            the_variable.used += 1;
-        }
-    });
-
-    function init_variable(name) {
-        const the_variable = lookup(name);
-        if (the_variable !== undefined) {
-            if (the_variable.writable) {
-                the_variable.init = true;
-                return;
+                function_stack.push(functionage);
+                functionage = thing.catch;
             }
-        }
-        warn("bad_assignment_a", name);
-    }
-
-    postaction("assignment", "+=", function (thing) {
-        let right = thing.expression[1];
-        if (right.constant) {
-            if (
-                right.value === ""
-                || (right.id === "(number)" && right.value === "0")
-                || right.id === "(boolean)"
-                || right.id === "null"
-                || right.id === "undefined"
-                || Number.isNaN(right.value)
-            ) {
-                warn("unexpected_a", right);
+        });
+        preaction("unary", "~", bitwise_check);
+        preaction("unary", "function", preaction_function);
+        preaction("variable", function (thing) {
+            const the_variable = lookup(thing);
+            if (the_variable !== undefined) {
+                thing.variable = the_variable;
+                the_variable.used += 1;
             }
-        }
-    });
-    postaction("assignment", function (thing) {
+        });
+
+        postaction("assignment", "+=", function (thing) {
+            let right = thing.expression[1];
+            if (right.constant) {
+                if (
+                    right.value === ""
+                    || (right.id === "(number)" && right.value === "0")
+                    || right.id === "(boolean)"
+                    || right.id === "null"
+                    || right.id === "undefined"
+                    || Number.isNaN(right.value)
+                ) {
+                    warn("unexpected_a", right);
+                }
+            }
+        });
+        postaction("assignment", function (thing) {
 
 // Assignment using = sets the init property of a variable. No other assignment
 // operator can do this. A = token keeps that variable (or array of variables
 // in case of destructuring) in its name property.
 
-        const lvalue = thing.expression[0];
-        if (thing.id === "=") {
-            if (thing.names !== undefined) {
+            const lvalue = thing.expression[0];
+            if (thing.id === "=") {
+                if (thing.names !== undefined) {
 
 // cause: "if(0){aa=0}"
 
-                assert_or_throw(
-                    !Array.isArray(thing.names),
-                    `Expected !Array.isArray(thing.names).`
-                );
+                    assert_or_throw(
+                        !Array.isArray(thing.names),
+                        `Expected !Array.isArray(thing.names).`
+                    );
 //          Probably deadcode.
 //          if (Array.isArray(thing.names)) {
 //              thing.names.forEach(init_variable);
 //          } else {
 //              init_variable(thing.names);
 //          }
-                init_variable(thing.names);
-            } else {
-                if (lvalue.id === "[" || lvalue.id === "{") {
-                    lvalue.expression.forEach(function (thing) {
-                        if (thing.variable) {
-                            thing.variable.init = true;
-                        }
-                    });
-                } else if (
-                    lvalue.id === "."
-                    && thing.expression[1].id === "undefined"
-                ) {
+                    init_variable(thing.names);
+                } else {
+                    if (lvalue.id === "[" || lvalue.id === "{") {
+                        lvalue.expression.forEach(function (thing) {
+                            if (thing.variable) {
+                                thing.variable.init = true;
+                            }
+                        });
+                    } else if (
+                        lvalue.id === "."
+                        && thing.expression[1].id === "undefined"
+                    ) {
 
 // cause: "aa.aa=undefined"
 
-                    warn(
-                        "expected_a_b",
-                        lvalue.expression,
-                        "delete",
-                        "undefined"
-                    );
+                        warn(
+                            "expected_a_b",
+                            lvalue.expression,
+                            "delete",
+                            "undefined"
+                        );
+                    }
                 }
-            }
-        } else {
-            if (lvalue.arity === "variable") {
-                if (!lvalue.variable || lvalue.variable.writable !== true) {
-                    warn("bad_assignment_a", lvalue);
+            } else {
+                if (lvalue.arity === "variable") {
+                    if (!lvalue.variable || lvalue.variable.writable !== true) {
+                        warn("bad_assignment_a", lvalue);
+                    }
                 }
-            }
-            const right = syntax[thing.expression[1].id];
-            if (
-                right !== undefined
-                && (
-                    right.id === "function"
-                    || right.id === "=>"
-                    || (
-                        right.constant
-                        && right.id !== "(number)"
-                        && (right.id !== "(string)" || thing.id !== "+=")
+                const right = syntax_object[thing.expression[1].id];
+                if (
+                    right !== undefined
+                    && (
+                        right.id === "function"
+                        || right.id === "=>"
+                        || (
+                            right.constant
+                            && right.id !== "(number)"
+                            && (right.id !== "(string)" || thing.id !== "+=")
+                        )
                     )
-                )
-            ) {
+                ) {
 
 // cause: "aa+=undefined"
 
-                warn("unexpected_a", thing.expression[1]);
+                    warn("unexpected_a", thing.expression[1]);
+                }
             }
-        }
-    });
+        });
 
-    function postaction_function(thing) {
-        delete functionage.finally;
-        delete functionage.loop;
-        delete functionage.switch;
-        delete functionage.try;
-        functionage = stack.pop();
-        if (thing.wrapped) {
-
-// cause: "aa=(function(){})"
-
-            warn("unexpected_parens", thing);
-        }
-        return pop_block();
-    }
-
-    postaction("binary", function (thing) {
-        let right;
-        if (relationop[thing.id]) {
-            if (
-                is_weird(thing.expression[0])
-                || is_weird(thing.expression[1])
-                || are_similar(thing.expression[0], thing.expression[1])
-                || (
-                    thing.expression[0].constant === true
-                    && thing.expression[1].constant === true
-                )
-            ) {
+        postaction("binary", function (thing) {
+            let right;
+            if (relationop[thing.id]) {
+                if (
+                    is_weird(thing.expression[0])
+                    || is_weird(thing.expression[1])
+                    || are_similar(thing.expression[0], thing.expression[1])
+                    || (
+                        thing.expression[0].constant === true
+                        && thing.expression[1].constant === true
+                    )
+                ) {
 
 // cause: "if(0===0){0}"
 
-                warn("weird_relation_a", thing);
+                    warn("weird_relation_a", thing);
+                }
             }
-        }
-        if (thing.id === "+") {
-            if (!option_object.convert) {
-                if (thing.expression[0].value === "") {
+            if (thing.id === "+") {
+                if (!option_object.convert) {
+                    if (thing.expression[0].value === "") {
 
 // cause: "\"\"+0"
 
-                    warn("expected_a_b", thing, "String(...)", "\"\" +");
-                } else if (thing.expression[1].value === "") {
+                        warn("expected_a_b", thing, "String(...)", "\"\" +");
+                    } else if (thing.expression[1].value === "") {
 
 // cause: "0+\"\""
 
-                    warn("expected_a_b", thing, "String(...)", "+ \"\"");
+                        warn("expected_a_b", thing, "String(...)", "+ \"\"");
+                    }
                 }
-            }
-        } else if (thing.id === "[") {
-            if (thing.expression[0].id === "window") {
+            } else if (thing.id === "[") {
+                if (thing.expression[0].id === "window") {
 
 // cause: "aa=window[0]"
 
-                warn("weird_expression_a", thing, "window[...]");
-            }
-            if (thing.expression[0].id === "self") {
+                    warn("weird_expression_a", thing, "window[...]");
+                }
+                if (thing.expression[0].id === "self") {
 
 // cause: "aa=self[0]"
 
-                warn("weird_expression_a", thing, "self[...]");
-            }
-        } else if (thing.id === "." || thing.id === "?.") {
-            if (thing.expression.id === "RegExp") {
+                    warn("weird_expression_a", thing, "self[...]");
+                }
+            } else if (thing.id === "." || thing.id === "?.") {
+                if (thing.expression.id === "RegExp") {
 
 // cause: "aa=RegExp.aa"
 
-                warn("weird_expression_a", thing);
-            }
-        } else if (thing.id !== "=>" && thing.id !== "(") {
-            right = thing.expression[1];
-            if (
-                (thing.id === "+" || thing.id === "-")
-                && right.id === thing.id
-                && right.arity === "unary"
-                && !right.wrapped
-            ) {
+                    warn("weird_expression_a", thing);
+                }
+            } else if (thing.id !== "=>" && thing.id !== "(") {
+                right = thing.expression[1];
+                if (
+                    (thing.id === "+" || thing.id === "-")
+                    && right.id === thing.id
+                    && right.arity === "unary"
+                    && !right.wrapped
+                ) {
 
 // cause: "0- -0"
 
-                warn("wrap_unary", right);
+                    warn("wrap_unary", right);
+                }
+                if (
+                    thing.expression[0].constant === true
+                    && right.constant === true
+                ) {
+                    thing.constant = true;
+                }
             }
+        });
+        postaction("binary", "&&", function (thing) {
             if (
-                thing.expression[0].constant === true
-                && right.constant === true
+                is_weird(thing.expression[0])
+                || are_similar(thing.expression[0], thing.expression[1])
+                || thing.expression[0].constant === true
+                || thing.expression[1].constant === true
             ) {
-                thing.constant = true;
-            }
-        }
-    });
-    postaction("binary", "&&", function (thing) {
-        if (
-            is_weird(thing.expression[0])
-            || are_similar(thing.expression[0], thing.expression[1])
-            || thing.expression[0].constant === true
-            || thing.expression[1].constant === true
-        ) {
 
 // cause: "aa=(``?``:``)&&(``?``:``)"
 // cause: "aa=0&&0"
 // cause: "aa=`${0}`&&`${0}`"
 
-            warn("weird_condition_a", thing);
-        }
-    });
-    postaction("binary", "||", function (thing) {
-        if (
-            is_weird(thing.expression[0])
-            || are_similar(thing.expression[0], thing.expression[1])
-            || thing.expression[0].constant === true
-        ) {
+                warn("weird_condition_a", thing);
+            }
+        });
+        postaction("binary", "||", function (thing) {
+            if (
+                is_weird(thing.expression[0])
+                || are_similar(thing.expression[0], thing.expression[1])
+                || thing.expression[0].constant === true
+            ) {
 
 // cause: "aa=0||0"
 
-            warn("weird_condition_a", thing);
-        }
-    });
-    postaction("binary", "=>", postaction_function);
-    postaction("binary", "(", function (thing) {
-        let left = thing.expression[0];
-        let the_new;
-        let arg;
-        if (left.id === "new") {
-            the_new = left;
-            left = left.expression;
-        }
-        if (left.id === "function") {
-            if (!thing.wrapped) {
+                warn("weird_condition_a", thing);
+            }
+        });
+        postaction("binary", "=>", postaction_function);
+        postaction("binary", "(", function (thing) {
+            let left = thing.expression[0];
+            let the_new;
+            let arg;
+            if (left.id === "new") {
+                the_new = left;
+                left = left.expression;
+            }
+            if (left.id === "function") {
+                if (!thing.wrapped) {
 
 // cause: "aa=function(){}()"
 
-                warn("wrap_immediate", thing);
-            }
-        } else if (left.identifier) {
-            if (the_new !== undefined) {
-                if (
-                    left.id[0] > "Z"
-                    || left.id === "Boolean"
-                    || left.id === "Number"
-                    || left.id === "String"
-                    || left.id === "Symbol"
-                ) {
+                    warn("wrap_immediate", thing);
+                }
+            } else if (left.identifier) {
+                if (the_new !== undefined) {
+                    if (
+                        left.id[0] > "Z"
+                        || left.id === "Boolean"
+                        || left.id === "Number"
+                        || left.id === "String"
+                        || left.id === "Symbol"
+                    ) {
 
 // cause: "new Boolean()"
 // cause: "new Number()"
@@ -4344,308 +5604,262 @@ function jslint(
 // cause: "new Symbol()"
 // cause: "new aa()"
 
-                    warn("unexpected_a", the_new);
-                } else if (left.id === "Function") {
-                    if (!option_object.eval) {
+                        warn("unexpected_a", the_new);
+                    } else if (left.id === "Function") {
+                        if (!option_object.eval) {
 
 // cause: "new Function()"
 
-                        warn("unexpected_a", left, "new Function");
-                    }
-                } else if (left.id === "Array") {
-                    arg = thing.expression;
-                    if (arg.length !== 2 || arg[1].id === "(string)") {
+                            warn("unexpected_a", left, "new Function");
+                        }
+                    } else if (left.id === "Array") {
+                        arg = thing.expression;
+                        if (arg.length !== 2 || arg[1].id === "(string)") {
 
 // cause: "new Array()"
 
-                        warn("expected_a_b", left, "[]", "new Array");
-                    }
-                } else if (left.id === "Object") {
+                            warn("expected_a_b", left, "[]", "new Array");
+                        }
+                    } else if (left.id === "Object") {
 
 // cause: "new Object()"
 
-                    warn(
-                        "expected_a_b",
-                        left,
-                        "Object.create(null)",
-                        "new Object"
-                    );
-                }
-            } else {
-                if (
-                    left.id[0] >= "A"
-                    && left.id[0] <= "Z"
-                    && left.id !== "Boolean"
-                    && left.id !== "Number"
-                    && left.id !== "String"
-                    && left.id !== "Symbol"
-                ) {
+                        warn(
+                            "expected_a_b",
+                            left,
+                            "Object.create(null)",
+                            "new Object"
+                        );
+                    }
+                } else {
+                    if (
+                        left.id[0] >= "A"
+                        && left.id[0] <= "Z"
+                        && left.id !== "Boolean"
+                        && left.id !== "Number"
+                        && left.id !== "String"
+                        && left.id !== "Symbol"
+                    ) {
 
 // cause: "let Aa=Aa()"
 
-                    warn(
-                        "expected_a_before_b",
-                        left,
-                        "new",
-                        artifact(left)
-                    );
+                        warn(
+                            "expected_a_before_b",
+                            left,
+                            "new",
+                            artifact(left)
+                        );
+                    }
                 }
-            }
-        } else if (left.id === ".") {
-            let cack = the_new !== undefined;
-            if (left.expression.id === "Date" && left.name.id === "UTC") {
+            } else if (left.id === ".") {
+                let cack = the_new !== undefined;
+                if (left.expression.id === "Date" && left.name.id === "UTC") {
 
 // cause: "new Date.UTC()"
 
-                cack = !cack;
-            }
-            if (rx_cap.test(left.name.id) !== cack) {
-                if (the_new !== undefined) {
+                    cack = !cack;
+                }
+                if (rx_cap.test(left.name.id) !== cack) {
+                    if (the_new !== undefined) {
 
 // cause: "new Date.UTC()"
 
-                    warn("unexpected_a", the_new);
-                } else {
+                        warn("unexpected_a", the_new);
+                    } else {
 
 // cause: "let Aa=Aa.Aa()"
 
-                    warn(
-                        "expected_a_before_b",
-                        left.expression,
-                        "new",
-                        left.name.id
-                    );
+                        warn(
+                            "expected_a_before_b",
+                            left.expression,
+                            "new",
+                            left.name.id
+                        );
+                    }
                 }
-            }
-            if (left.name.id === "getTime") {
-                const paren = left.expression;
-                if (paren.id === "(") {
-                    const array = paren.expression;
-                    if (array.length === 1) {
-                        const new_date = array[0];
-                        if (
-                            new_date.id === "new"
-                            && new_date.expression.id === "Date"
-                        ) {
+                if (left.name.id === "getTime") {
+                    const paren = left.expression;
+                    if (paren.id === "(") {
+                        const array = paren.expression;
+                        if (array.length === 1) {
+                            const new_date = array[0];
+                            if (
+                                new_date.id === "new"
+                                && new_date.expression.id === "Date"
+                            ) {
 
 // cause: "new Date().getTime()"
 
-                            warn(
-                                "expected_a_b",
-                                new_date,
-                                "Date.now()",
-                                "new Date().getTime()"
-                            );
+                                warn(
+                                    "expected_a_b",
+                                    new_date,
+                                    "Date.now()",
+                                    "new Date().getTime()"
+                                );
+                            }
                         }
                     }
                 }
             }
-        }
-    });
-    postaction("binary", "[", function (thing) {
-        if (thing.expression[0].id === "RegExp") {
+        });
+        postaction("binary", "[", function (thing) {
+            if (thing.expression[0].id === "RegExp") {
 
 // cause: "aa=RegExp[0]"
 
-            warn("weird_expression_a", thing);
-        }
-        if (is_weird(thing.expression[1])) {
+                warn("weird_expression_a", thing);
+            }
+            if (is_weird(thing.expression[1])) {
 
 // cause: "aa[[0]]"
 
-            warn("weird_expression_a", thing.expression[1]);
-        }
-    });
-    postaction("statement", "{", pop_block);
-    postaction("statement", "const", action_var);
-    postaction("statement", "export", top_level_only);
-    postaction("statement", "for", function (thing) {
-        walk_statement(thing.inc);
-    });
-    postaction("statement", "function", postaction_function);
-    postaction("statement", "import", function (the_thing) {
-        const name = the_thing.name;
-        if (name) {
-            if (Array.isArray(name)) {
-                name.forEach(function (name) {
+                warn("weird_expression_a", thing.expression[1]);
+            }
+        });
+        postaction("statement", "{", pop_block);
+        postaction("statement", "const", action_var);
+        postaction("statement", "export", top_level_only);
+        postaction("statement", "for", function (thing) {
+            walk_statement(thing.inc);
+        });
+        postaction("statement", "function", postaction_function);
+        postaction("statement", "import", function (the_thing) {
+            const name = the_thing.name;
+            if (name) {
+                if (Array.isArray(name)) {
+                    name.forEach(function (name) {
+                        name.dead = false;
+                        name.init = true;
+                        blockage.live.push(name);
+                    });
+                } else {
                     name.dead = false;
                     name.init = true;
                     blockage.live.push(name);
-                });
-            } else {
-                name.dead = false;
-                name.init = true;
-                blockage.live.push(name);
+                }
+                return top_level_only(the_thing);
             }
-            return top_level_only(the_thing);
-        }
-    });
-    postaction("statement", "let", action_var);
-    postaction("statement", "try", function (thing) {
-        if (thing.catch !== undefined) {
-            const the_name = thing.catch.name;
-            if (the_name !== undefined) {
-                const the_variable = functionage.context[the_name.id];
-                the_variable.dead = false;
-                the_variable.init = true;
-            }
-            walk_statement(thing.catch.block);
+        });
+        postaction("statement", "let", action_var);
+        postaction("statement", "try", function (thing) {
+            if (thing.catch !== undefined) {
+                const the_name = thing.catch.name;
+                if (the_name !== undefined) {
+                    const the_variable = functionage.context[the_name.id];
+                    the_variable.dead = false;
+                    the_variable.init = true;
+                }
+                walk_statement(thing.catch.block);
 
 // Restore previous function-scope after catch-block.
 
-            functionage = stack.pop();
-        }
-    });
-    postaction("statement", "var", action_var);
-    postaction("ternary", function (thing) {
-        if (
-            is_weird(thing.expression[0])
-            || thing.expression[0].constant === true
-            || are_similar(thing.expression[1], thing.expression[2])
-        ) {
-            warn("unexpected_a", thing);
-        } else if (are_similar(thing.expression[0], thing.expression[1])) {
+                functionage = function_stack.pop();
+            }
+        });
+        postaction("statement", "var", action_var);
+        postaction("ternary", function (thing) {
+            if (
+                is_weird(thing.expression[0])
+                || thing.expression[0].constant === true
+                || are_similar(thing.expression[1], thing.expression[2])
+            ) {
+                warn("unexpected_a", thing);
+            } else if (are_similar(thing.expression[0], thing.expression[1])) {
 
 // cause: "aa?aa:0"
 
-            warn("expected_a_b", thing, "||", "?");
-        } else if (are_similar(thing.expression[0], thing.expression[2])) {
+                warn("expected_a_b", thing, "||", "?");
+            } else if (are_similar(thing.expression[0], thing.expression[2])) {
 
 // cause: "aa?0:aa"
 
-            warn("expected_a_b", thing, "&&", "?");
-        } else if (
-            thing.expression[1].id === "true"
-            && thing.expression[2].id === "false"
-        ) {
+                warn("expected_a_b", thing, "&&", "?");
+            } else if (
+                thing.expression[1].id === "true"
+                && thing.expression[2].id === "false"
+            ) {
 
 // cause: "aa?true:false"
 
-            warn("expected_a_b", thing, "!!", "?");
-        } else if (
-            thing.expression[1].id === "false"
-            && thing.expression[2].id === "true"
-        ) {
+                warn("expected_a_b", thing, "!!", "?");
+            } else if (
+                thing.expression[1].id === "false"
+                && thing.expression[2].id === "true"
+            ) {
 
 // cause: "aa?false:true"
 
-            warn("expected_a_b", thing, "!", "?");
-        } else if (
-            thing.expression[0].wrapped !== true
-            && (
-                thing.expression[0].id === "||"
-                || thing.expression[0].id === "&&"
-            )
-        ) {
+                warn("expected_a_b", thing, "!", "?");
+            } else if (
+                thing.expression[0].wrapped !== true
+                && (
+                    thing.expression[0].id === "||"
+                    || thing.expression[0].id === "&&"
+                )
+            ) {
 
 // cause: "(aa&&!aa?0:1)"
 
-            warn("wrap_condition", thing.expression[0]);
-        }
-    });
-    postaction("unary", function (thing) {
-        if (thing.id === "`") {
-            if (thing.expression.every(function (thing) {
-                return thing.constant;
-            })) {
-                thing.constant = true;
+                warn("wrap_condition", thing.expression[0]);
             }
-        } else if (thing.id === "!") {
-            if (thing.expression.constant === true) {
-                warn("unexpected_a", thing);
-            }
-        } else if (thing.id === "!!") {
-            if (!option_object.convert) {
+        });
+        postaction("unary", function (thing) {
+            if (thing.id === "`") {
+                if (thing.expression.every(function (thing) {
+                    return thing.constant;
+                })) {
+                    thing.constant = true;
+                }
+            } else if (thing.id === "!") {
+                if (thing.expression.constant === true) {
+                    warn("unexpected_a", thing);
+                }
+            } else if (thing.id === "!!") {
+                if (!option_object.convert) {
 
 // cause: "!!0"
 
-                warn("expected_a_b", thing, "Boolean(...)", "!!");
+                    warn("expected_a_b", thing, "Boolean(...)", "!!");
+                }
+            } else if (
+                thing.id !== "["
+                && thing.id !== "{"
+                && thing.id !== "function"
+                && thing.id !== "new"
+            ) {
+                if (thing.expression.constant === true) {
+                    thing.constant = true;
+                }
             }
-        } else if (
-            thing.id !== "["
-            && thing.id !== "{"
-            && thing.id !== "function"
-            && thing.id !== "new"
-        ) {
-            if (thing.expression.constant === true) {
-                thing.constant = true;
-            }
-        }
-    });
-    postaction("unary", "function", postaction_function);
-    postaction("unary", "+", function (thing) {
-        if (!option_object.convert) {
+        });
+        postaction("unary", "function", postaction_function);
+        postaction("unary", "+", function (thing) {
+            const right = thing.expression;
+            if (!option_object.convert) {
 
 // cause: "aa=+0"
 
-            warn("expected_a_b", thing, "Number(...)", "+");
-        }
-        const right = thing.expression;
-        if (right.id === "(" && right.expression[0].id === "new") {
-            warn("unexpected_a_before_b", thing, "+", "new");
-        } else if (
-            right.constant
-            || right.id === "{"
-            || (right.id === "[" && right.arity !== "binary")
-        ) {
-            warn("unexpected_a", thing, "+");
-        }
-    });
-
-    function delve(the_function) {
-        Object.keys(the_function.context).forEach(function (id) {
-            if (id !== "ignore") {
-                const name = the_function.context[id];
-                if (name.parent === the_function) {
-
-// cause: "let aa=function bb(){return;};"
-
-                    if (
-                        name.used === 0
-                        && assert_or_throw(
-                            name.role !== "function",
-                            `Expected name.role !== "function".`
-                        )
-//                  Probably deadcode.
-//                  && (
-//                      name.role !== "function"
-//                      || name.parent.arity !== "unary"
-//                  )
-                    ) {
-
-// cause: "/*jslint node*/\nlet aa;"
-// cause: "function aa(aa){return;}"
-
-                        warn("unused_a", name);
-                    } else if (!name.init) {
-
-// cause: "/*jslint node*/\nlet aa;aa();"
-
-                        warn("uninitialized_a", name);
-                    }
-                }
+                warn("expected_a_b", thing, "Number(...)", "+");
             }
-
-// cause: "function aa(ignore){return;}"
-
+            if (right.id === "(" && right.expression[0].id === "new") {
+                warn("unexpected_a_before_b", thing, "+", "new");
+            } else if (
+                right.constant
+                || right.id === "{"
+                || (right.id === "[" && right.arity !== "binary")
+            ) {
+                warn("unexpected_a", thing, "+");
+            }
         });
+
+        walk_statement(token_tree);
     }
 
-    function uninitialized_and_unused() {
 
-// Delve into the functions looking for variables that were not initialized
-// or used. If the file imports or exports, then its global object is also
-// delved.
+    function phase5_whitage() {
 
-        if (mode_module === true || option_object.node) {
-            delve(global);
-        }
-        functions.forEach(delve);
-    }
+// PHASE 5. Check whitespace between tokens in <token_array>.
 
-// Go through the token list, looking at usage of whitespace.
-
-    function whitage() {
         let closer = "(end)";
 
 // free = false
@@ -4675,25 +5889,6 @@ function jslint(
         let opening = true;
         let right;
 
-        function pop() {
-            const previous = stack.pop();
-            closer = previous.closer;
-            free = previous.free;
-            margin = previous.margin;
-            open = previous.open;
-            opening = previous.opening;
-        }
-
-        function push() {
-            stack.push({
-                closer,
-                free,
-                margin,
-                open,
-                opening
-            });
-        }
-
         function expected_at(at) {
             assert_or_throw(
                 !(right === undefined),
@@ -4722,22 +5917,43 @@ function jslint(
             }
         }
 
-        function no_space_only() {
-            if (
-                left.id !== "(global)"
-                && left.nr + 1 === right.nr
-                && (
-                    left.line !== right.line
-                    || left.thru !== right.from
-                )
-            ) {
-                warn(
-                    "unexpected_space_a_b",
-                    right,
-                    artifact(left),
-                    artifact(right)
-                );
-            }
+        function delve(the_function) {
+            Object.keys(the_function.context).forEach(function (id) {
+                if (id !== "ignore") {
+                    const name = the_function.context[id];
+                    if (name.parent === the_function) {
+
+// cause: "let aa=function bb(){return;};"
+
+                        if (
+                            name.used === 0
+                            && assert_or_throw(
+                                name.role !== "function",
+                                `Expected name.role !== "function".`
+                            )
+//                  Probably deadcode.
+//                  && (
+//                      name.role !== "function"
+//                      || name.parent.arity !== "unary"
+//                  )
+                        ) {
+
+// cause: "/*jslint node*/\nlet aa;"
+// cause: "function aa(aa){return;}"
+
+                            warn("unused_a", name);
+                        } else if (!name.init) {
+
+// cause: "/*jslint node*/\nlet aa;aa();"
+
+                            warn("uninitialized_a", name);
+                        }
+                    }
+                }
+
+// cause: "function aa(ignore){return;}"
+
+            });
         }
 
         function no_space() {
@@ -4800,10 +6016,17 @@ function jslint(
             }
         }
 
-        function one_space_only() {
-            if (left.line !== right.line || left.thru + 1 !== right.from) {
+        function no_space_only() {
+            if (
+                left.id !== "(global)"
+                && left.nr + 1 === right.nr
+                && (
+                    left.line !== right.line
+                    || left.thru !== right.from
+                )
+            ) {
                 warn(
-                    "expected_space_a_b",
+                    "unexpected_space_a_b",
                     right,
                     artifact(left),
                     artifact(right)
@@ -4828,7 +6051,54 @@ function jslint(
             }
         }
 
-        stack = [];
+        function one_space_only() {
+            if (left.line !== right.line || left.thru + 1 !== right.from) {
+                warn(
+                    "expected_space_a_b",
+                    right,
+                    artifact(left),
+                    artifact(right)
+                );
+            }
+        }
+
+        function pop() {
+            const previous = function_stack.pop();
+            closer = previous.closer;
+            free = previous.free;
+            margin = previous.margin;
+            open = previous.open;
+            opening = previous.opening;
+        }
+
+        function push() {
+            function_stack.push({
+                closer,
+                free,
+                margin,
+                open,
+                opening
+            });
+        }
+
+// Delve into the functions looking for variables that were not initialized
+// or used. If the file imports or exports, then its global object is also
+// delved.
+
+//      uninitialized_and_unused();
+        if (mode_module === true || option_object.node) {
+            delve(global);
+        }
+        function_array.forEach(delve);
+
+        if (option_object.white) {
+            return;
+        }
+
+// Go through the token list, looking at usage of whitespace.
+
+//      whitage();
+        function_stack = [];
         token_array.forEach(function (the_token) {
             right = the_token;
             if (right.id === "(comment)" || right.id === "(end)") {
@@ -5198,1116 +6468,15 @@ function jslint(
         });
     }
 
-    function line_next() {
-
-// Put the next line of source in line_source. If the line contains tabs,
-// replace them with spaces and give a warning. Also warn if the line contains
-// unsafe characters or is too damn long.
-
-        let at;
-        if (
-            !option_object.long
-            && line_whole.length > 80
-            && line_disable === undefined
-            && !mode_json
-            && token_1
-            && !mode_regexp
-        ) {
-
-// cause: "too_long"
-
-            warn_at("too_long", line);
-        }
-        column = 0;
-        line += 1;
-        mode_regexp = false;
-        line_source = undefined;
-        line_whole = "";
-        if (line_array[line] === undefined) {
-            return line_source;
-        }
-        line_source = line_array[line].line_source;
-        line_whole = line_source;
-
-// Scan each line for following ignore-directives:
-// "/*jslint-disable*/"
-// "/*jslint-enable*/"
-// "//jslint-quiet"
-
-        if (line_source === "/*jslint-disable*/") {
-
-// cause: "/*jslint-disable*/"
-
-            line_disable = line;
-        } else if (line_source === "/*jslint-enable*/") {
-            if (line_disable === undefined) {
-
-// cause: "/*jslint-enable*/"
-
-                stop_at("unopened_enable", line);
-            }
-            line_disable = undefined;
-        } else if (line_source.endsWith(" //jslint-quiet")) {
-
-// cause: "0 //jslint-quiet"
-
-            line_array[line].directive_quiet = true;
-        }
-        if (line_disable !== undefined) {
-
-// cause: "/*jslint-disable*/\n0"
-
-            line_source = "";
-        }
-        at = line_source.search(rx_tab);
-        if (at >= 0) {
-            if (!option_object.white) {
-
-// cause: "\t"
-
-                warn_at("use_spaces", line, at);
-            }
-            line_source = line_source.replace(rx_tab, " ");
-        }
-        if (!option_object.white && line_source.endsWith(" ")) {
-
-// cause: " "
-
-            warn_at("unexpected_trailing_space", line, line_source.length - 1);
-        }
-        return line_source;
-    }
-
-// Most tokens, including the identifiers, operators, and punctuators, can be
-// found with a regular expression. Regular expressions cannot correctly match
-// regular expression literals, so we will match those the hard way. String
-// literals and number literals can be matched by regular expressions, but they
-// don't provide good warnings. The functions char_after, char_before,
-// read_some_digits, and char_after_escape help in the parsing of literals.
-
-    function char_after(match) {
-
-// Get the next character from the source line. Remove it from the line_source,
-// and append it to the snippet. Optionally check that the previous character
-// matched an expected value.
-
-        if (match !== undefined && char !== match) {
-            return (
-                char === ""
-
-// cause: "aa=/[/"
-
-                ? stop_at("expected_a", line, column - 1, match, char)
-
-// cause: "aa=/aa{/"
-
-                : stop_at("expected_a_b", line, column, match, char)
-            );
-        }
-        char = line_source.slice(0, 1);
-        line_source = line_source.slice(1);
-        snippet += char || " ";
-        column += 1;
-        return char;
-    }
-
-    function char_before() {
-
-// Back up one character by moving a character from the end of the snippet to
-// the front of the line_source.
-
-        char = snippet.slice(-1);
-        line_source = char + line_source;
-        column -= char.length;
-
-// Remove last character from snippet.
-
-        snippet = snippet.slice(0, -1);
-        return char;
-    }
-
-    function read_some_digits(rx, quiet) {
-        const digits = line_source.match(rx)[0];
-        const length = digits.length;
-        if (!quiet && length === 0) {
-
-// cause: "0x"
-
-            warn_at("expected_digits_after_a", line, column, snippet);
-        }
-        column += length;
-        line_source = line_source.slice(length);
-        snippet += digits;
-        char_after();
-        return length;
-    }
-
-    function char_after_escape(extra) {
-
-// Validate char after escape "\\".
-
-        char_after("\\");
-        switch (char) {
-        case "":
-
-// cause: "\"\\"
-
-            return stop_at("unclosed_string", line, column);
-        case "/":
-        case "\\":
-        case "`":
-        case "b":
-        case "f":
-        case "n":
-        case "r":
-        case "t":
-            return char_after();
-        case "u":
-            if (char_after("u") === "{") {
-                if (mode_json) {
-
-// cause: "[\"\\u{12345}\"]"
-
-                    warn_at("unexpected_a", line, column, char);
-                }
-                if (read_some_digits(rx_hexs) > 5) {
-
-// cause: "\"\\u{123456}\""
-
-                    warn_at("too_many_digits", line, column);
-                }
-                if (char !== "}") {
-
-// cause: "\"\\u{12345\""
-
-                    stop_at("expected_a_before_b", line, column, "}", char);
-                }
-                return char_after();
-            }
-            char_before();
-            if (read_some_digits(rx_hexs, true) < 4) {
-
-// cause: "\"\\u0\""
-
-                warn_at("expected_four_digits", line, column);
-            }
-            return;
-        default:
-            if (extra && extra.indexOf(char) >= 0) {
-                return char_after();
-            }
-
-// cause: "\"\\0\""
-
-            warn_at("unexpected_a_before_b", line, column, "\\", char);
-        }
-    }
-
-    function token_create(id, value, identifier) {
-
-// Create the token object and append it to token_array.
-
-        const the_token = {
-            from,
-            id,
-            identifier: Boolean(identifier),
-            line,
-            nr: token_array.length,
-            thru: column
-        };
-        token_array.push(the_token);
-
-// Directives must appear before the first statement.
-
-        if (id !== "(comment)" && id !== ";") {
-            mode_directive = false;
-        }
-
-// If the token is to have a value, give it one.
-
-        if (value !== undefined) {
-            the_token.value = value;
-        }
-
-// If this token is an identifier that touches a preceding number, or
-// a "/", comment, or regular expression literal that touches a preceding
-// comment or regular expression literal, then give a missing space warning.
-// This warning is not suppressed by option_object.white.
-
-        if (
-            token_prv.line === line
-            && token_prv.thru === from
-            && (id === "(comment)" || id === "(regexp)" || id === "/")
-            && (token_prv.id === "(comment)" || token_prv.id === "(regexp)")
-        ) {
-
-// cause: "/**//**/"
-
-            warn(
-                "expected_space_a_b",
-                the_token,
-                artifact(token_prv),
-                artifact(the_token)
-            );
-        }
-        if (token_prv.id === "." && id === "(number)") {
-
-// cause: ".0"
-
-            warn("expected_a_before_b", token_prv, "0", ".");
-        }
-        if (token_before_slash.id === "." && the_token.identifier) {
-            the_token.dot = true;
-        }
-
-// The previous token is used to detect adjacency problems.
-
-        token_prv = the_token;
-
-// The token_before_slash token is a previous token that was not a comment.
-// The token_before_slash token
-// is used to disambiguate "/", which can mean division or regular expression
-// literal.
-
-        if (token_prv.id !== "(comment)") {
-            token_before_slash = token_prv;
-        }
-        return the_token;
-    }
-
-    function parse_directive(the_comment, body) {
-
-// JSLint recognizes three directives that can be encoded in comments. This
-// function processes one item, and calls itself recursively to process the
-// next one.
-
-        const result = body.match(rx_directive_part);
-        if (result) {
-            let allowed;
-            const name = result[1];
-            const value = result[2];
-            if (the_comment.directive === "jslint") {
-                allowed = allowed_option[name];
-                if (
-                    typeof allowed === "boolean"
-                    || typeof allowed === "object"
-                ) {
-                    if (value === "true" || value === undefined) {
-                        option_object[name] = true;
-                        if (Array.isArray(allowed)) {
-                            populate(allowed, global_array, false);
-                        }
-                    } else {
-                        assert_or_throw(
-                            value === "false",
-                            `Expected value === "false".`
-                        );
-                        option_object[name] = false;
-//                  Probably deadcode.
-//                  } else if (value === "false") {
-//                      option_object[name] = false;
-//                  } else {
-//                      warn("bad_option_a", the_comment, name + ":" + value);
-                    }
-                } else {
-
-// cause: "/*jslint undefined*/"
-
-                    warn("bad_option_a", the_comment, name);
-                }
-            } else if (the_comment.directive === "property") {
-                if (tenure === undefined) {
-                    tenure = empty();
-                }
-                tenure[name] = true;
-            } else if (the_comment.directive === "global") {
-                if (value) {
-
-// cause: "/*global aa:false*/"
-
-                    warn("bad_option_a", the_comment, name + ":" + value);
-                }
-                global_array[name] = false;
-                mode_module = the_comment;
-            }
-            return parse_directive(the_comment, result[3]);
-        }
-        if (body) {
-
-// cause: "/*jslint !*/"
-
-            return stop("bad_directive_a", the_comment, body);
-        }
-    }
-
-    function comment(snippet) {
-
-// Create a comment object. Comments are not allowed in JSON text. Comments can
-// include directives and notices of incompletion.
-
-        const the_comment = token_create("(comment)", snippet);
-        if (Array.isArray(snippet)) {
-            snippet = snippet.join(" ");
-        }
-        if (!option_object.devel && rx_todo.test(snippet)) {
-
-// cause: "//\u0074odo"
-
-            warn("todo_comment", the_comment);
-        }
-        const result = snippet.match(rx_directive);
-        if (result) {
-            if (!mode_directive) {
-
-// cause: "0\n/*global aa*/"
-
-                warn_at("misplaced_directive_a", line, from, result[1]);
-            } else {
-                the_comment.directive = result[1];
-                parse_directive(the_comment, result[2]);
-            }
-            directives.push(the_comment);
-        }
-        return the_comment;
-    }
-
-    function regexp() {
-
-// Regexp
-// Parse a regular expression literal.
-
-        let mode_multi = false;
-        let result;
-        let value;
-        mode_regexp = true;
-
-        function regexp_subklass() {
-
-// RegExp
-// Match a character in a character class.
-
-            switch (char) {
-            case "\\":
-                char_after_escape("BbDdSsWw-[]^");
-                return true;
-            case "":
-            case "[":
-            case "]":
-            case "/":
-            case "^":
-            case "-":
-                return false;
-            case " ":
-
-// cause: "aa=/[ ]/"
-
-                warn_at("expected_a_b", line, column, "\\u0020", " ");
-                char_after();
-                return true;
-            case "`":
-                if (mode_mega) {
-
-// cause: "`${/[`]/}`"
-
-                    warn_at("unexpected_a", line, column, "`");
-                }
-                char_after();
-                return true;
-            default:
-                char_after();
-                return true;
-            }
-        }
-
-        function regexp_choice() {
-            let follow;
-
-// RegExp
-// Parse sequence of characters in regexp.
-
-            while (true) {
-                switch (char) {
-                case "":
-                case "/":
-                case "]":
-                case ")":
-
-// RegExp
-// Break while-loop in regexp_choice().
-
-                    if (!follow) {
-
-// cause: "/ /"
-
-                        warn_at("expected_regexp_factor_a", line, column, char);
-                    }
-
-// RegExp
-// Match a choice (a sequence that can be followed by | and another choice).
-
-                    assert_or_throw(
-                        !(char === "|"),
-                        `Expected !(char === "|").`
-                    );
-//                  Probably deadcode.
-//                  if (char === "|") {
-//                      char_after("|");
-//                      return regexp_choice();
-//                  }
-                    return;
-                case "(":
-
-// RegExp
-// Match a group that starts with left paren.
-
-                    char_after("(");
-                    if (char === "?") {
-                        char_after("?");
-                        if (char === "=" || char === "!") {
-                            char_after();
-                        } else {
-                            char_after(":");
-                        }
-                    } else if (char === ":") {
-
-// cause: "aa=/(:)/"
-// cause: "aa=/?/"
-
-                        warn_at("expected_a_before_b", line, column, "?", ":");
-                    }
-
-// RegExp
-// Recurse regexp_choice().
-
-                    regexp_choice();
-                    char_after(")");
-                    break;
-                case "[":
-
-// RegExp
-// Match a class.
-
-                    char_after("[");
-                    if (char === "^") {
-                        char_after("^");
-                    }
-                    while (true) {
-
-// RegExp
-// Match a range of subclasses.
-
-                        while (regexp_subklass()) {
-                            if (char === "-") {
-                                char_after("-");
-                                if (!regexp_subklass()) {
-
-// cause: "aa=/[0-]/"
-
-                                    return stop_at(
-                                        "unexpected_a",
-                                        line,
-                                        column - 1,
-                                        "-"
-                                    );
-                                }
-                            }
-                        }
-                        if (char === "]" || char === "") {
-                            break;
-                        }
-
-// cause: "aa=/[/"
-
-                        warn_at(
-                            "expected_a_before_b",
-                            line,
-                            column,
-                            "\\",
-                            char
-                        );
-                        char_after();
-                    }
-                    char_after("]");
-                    break;
-                case "\\":
-                    char_after_escape("BbDdSsWw^${}[]():=!.|*+?");
-                    break;
-                case "?":
-                case "+":
-                case "*":
-                case "}":
-                case "{":
-                    warn_at("expected_a_before_b", line, column, "\\", char);
-                    char_after();
-                    break;
-                case "`":
-                    if (mode_mega) {
-
-// cause: "`${/`/}`"
-
-                        warn_at("unexpected_a", line, column, "`");
-                    }
-                    char_after();
-                    break;
-                case " ":
-
-// cause: "aa=/ /"
-
-                    warn_at("expected_a_b", line, column, "\\s", " ");
-                    char_after();
-                    break;
-                case "$":
-                    if (line_source[0] !== "/") {
-                        mode_multi = true;
-                    }
-                    char_after();
-                    break;
-                case "^":
-                    if (snippet !== "^") {
-                        mode_multi = true;
-                    }
-                    char_after();
-                    break;
-                default:
-                    char_after();
-                }
-
-// RegExp
-// Match an optional quantifier.
-
-                switch (char) {
-                case "?":
-                case "*":
-                case "+":
-                    if (char_after() === "?") {
-                        char_after("?");
-                    }
-                    break;
-                case "{":
-                    if (read_some_digits(rx_digits, true) === 0) {
-
-// cause: "aa=/aa{/"
-
-                        warn_at("expected_a_before_b", line, column, "0", ",");
-                    }
-                    if (char === ",") {
-
-// cause: "aa=/.{,/"
-
-                        read_some_digits(rx_digits, true);
-                    }
-                    if (char_after("}") === "?") {
-
-// cause: "aa=/.{0}?/"
-
-                        warn_at("unexpected_a", line, column, char);
-                        char_after("?");
-                    }
-                    break;
-                }
-                follow = true;
-            }
-        }
-
-// RegExp
-// Scan the regexp literal. Give a warning if the first character is = because
-// /= looks like a division assignment operator.
-
-        snippet = "";
-        char_after();
-        if (char === "=") {
-
-// cause: "aa=/=/"
-
-            warn_at("expected_a_before_b", line, column, "\\", "=");
-        }
-        regexp_choice();
-
-// RegExp
-// Remove last character from snippet.
-
-        snippet = snippet.slice(0, -1);
-
-// RegExp
-// Make sure there is a closing slash.
-
-        value = snippet;
-        char_after("/");
-
-// RegExp
-// Create flag.
-
-        const flag = empty();
-        while (
-
-// Regexp
-// char is a letter.
-
-            (char >= "a" && char <= "z\uffff")
-            || (char >= "A" && char <= "Z\uffff")
-        ) {
-
-// RegExp
-// Process dangling flag letters.
-
-            switch (!flag[char] && char) {
-            case "g":
-            case "i":
-            case "m":
-            case "u":
-            case "y":
-
-// cause: "aa=/./gimuy"
-
-                break;
-            default:
-
-// cause: "aa=/./gg"
-// cause: "aa=/./z"
-
-                warn_at("unexpected_a", line, column, char);
-            }
-            flag[char] = true;
-            char_after();
-        }
-        char_before();
-        if (char === "/" || char === "*") {
-
-// cause: "aa=/.//"
-
-            return stop_at("unexpected_a", line, from, char);
-        }
-        result = token_create("(regexp)", char);
-        result.flag = flag;
-        result.value = value;
-        if (mode_multi && !flag.m) {
-
-// cause: "aa=/$^/"
-
-            warn_at("missing_m", line, column);
-        }
-        return result;
-    }
-
-    function string(quote) {
-
-// Create a string token.
-
-        let the_token;
-        snippet = "";
-        char_after();
-
-// Parse/loop through each character in "...".
-
-        while (true) {
-            switch (char) {
-            case quote:
-
-// Remove last character from snippet.
-
-                snippet = snippet.slice(0, -1);
-                the_token = token_create("(string)", snippet);
-                the_token.quote = quote;
-                return the_token;
-            case "":
-
-// cause: "\""
-
-                return stop_at("unclosed_string", line, column);
-            case "\\":
-                char_after_escape(quote);
-                break;
-            case "`":
-                if (mode_mega) {
-
-// cause: "`${\"`\"}`"
-
-                    warn_at("unexpected_a", line, column, "`");
-                }
-                char_after("`");
-                break;
-            default:
-                char_after();
-            }
-        }
-    }
-
-    function frack() {
-        if (char === ".") {
-            read_some_digits(rx_digits);
-        }
-        if (char === "E" || char === "e") {
-            char_after();
-            if (char !== "+" && char !== "-") {
-                char_before();
-            }
-            read_some_digits(rx_digits);
-        }
-    }
-
-    function number() {
-        if (snippet === "0") {
-            char_after();
-            if (char === ".") {
-                frack();
-            } else if (char === "b") {
-                read_some_digits(rx_bits);
-            } else if (char === "o") {
-                read_some_digits(rx_octals);
-            } else if (char === "x") {
-                read_some_digits(rx_hexs);
-            }
-        } else {
-            char_after();
-            frack();
-        }
-
-// If the next character after a number is a digit or letter, then something
-// unexpected is going on.
-
-        if (
-            (char >= "0" && char <= "9")
-            || (char >= "a" && char <= "z")
-            || (char >= "A" && char <= "Z")
-        ) {
-
-// cause: "0a"
-
-            return stop_at(
-                "unexpected_a_after_b",
-                line,
-                column,
-                snippet.slice(-1),
-                snippet.slice(0, -1)
-            );
-        }
-        char_before();
-        return token_create("(number)", snippet);
-    }
-
-    function lex() {
-        let array;
-        let i = 0;
-        let j = 0;
-        let last;
-        let result;
-        let the_token;
-
-// This should properly be a tail recursive function, but sadly, conformant
-// implementations of ES6 are still rare. This is the ideal code:
-
-//      if (!line_source) {
-//          line_source = line_next();
-//          from = 0;
-//          return (
-//              line_source === undefined
-//              ? (
-//                  mode_mega
-//                  ? stop_at("unclosed_mega", line_mega, from_mega)
-//                  : token_create("(end)")
-//              )
-//              : lex()
-//          );
-//      }
-
-// Unfortunately, incompetent JavaScript engines will sometimes fail to execute
-// it correctly. So for now, we do it the old fashioned way.
-
-        while (!line_source) {
-            line_source = line_next();
-            from = 0;
-            if (line_source === undefined) {
-                return (
-                    mode_mega
-
-// cause: "`${//}`"
-
-                    ? stop_at("unclosed_mega", line_mega, from_mega)
-                    : line_disable !== undefined
-
-// cause: "/*jslint-disable*/"
-
-                    ? stop_at("unclosed_disable", line_disable)
-                    : token_create("(end)")
-                );
-            }
-        }
-
-        from = column;
-        result = line_source.match(rx_token);
-
-// result[1] token
-// result[2] whitespace
-// result[3] identifier
-// result[4] number
-// result[5] rest
-
-        if (!result) {
-
-// cause: "#"
-
-            return stop_at(
-                "unexpected_char_a",
-                line,
-                column,
-                line_source[0]
-            );
-        }
-
-        snippet = result[1];
-        column += snippet.length;
-        line_source = result[5];
-
-// Whitespace was matched. Call lex again to get more.
-
-        if (result[2]) {
-            return lex();
-        }
-
-// The token is an identifier.
-
-        if (result[3]) {
-            return token_create(snippet, undefined, true);
-        }
-
-// Create token from number.
-
-        if (result[4]) {
-            return number(snippet);
-        }
-
-// Create token from string.
-
-        if (snippet === "\"") {
-            return string(snippet);
-        }
-        if (snippet === "'") {
-            if (!option_object.single) {
-
-// cause: "''"
-
-                warn_at("use_double", line, column);
-            }
-            return string(snippet);
-        }
-
-// The token is a megastring. We don't allow any kind of mega nesting.
-
-        if (snippet === "`") {
-            if (mode_mega) {
-
-// cause: "`${`"
-
-                return stop_at("expected_a_b", line, column, "}", "`");
-            }
-            snippet = "";
-            from_mega = from;
-            line_mega = line;
-            mode_mega = true;
-
-// Parsing a mega literal is tricky. First create a ` token.
-
-            token_create("`");
-            from += 1;
-
-// Then loop, building up a string, possibly from many lines, until seeing
-// the end of file, a closing `, or a ${ indicting an expression within the
-// string.
-
-            (function part() {
-                const at = line_source.search(rx_mega);
-
-// If neither ` nor ${ is seen, then the whole line joins the snippet.
-
-                if (at < 0) {
-                    snippet += line_source + "\n";
-                    return (
-                        line_next() === undefined
-
-// cause: "`"
-
-                        ? stop_at("unclosed_mega", line_mega, from_mega)
-                        : part()
-                    );
-                }
-                snippet += line_source.slice(0, at);
-                column += at;
-                line_source = line_source.slice(at);
-                if (line_source[0] === "\\") {
-                    snippet += line_source.slice(0, 2);
-                    line_source = line_source.slice(2);
-                    column += 2;
-                    return part();
-                }
-
-// if either ` or ${ was found, then the preceding joins the snippet to become
-// a string token.
-
-                token_create("(string)", snippet).quote = "`";
-                snippet = "";
-
-// If ${, then create tokens that will become part of an expression until
-// a } token is made.
-
-                if (line_source[0] === "$") {
-                    column += 2;
-                    token_create("${");
-                    line_source = line_source.slice(2);
-                    (function expr() {
-                        const id = lex().id;
-                        if (id === "{") {
-
-// cause: "`${{"
-
-                            return stop_at(
-                                "expected_a_b",
-                                line,
-                                column,
-                                "}",
-                                "{"
-                            );
-                        }
-                        if (id !== "}") {
-                            return expr();
-                        }
-                    }());
-                    return part();
-                }
-            }());
-            line_source = line_source.slice(1);
-            column += 1;
-            mode_mega = false;
-            return token_create("`");
-        }
-
-// The token is a // comment.
-
-        if (snippet === "//") {
-            snippet = line_source;
-            line_source = "";
-            the_token = comment(snippet);
-            if (mode_mega) {
-
-// cause: "`${//}`"
-
-                warn("unexpected_comment", the_token, "`");
-            }
-            return the_token;
-        }
-
-// The token is a /* comment.
-
-        if (snippet === "/*") {
-            array = [];
-            if (line_source[0] === "/") {
-                warn_at("unexpected_a", line, column + i, "/");
-            }
-            (function next() {
-                if (line_source > "") {
-                    i = line_source.search(rx_star_slash);
-                    if (i >= 0) {
-                        return;
-                    }
-                    j = line_source.search(rx_slash_star);
-                    if (j >= 0) {
-
-// cause: "/*/*"
-
-                        warn_at("nested_comment", line, column + j);
-                    }
-                }
-                array.push(line_source);
-                line_source = line_next();
-                if (line_source === undefined) {
-
-// cause: "/*"
-
-                    return stop_at("unclosed_comment", line, column);
-                }
-                return next();
-            }());
-            snippet = line_source.slice(0, i);
-            j = snippet.search(rx_slash_star_or_slash);
-            if (j >= 0) {
-
-// cause: "/*/**/"
-
-                warn_at("nested_comment", line, column + j);
-            }
-            array.push(snippet);
-            column += i + 2;
-            line_source = line_source.slice(i + 2);
-            return comment(array);
-        }
-
-// The token is a slash.
-
-        if (snippet === "/") {
-
-// The / can be a division operator or the beginning of a regular expression
-// literal. It is not possible to know which without doing a complete parse.
-// We want to complete the tokenization before we begin to parse, so we will
-// estimate. This estimator can fail in some cases. For example, it cannot
-// know if "}" is ending a block or ending an object literal, so it can
-// behave incorrectly in that case; it is not meaningful to divide an
-// object, so it is likely that we can get away with it. We avoided the worst
-// cases by eliminating automatic semicolon insertion.
-
-            if (token_before_slash.identifier) {
-                if (!token_before_slash.dot) {
-                    if (token_before_slash.id === "return") {
-                        return regexp();
-                    }
-                    if (
-                        token_before_slash.id === "(begin)"
-                        || token_before_slash.id === "case"
-                        || token_before_slash.id === "delete"
-                        || token_before_slash.id === "in"
-                        || token_before_slash.id === "instanceof"
-                        || token_before_slash.id === "new"
-                        || token_before_slash.id === "typeof"
-                        || token_before_slash.id === "void"
-                        || token_before_slash.id === "yield"
-                    ) {
-                        the_token = regexp();
-
-// cause: "/./"
-// cause: "case /./"
-// cause: "delete /./"
-// cause: "in /./"
-// cause: "instanceof /./"
-// cause: "new /./"
-// cause: "typeof /./"
-// cause: "void /./"
-// cause: "yield /./"
-
-                        return stop("unexpected_a", the_token);
-                    }
-                }
-            } else {
-                last = token_before_slash.id[token_before_slash.id.length - 1];
-                if ("(,=:?[".indexOf(last) >= 0) {
-                    return regexp();
-                }
-                if ("!&|{};~+-*%/^<>".indexOf(last) >= 0) {
-                    the_token = regexp();
-
-// cause: "!/./"
-
-                    warn("wrap_regexp", the_token);
-                    return the_token;
-                }
-            }
-            if (line_source[0] === "=") {
-                column += 1;
-                line_source = line_source.slice(1);
-                snippet = "/=";
-                warn_at("unexpected_a", line, column, "/=");
-            }
-        }
-        return token_create(snippet);
-    }
     try {
+
+// tokenize takes a source and produces from it an array of token objects.
+// JavaScript is notoriously difficult to tokenize because of the horrible
+// interactions between automatic semicolon insertion, regular expression
+// literals, and now megastring literals. JSLint benefits from eliminating
+// automatic semicolon insertion and nested megastring literals, which allows
+// full tokenization to precede parsing.
+
         option_object = Object.assign(empty(), option_object);
         global_array = Object.assign(empty(), global_array);
         populate(standard, global_array, false);
@@ -6320,88 +6489,30 @@ function jslint(
             }
         });
 
-// tokenize takes a source and produces from it an array of token objects.
-// JavaScript is notoriously difficult to tokenize because of the horrible
-// interactions between automatic semicolon insertion, regular expression
-// literals, and now megastring literals. JSLint benefits from eliminating
-// automatic semicolon insertion and nested megastring literals, which allows
-// full tokenization to precede parsing.
+// PHASE 1. Split <source> by newlines into <line_array>.
 
-// PHASE 1. split the <source> by newlines into <line_array>.
+        phase1_split();
 
-        line_array = String("\n" + source).split(
-            // rx_crlf
-            /\n|\r\n?/
-        ).map(function (line_source) {
-            return {
-                line_source
-            };
-        });
+// PHASE 2. Lex <line_array> into <token_array>.
 
-// PHASE 2. lex <line_array> into an array of <token_array>.
+        phase2_lex();
 
-// Scan first line for "#!" and ignore it.
+// PHASE 3. Parse <token_array> into <token_tree> using Pratt parsing.
 
-        if (line_array[line_fudge].line_source.startsWith("#!")) {
-            line += 1;
-            mode_shebang = true;
-        }
-        token_1 = lex();
-        mode_json = token_1.id === "{" || token_1.id === "[";
+        phase3_parse();
 
-// This loop will be replaced with a recursive call to lex when ES6 has been
-// finished and widely deployed and adopted.
-
-        while (true) {
-            if (lex().id === "(end)") {
-                break;
-            }
-        }
-
-// PHASE 3. Furcate the <token_array> into a parse <tree>.
-
-        advance();
-        if (mode_json) {
-            tree = json_value();
-            advance("(end)");
-        } else {
-
-// Because browsers encourage combining of script files, the first token might
-// be a semicolon to defend against a missing semicolon in the preceding file.
-
-            if (option_object.browser) {
-                if (token_nxt.id === ";") {
-                    advance(";");
-                }
-            } else {
-
-// If we are not in a browser, then the file form of strict pragma may be used.
-
-                if (
-                    token_nxt.value === "use strict"
-                ) {
-                    advance("(string)");
-                    advance(";");
-                }
-            }
-            tree = statements();
-            advance("(end)");
-            functionage = global;
-
-// PHASE 4. Walk the <tree>, traversing all of the nodes of the tree. It is a
+// PHASE 4. Walk <token_tree>, traversing all of the nodes of the tree. It is a
 //          recursive traversal. Each node may be processed on the way down
 //          (preaction) and on the way up (postaction).
 
-            walk_statement(tree);
+        if (!mode_json) {
+            phase4_walk();
+        }
 
-// PHASE 5. Check the whitespace between the <token_array>.
+// PHASE 5. Check whitespace between tokens in <token_array>.
 
-            if (warnings.length === 0) {
-                uninitialized_and_unused();
-                if (!option_object.white) {
-                    whitage();
-                }
-            }
+        if (!mode_json && warning_array.length === 0) {
+            phase5_whitage();
         }
         if (!option_object.browser) {
             directives.forEach(function (comment) {
@@ -6421,7 +6532,7 @@ function jslint(
         e.mode_stop = true;
         e.message = "[JSLint was unable to finish]\n" + e.message;
         if (e.name !== "JSLintError") {
-            warnings.push(Object.assign(e, {
+            warning_array.push(Object.assign(e, {
                 column: line_fudge,
                 line: line_fudge,
                 line_source: "",
@@ -6430,11 +6541,9 @@ function jslint(
         }
     }
 
-// PHASE 6: sort and format <warnings>.
+// Sort warning_array by mode_stop first, line, column respectively.
 
-// Sort warnings by mode_stop first, line, column respectively.
-
-    warnings.sort(function (a, b) {
+    warning_array.sort(function (a, b) {
         return (
             Boolean(b.mode_stop) - Boolean(a.mode_stop)
             || a.line - b.line
@@ -6460,20 +6569,18 @@ function jslint(
         ).trim();
     });
 
-// PHASE 7: return jslint result.
-
     return {
         directives,
         edition,
         exports: export_object,
-        froms: import_from_array,
-        functions,
+        froms: import_array,
+        functions: function_array,
         global,
         id: "(JSLint)",
         json: mode_json,
         lines: line_array,
         module: mode_module === true,
-        ok: warnings.length === 0 && !mode_stop,
+        ok: warning_array.length === 0 && !mode_stop,
         option: option_object,
         property,
         shebang: (
@@ -6483,8 +6590,8 @@ function jslint(
         ),
         stop: mode_stop,
         tokens: token_array,
-        tree,
-        warnings
+        tree: token_tree,
+        warnings: warning_array
     };
 }
 

--- a/jslint.js
+++ b/jslint.js
@@ -106,9 +106,10 @@
     quote, readFile, readdir, repeat, replace, resolve, role, search, shebang,
     signature, single, slice, some, sort, source, split, stack, stack_trace,
     startsWith, statement, stop, stop_at, switch, syntax_dict, tenure, test,
-    test_internal_error, then, this, thru, token_global, token_list, token_tree,
-    tokens, tree, trim, try, type, unordered, used, value, variable, versions,
-    warn, warn_at, warning, warning_list, warnings, white, wrapped, writable
+    test_internal_error, then, this, thru, token_global, token_list, token_nxt,
+    token_tree, tokens, tree, trim, try, type, unordered, used, value, variable,
+    versions, warn, warn_at, warning, warning_list, warnings, white, wrapped,
+    writable
 */
 
 const edition = "v2021.6.4-beta";
@@ -1524,7 +1525,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "()"
 
-                ? stop("expected_a_b", token_nxt, id, artifact(token_nxt))
+                ? stop("expected_a_b", token_nxt, id, artifact())
 
 // cause: "{\"aa\":0"
 
@@ -1534,7 +1535,7 @@ function jslint_phase3_parse(state) {
                     id,
                     artifact(match),
                     match.line,
-                    artifact(token_nxt)
+                    artifact()
                 )
             );
         }
@@ -1544,6 +1545,7 @@ function jslint_phase3_parse(state) {
         token_now = token_nxt;
         while (true) {
             token_nxt = token_list[token_ii];
+            state.token_nxt = token_nxt;
             token_ii += 1;
             if (token_nxt.id !== "(comment)") {
                 if (token_nxt.id === "(end)") {
@@ -1555,7 +1557,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "[//]"
 
-                warn("unexpected_a", token_nxt);
+                warn("unexpected_a");
             }
         }
     }
@@ -1826,7 +1828,7 @@ function jslint_phase3_parse(state) {
                 token_now.line,
                 token_now.thru + 1,
                 ";",
-                artifact(token_nxt)
+                artifact()
             );
         }
         anon = "anonymous";
@@ -2361,7 +2363,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "/*jslint eval*/\neval"
 
-            warn("expected_a_before_b", token_nxt, "(", artifact(token_nxt));
+            warn("expected_a_before_b", token_nxt, "(", artifact());
         }
         return token_now;
     });
@@ -2376,7 +2378,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "/*jslint eval*/\nFunction"
 
-            warn("expected_a_before_b", token_nxt, "(", artifact(token_nxt));
+            warn("expected_a_before_b", token_nxt, "(", artifact());
         }
         return token_now;
     });
@@ -2545,7 +2547,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "aa.0"
 
-            stop("expected_identifier_a", token_nxt);
+            stop("expected_identifier_a");
         }
         advance();
         survey(name);
@@ -2593,7 +2595,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "aa?.0"
 
-            stop("expected_identifier_a", token_nxt);
+            stop("expected_identifier_a");
         }
         advance();
         survey(name);
@@ -2725,7 +2727,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "new aa"
 
-            warn("expected_a_before_b", token_nxt, "()", artifact(token_nxt));
+            warn("expected_a_before_b", token_nxt, "()", artifact());
         }
         the_new.expression = right;
         return the_new;
@@ -2775,7 +2777,7 @@ function jslint_phase3_parse(state) {
 // cause: "function aa(aa=0,{}){}"
 // cause: "function aa({0}){}"
 
-                            return stop("expected_identifier_a", token_nxt);
+                            return stop("expected_identifier_a");
                         }
                         survey(subparam);
                         artifact_now = artifact_nxt;
@@ -2856,7 +2858,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "function aa(aa=0,[]){}"
 
-                            return stop("expected_identifier_a", token_nxt);
+                            return stop("expected_identifier_a");
                         }
                         advance();
                         param.names.push(subparam);
@@ -2901,7 +2903,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "function aa(0){}"
 
-                        return stop("expected_identifier_a", token_nxt);
+                        return stop("expected_identifier_a");
                     }
                     param = token_nxt;
                     list.push(param);
@@ -2954,7 +2956,7 @@ function jslint_phase3_parse(state) {
 // cause: "function(){}"
 // cause: "function*aa(){}"
 
-                    return stop("expected_identifier_a", token_nxt);
+                    return stop("expected_identifier_a");
                 }
                 name = token_nxt;
                 enroll(name, "variable", true);
@@ -3047,7 +3049,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "function aa(){}0"
 
-            return stop("unexpected_a", token_nxt);
+            return stop("unexpected_a");
         }
         if (
             token_nxt.id === "."
@@ -3057,7 +3059,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "function aa(){}\n[]"
 
-            warn("unexpected_a", token_nxt);
+            warn("unexpected_a");
         }
 
 // Restore the previous context.
@@ -3398,12 +3400,12 @@ function jslint_phase3_parse(state) {
 
 // cause: "aa:{function aa(aa){break aa;}}"
 
-                    warn("out_of_scope_a", token_nxt);
+                    warn("out_of_scope_a");
                 } else {
 
 // cause: "aa:{break aa;}"
 
-                    warn("not_label_a", token_nxt);
+                    warn("not_label_a");
                 }
             } else {
                 the_label.used += 1;
@@ -3458,7 +3460,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "let {0}"
 
-                        return stop("expected_identifier_a", token_nxt);
+                        return stop("expected_identifier_a");
                     }
                     const name = token_nxt;
                     survey(name);
@@ -3486,7 +3488,7 @@ function jslint_phase3_parse(state) {
 // cause: "let {aa:0}"
 // cause: "let {aa:{aa}}"
 
-                            return stop("expected_identifier_a", token_nxt);
+                            return stop("expected_identifier_a");
                         }
                         token_nxt.label = name;
                         the_statement.names.push(token_nxt);
@@ -3528,7 +3530,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "let[]"
 
-                        return stop("expected_identifier_a", token_nxt);
+                        return stop("expected_identifier_a");
                     }
                     const name = token_nxt;
                     advance();
@@ -3575,7 +3577,7 @@ function jslint_phase3_parse(state) {
 // cause: "let 0"
 // cause: "var{aa:{aa}}"
 
-                return stop("expected_identifier_a", token_nxt);
+                return stop("expected_identifier_a");
             }
         }());
         semicolon();
@@ -3653,7 +3655,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "export {}"
 
-                stop("expected_identifier_a", token_nxt);
+                stop("expected_identifier_a");
             }
             the_id = token_nxt.id;
             the_name = token_global.context[the_id];
@@ -3661,14 +3663,14 @@ function jslint_phase3_parse(state) {
 
 // cause: "export {aa}"
 
-                warn("unexpected_a", token_nxt);
+                warn("unexpected_a");
             } else {
                 the_name.used += 1;
                 if (export_dict[the_id] !== undefined) {
 
 // cause: "let aa;export{aa,aa}"
 
-                    warn("duplicate_a", token_nxt);
+                    warn("duplicate_a");
                 }
                 export_dict[the_id] = the_name;
             }
@@ -3682,7 +3684,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "export default 0;export default 0"
 
-                warn("duplicate_a", token_nxt);
+                warn("duplicate_a");
             }
             advance("default");
             the_thing = parse_expression(0);
@@ -3712,7 +3714,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "export function aa(){}"
 
-                warn("freeze_exports", token_nxt);
+                warn("freeze_exports");
                 the_thing = parse_statement();
                 the_name = the_thing.name;
                 the_id = the_name.id;
@@ -3737,7 +3739,7 @@ function jslint_phase3_parse(state) {
 // cause: "export let"
 // cause: "export var"
 
-                warn("unexpected_a", token_nxt);
+                warn("unexpected_a");
                 parse_statement();
             } else if (token_nxt.id === "{") {
 
@@ -3757,7 +3759,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "export"
 
-                stop("unexpected_a", token_nxt);
+                stop("unexpected_a");
             }
         }
         state.mode_module = true;
@@ -3793,7 +3795,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "for(const aa in aa){}"
 
-            return stop("unexpected_a", token_nxt);
+            return stop("unexpected_a");
         }
         first = parse_expression(0);
         if (first.id === "in") {
@@ -3900,7 +3902,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "import {"
 
-                        stop("expected_identifier_a", token_nxt);
+                        stop("expected_identifier_a");
                     }
                     name = token_nxt;
                     advance();
@@ -4006,7 +4008,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "switch(0){case 0:}"
 
-                warn("expected_statements_a", token_nxt);
+                warn("expected_statements_a");
                 return;
             }
             the_case.block = stmts;
@@ -4017,12 +4019,7 @@ function jslint_phase3_parse(state) {
                     the_disrupt = false;
                 }
             } else {
-                warn(
-                    "expected_a_before_b",
-                    token_nxt,
-                    "break;",
-                    artifact(token_nxt)
-                );
+                warn("expected_a_before_b", token_nxt, "break;", artifact());
             }
             if (token_nxt.id === "case") {
                 return major();
@@ -4110,7 +4107,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "try{}catch(){}"
 
-                    return stop("expected_identifier_a", token_nxt);
+                    return stop("expected_identifier_a");
                 }
                 if (token_nxt.id !== "ignore") {
                     ignored = undefined;
@@ -4136,12 +4133,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "try{}finally{break;}"
 
-            warn(
-                "expected_a_before_b",
-                token_nxt,
-                "catch",
-                artifact(token_nxt)
-            );
+            warn("expected_a_before_b", token_nxt, "catch", artifact());
 
         }
         if (token_nxt.id === "finally") {
@@ -4287,7 +4279,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "[0x0]"
 
-                    warn("unexpected_a", token_nxt);
+                    warn("unexpected_a");
                 }
                 advance();
                 return token_now;
@@ -4317,7 +4309,7 @@ function jslint_phase3_parse(state) {
 
 // cause: "[undefined]"
 
-                stop("unexpected_a", token_nxt);
+                stop("unexpected_a");
             }
         }());
         advance("(end)");
@@ -6166,14 +6158,7 @@ function jslint(
 
 // Return a string representing an artifact.
 
-        assert_or_throw(
-            the_token !== undefined,
-            "Expected the_token !== undefined."
-        );
-// Probably deadcode.
-// if (the_token === undefined) {
-//     the_token = token_nxt;
-// }
+        the_token = the_token || state.token_nxt;
         return (
             (the_token.id === "(string)" || the_token.id === "(number)")
             ? String(the_token.value)
@@ -6634,14 +6619,7 @@ function jslint(
 // If there is already a warning on this token, suppress the new one. It is
 // likely that the first warning will be the most meaningful.
 
-        assert_or_throw(
-            the_token !== undefined,
-            "Expected the_token !== undefined."
-        );
-// Probably deadcode.
-// if (the_token === undefined) {
-//     the_token = token_nxt;
-// }
+        the_token = the_token || state.token_nxt;
         if (the_token.warning === undefined) {
             the_token.warning = warn_at(
                 code,
@@ -6662,14 +6640,7 @@ function jslint(
 // warning will be replaced with this new one. It is likely that the stopping
 // warning will be the more meaningful.
 
-        assert_or_throw(
-            the_token !== undefined,
-            "Expected the_token !== undefined."
-        );
-// Probably deadcode.
-// if (the_token === undefined) {
-//     the_token = token_nxt;
-// }
+        the_token = the_token || state.token_nxt;
         delete the_token.warning;
         throw warn(code, the_token, a, b, c, d);
     }
@@ -6720,6 +6691,7 @@ function jslint(
             tenure,
             token_global,
             token_list,
+            token_nxt: token_global,
             warn,
             warn_at,
             warning_list

--- a/test.js
+++ b/test.js
@@ -25,15 +25,15 @@ function noop() {
     process.exit = function (exitCode) {
         assertOrThrow(!exitCode, exitCode);
     };
-    jslint.cli({
+    jslint.jslint_cli({
         file: "jslint.js"
     });
-    jslint.cli({
+    jslint.jslint_cli({
         // suppress error
         console_error: noop,
         file: "undefined"
     });
-    jslint.cli({
+    jslint.jslint_cli({
         // suppress error
         console_error: noop,
         file: "syntax_error.js",
@@ -42,7 +42,7 @@ function noop() {
         },
         source: "syntax error"
     });
-    jslint.cli({
+    jslint.jslint_cli({
         file: "aa.html",
         source: "<script>\nlet aa = 0;\n</script>\n"
     });


### PR DESCRIPTION
this pr is biggest jslint-refactor to-date.

add 4-space-indent to 4000+ lines of jslint's core-logic so they can be split into 5 [mostly]-self-contained sub-functions:

```javascript
function jslint(
    source = "",
    option_object = empty(),
    global_array = []
) {

// PHASE 1. Split <source> by newlines into <line_array>.
    function phase1_split() {
        <10 lines-of-code>
    }

// PHASE 2. Lex <line_array> into <token_array>.
    function phase2_lex()   {
        <1,200 lines-of-code>
    }

// PHASE 3. Parse <token_array> into <token_tree> using Pratt parsing.
    function phase3_parse() {
        <2,800 lines-of-code>
    }

// PHASE 4. Walk <token_tree>, traversing all of the nodes of the tree. It is a
//          recursive traversal. Each node may be processed on the way down
//          (preaction) and on the way up (postaction).
    function phase4_walk()  {
        <1,000 lines-of-code>
    }

// PHASE 5. Check whitespace between tokens in <token_array>.
    function phase5_whitage() {
        <600 lines-of-code>
    }

    try {
        phase1_split();
        phase2_lex();
        phase3_parse();
        phase4_walk();
        phase5_whitage();
    } catch ...
    return ...
}
```
