### PR TITLE
## v2021.6.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - tests - update function warn_at() with assertion-check matching column with artifact.
 - website - replace current-editor with CodeMirror-editor and change programming-font-family from `Programma` to `Consolas, Menlo, monospace`.
 
-## v2021.6.4-beta
+## v2021.6.12
 - bugfix - fix await expression/statement inside catch-statement not registered by functionage.await.
 - bugfix - fix cli appending slash "/" to normalized filename.
 - bugfix - fix issue #316, #317 - jslint complains about dynamic-import.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Status
-| Branch | [master<br>(v2021.6.3)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
+| Branch | [master<br>(v2021.6.12)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
 |--:|:--:|:--:|:--:|
 | CI | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jslint-org/jslint/actions?query=branch%3Amaster) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/jslint-org/jslint/actions?query=branch%3Abeta) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/jslint-org/jslint/actions?query=branch%3Aalpha) |
 | Coverage | [![coverage](https://jslint-org.github.io/jslint/branch-master/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch-master/.build/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-beta/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch-beta/.build/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-alpha/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch-alpha/.build/coverage/index.html) |

--- a/jslint.js
+++ b/jslint.js
@@ -113,7 +113,7 @@
     writable
 */
 
-const edition = "v2021.6.4-beta";
+const edition = "v2021.6.12";
 
 const line_fudge = 1;   // Fudge starting line and starting column to 1.
 


### PR DESCRIPTION
- bugfix - fix await expression/statement inside catch-statement not registered by functionage.await.
- bugfix - fix cli appending slash "/" to normalized filename.
- bugfix - fix issue #316, #317 - jslint complains about dynamic-import.
- bugfix - fix misleading warning describing alphabetical-order instead of ascii-order.
- bugfix - fix off-by-one-column bug in missing-semicolon-warning.
- bugfix - fix try-catch-block complaining about "Unexpected await" inside async-function.
- directive - re-introduce `/*jslint name*/` to ignore "Bad property name" warning.
- doc - add install-screenshots.
- jslint - add new warning if case-statements are not sorted.
- jslint - add warning for unexpected ? in example `aa=/.{0}?/`.
- jslint - add warning for unexpected-expr in example `async function aa(){await 0;}`.
- jslint-refactor-1 - make "stateful" variables scoped outside of jslint() "stateless" by moving them into jslint().
- jslint-refactor-2 - inline constants anticondition, bitwiseop, escapeable, and opener directly into code.
- jslint-refactor-3 - inline regexp-functions quantifier(), ranges(), klass(), choice(), directly into code.
- jslint-refactor-4 - document jslint process and each recursion-loop converted to while-loop.
    - remove unnecessary variables nr.
    - rename artifact-related variables a, b to let artifact_now, artifact_nxt.
    - rename functions make() to token_create().
    - reorganize/rename "global" variables by topical-prefixes:
        artifact_xxx, export_xxx, from_xxx, import_xxx, line_xxx, mode_xxx, token_xxx
- jslint-refactor-5 - split jslint-core-logic into 5-phases.
    - move phase-sub-functions out of function-jslint().
    - move global-vars into state-object, that can be passed between functions.
    - migrate recursive-loops to while-loops in sub-function phase2_lex().
    - move remaining global-vars into sub-functions or hardcode.
    - update functions artifact(), stop(), warn() with fallback-code `the_token = the_token || state.token_nxt;`.
- website - add ui-loader-animation.