### PR TITLE
- jslint - add new directive `/*jslint variable*/` - allow unordered variable-declarations that are not at top of function-scope.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,22 @@
 - app - deploy jslint as chrome-extension.
 - jslint - add `for...of` syntax support.
 - jslint - add html and css linting back into jslint.
-- jslint - add new warning if const/let/var statements are not declared at top of function-scope.
 - jslint - add new warning if const/let/var statements are not sorted.
 - jslint - include explicit commonjs (jslint.cjs) and es-module (jslint.mjs) variants of jslint.
 - jslint - remove directive "eval" (use line-specific ignore-directive "//jslint-quiet" instead).
 - jslint - simplify comments/docs by removing unnecessary grammar-article "the".
 - jslint-refactor - migrate recursive-loops to for/while loops.
-    - inline functions number(), string().
 - node - after node-v12 is deprecated, change `require("fs").promises` to `require("fs/promises")`.
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - tests - update function warn_at() with assertion-check matching column with artifact.
 
 ## v2021.6.14-beta
 - bugfix - fix global_list being ignored by jslint.
+- bugfix - fix no-warning when exception in catch-block is unused.
 - ci - migrate ci-scripts from cjs to esm.
+- jslint - add new directive `/*jslint beta*/` - enable features currently in beta.
+- jslint - add new directive `/*jslint variable*/` - allow unordered variable-declarations that are not at top of function-scope.
+- jslint - add new warning if const/let/var statements are not declared at top of function-scope.
 - website - invalidate url-cache with each deployment.
 - website - replace .png logo with .svg logo.
 - website - replace current-editor with CodeMirror-editor and change programming-font-family from `Programma` to `consolas, menlo, monospace`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - jslint - add html and css linting back into jslint.
 - jslint - add new warning if const/let/var statements are not sorted.
 - jslint - include explicit commonjs (jslint.cjs) and es-module (jslint.mjs) variants of jslint.
+- jslint - reintroduce directive `/*jslint indent2*/` - allow 2-space indent.
 - jslint - remove directive "eval" (use line-specific ignore-directive "//jslint-quiet" instead).
 - jslint - simplify comments/docs by removing unnecessary grammar-article "the".
 - jslint-refactor - migrate recursive-loops to for/while loops.

--- a/browser.js
+++ b/browser.js
@@ -354,15 +354,41 @@ editor = globalThis.CodeMirror.fromTextArea(document.querySelector(
     showTrailingSpace: true
 });
 editor.setValue(`#!/usr/bin/env node
-/*jslint node*/
+
+/*jslint beta node*/
+
 import jslint from \u0022./jslint.mjs\u0022;
 import https from "https";
 
+// Optional directives.
+// .... /*jslint beta*/ .......... Enable experimental features.
+// .... /*jslint bitwise*/ ....... Allow bitwise operators.
+// .... /*jslint browser*/ ....... Assume browser environment.
+// .... /*jslint convert*/ ....... Allow conversion operators.
+// .... /*jslint couch*/ ......... Assume CouchDb environment.
+// .... /*jslint debug*/ ......... Include jslint stack-trace in warnings.
+// .... /*jslint devel*/ ......... Allow console.log() and friends.
+// .... /*jslint eval*/ .......... Allow eval().
+// .... /*jslint for*/ ........... Allow for-statement.
+// .... /*jslint getset*/ ........ Allow get() and set().
+// .... /*jslint long*/ .......... Allow long-lines.
+// .... /*jslint name*/ .......... Allow weird property-names.
+// .... /*jslint node*/ .......... Assume Node.js environment.
+// .... /*jslint single*/ ........ Allow single-quote strings.
+// .... /*jslint test_internal_error*/ ... Test jslint's internal-error
+// ........................................... handling-ability.
+// .... /*jslint this*/ .......... Allow 'this'.
+// .... /*jslint unordered*/ ..... Allow unordered cases, params, properties.
+// .... /*jslint variable*/ ...... Allow unordered variable-declarations that
+// ................................... are not at top of function-scope.
+// .... /*jslint white: true...... Allow messy whitespace.
+
 /*jslint-disable*/
-// TODO: jslint this code-block in the future.
+// TODO: jslint this code-block in future.
 console.log('hello world');
 /*jslint-enable*/
 
+// Suppress warnings on next-line.
 eval( //jslint-quiet
     "console.log('hello world');"
 );

--- a/index.html
+++ b/index.html
@@ -453,34 +453,39 @@ style="
       <button name=options id=JSLINT_CLEAR_OPTIONS>clear options</button>
   </div>
   <fieldset id=JSLINT_OPTIONS><legend>Options</legend>
-    <div>Assume...
-      <div><label><input title=devel type=checkbox>in development</label></div>
+    <div>Env...
       <div><label><input title=browser type=checkbox>browser</label></div>
-      <div><label><input title=couch type=checkbox>CouchDB</label></div>
-      <div><label><input title=node type=checkbox>Node.js</label></div>
+      <div><label><input title=couch type=checkbox>couch</label></div>
+      <div><label><input title=devel type=checkbox>devel</label></div>
+      <div><label><input title=node type=checkbox>node</label></div>
     </div>
-    <div>Tolerate...
-      <div><label><input title=bitwise type=checkbox>bitwise operators</label></div>
-      <div><label><input title=convert type=checkbox>conversion operators</label></div>
+    <div>Allow...
+      <div><label><input title=beta type=checkbox>beta</label></div>
+      <div><label><input title=bitwise type=checkbox>bitwise</label></div>
+      <div><label><input title=convert type=checkbox>convert</label></div>
+      <div><label><input title=debug type=checkbox>debug</label></div>
+    </div>
+    <div>&nbsp;
       <div><label><input title=eval type=checkbox>eval</label></div>
-      <div><label><input title=for type=checkbox>for statement</label></div>
+      <div><label><input title=for type=checkbox>for</label></div>
+      <div><label><input title=getset type=checkbox>getset</label></div>
+      <div><label><input title=long type=checkbox>long</label></div>
     </div>
     <div>&nbsp;
-      <div><label><input title=getset type=checkbox>get and set</label></div>
-      <div><label><input title=long type=checkbox>long lines</label></div>
-      <div><label><input title=name type=checkbox>bad property names</label></div>
-      <div><label><input title=single type=checkbox>single quote strings</label></div>
-    </div>
-    <div>&nbsp;
+      <div><label><input title=name type=checkbox>name</label></div>
+      <div><label><input title=single type=checkbox>single</label></div>
       <div><label><input title=this type=checkbox>this</label></div>
-      <div><label><input title=unordered type=checkbox>unordered stuff</label></div>
-      <div><label><input title=white type=checkbox>whitespace mess</label></div>
+      <div><label><input title=unordered type=checkbox>unordered</label></div>
+    </div>
+    <div>&nbsp;
+      <div><label><input title=variable type=checkbox>variable</label></div>
+      <div><label><input title=white type=checkbox>white</label></div>
     </div>
     <textarea
       id=JSLINT_GLOBAL
       title=global
       spellcheck="false"
-      placeholder="imported globals here"
+      placeholder="imported globals (e.g. atob, btoa)"
     ></textarea>
   </fieldset>
   <fieldset id="JSLINT_WARNINGS">

--- a/index.html
+++ b/index.html
@@ -173,7 +173,6 @@ a:link {
 }
 
 #JSLINT_ textarea {
-    background-color: white;
     border: 0;
     margin: 2%;
     padding: 0.5%;
@@ -240,6 +239,9 @@ a:link {
     font-weight: bold;
     margin-left: 8em;
     padding-bottom: 2pt;
+}
+#JSLINT_PROPERTY {
+    background-color: honeydew;
 }
 #JSLINT_WARNINGS>legend {
     background-color: indianred;

--- a/jslint.js
+++ b/jslint.js
@@ -38,7 +38,7 @@
 //      edition: the version of JSLint that did the analysis.
 //      exports: the names exported from the module.
 //      froms: an array of strings representing each of the imports.
-//      functions: an array of objects that represent all of the functions
+//      functions: an array of objects that represent all functions
 //              declared in the file.
 //      global: an object representing the global object. Its .context property
 //              is an object containing a property for each global variable.
@@ -73,7 +73,7 @@
 // PHASE 1. Split <source> by newlines into <line_list>.
 // PHASE 2. Lex <line_list> into <token_list>.
 // PHASE 3. Parse <token_list> into <token_tree> using the Pratt-parser.
-// PHASE 4. Walk <token_tree>, traversing all of the nodes of the tree. It is a
+// PHASE 4. Walk <token_tree>, traversing all nodes of the tree. It is a
 //          recursive traversal. Each node may be processed on the way down
 //          (preaction) and on the way up (postaction).
 // PHASE 5. Check whitespace between tokens in <token_list>.
@@ -85,10 +85,15 @@
 
 // WARNING: JSLint will hurt your feelings.
 
-/*jslint node*/
+/*jslint beta, node*/
 
 /*property
+    beta,
+    catch_list, catch_stack,
+    function_stack,
     global_dict,
+    last_statement,
+    variable,
     execArgv, fileURLToPath, filter, meta, order, reduce, stringify, token, url,
     JSLINT_CLI, a, all, allowed_option, argv, arity, artifact, assign, async, b,
     bind, bitwise, block, body, browser, c, calls, catch, closer, closure, code,
@@ -1511,8 +1516,11 @@ function jslint_phase3_parse(state) {
 
     const {
         artifact,
+        catch_list,
+        catch_stack,
         export_dict,
         function_list,
+        function_stack,
         import_list,
         is_equal,
         option_dict,
@@ -1525,7 +1533,6 @@ function jslint_phase3_parse(state) {
         warn,
         warn_at
     } = state;
-    const function_stack = [];  // The stack of functions.
     const rx_identifier = (
         /^([a-zA-Z_$][a-zA-Z0-9_$]*)$/
     );
@@ -1533,6 +1540,7 @@ function jslint_phase3_parse(state) {
         /^-?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][\-+]?\d+)?$/
     );
     let anon = "anonymous";     // The guessed name for anonymous functions.
+    let catchage = catch_stack[0];      // The current catch-block.
     let functionage = token_global;     // The current function.
     let mode_var;               // "var" if using var; "let" if using let.
     let token_ii = 0;           // The number of the next token.
@@ -1693,6 +1701,7 @@ function jslint_phase3_parse(state) {
 // because it causes confusion.
 
         const id = name.id;
+        let earlier;
 
 // Reserved words may not be enrolled.
 
@@ -1705,7 +1714,7 @@ function jslint_phase3_parse(state) {
 
 // Has the name been enrolled in this context?
 
-            let earlier = functionage.context[id];
+            earlier = functionage.context[id] || catchage.context[id];
             if (earlier) {
 
 // cause: "let aa;let aa"
@@ -1735,8 +1744,7 @@ function jslint_phase3_parse(state) {
                                 role !== "exception"
                                 || earlier.role !== "exception"
                             )
-                            && role !== "parameter"
-                            && role !== "function"
+                            && role !== "parameter" && role !== "function"
                         ) {
 
 // cause: "function aa(){try{aa();}catch(aa){aa();}}"
@@ -1754,13 +1762,19 @@ function jslint_phase3_parse(state) {
 
 // Enroll it.
 
-                functionage.context[id] = name;
-                name.dead = true;
-                name.parent = functionage;
-                name.init = false;
-                name.role = role;
-                name.used = 0;
-                name.writable = !readonly;
+                Object.assign(name, {
+                    dead: true,
+                    init: false,
+                    parent: (
+                        role === "exception"
+                        ? catchage
+                        : functionage
+                    ),
+                    role,
+                    used: 0,
+                    writable: !readonly
+                });
+                name.parent.context[id] = name;
             }
         }
     }
@@ -1971,6 +1985,7 @@ function jslint_phase3_parse(state) {
                 the_label.init = true;
                 the_label.dead = false;
                 the_statement = parse_statement();
+                functionage.last_statement = the_statement;
                 the_statement.label = the_label;
                 the_statement.statement = true;
                 return the_statement;
@@ -1998,11 +2013,13 @@ function jslint_phase3_parse(state) {
             the_symbol.disrupt = false;
             the_symbol.statement = true;
             the_statement = the_symbol.fud();
+            functionage.last_statement = the_statement;
         } else {
 
 // It is an expression statement.
 
             the_statement = parse_expression(0, true);
+            functionage.last_statement = the_statement;
             if (the_statement.wrapped && the_statement.id !== "(") {
 
 // cause: "(0)"
@@ -2086,6 +2103,9 @@ function jslint_phase3_parse(state) {
             advance("{");
         }
         the_block = token_now;
+        if (special !== "body") {
+            functionage.last_statement = the_block;
+        }
         the_block.arity = "statement";
         the_block.body = special === "body";
 
@@ -2716,8 +2736,9 @@ function jslint_phase3_parse(state) {
     infix("[", 170, function (left) {
         const the_token = token_now;
         const the_subscript = parse_expression(0);
+        let name;
         if (the_subscript.id === "(string)" || the_subscript.id === "`") {
-            const name = survey(the_subscript);
+            name = survey(the_subscript);
             if (rx_identifier.test(name)) {
 
 // cause: "aa[`aa`]"
@@ -3314,17 +3335,19 @@ function jslint_phase3_parse(state) {
     prefix("{", function () {
         const seen = empty();
         const the_brace = token_now;
+        let extra;
+        let full;
+        let id;
+        let name;
+        let value;
+        let the_colon;
         the_brace.expression = [];
         if (token_nxt.id !== "}") {
 
 // Parse/loop through each property in {...}.
 
             while (true) {
-                let extra;
-                let full;
-                let id;
-                let name = token_nxt;
-                let value;
+                name = token_nxt;
                 advance();
                 if (
                     (name.id === "get" || name.id === "set")
@@ -3394,7 +3417,7 @@ function jslint_phase3_parse(state) {
 
                             advance("(");
                         }
-                        let the_colon = token_nxt;
+                        the_colon = token_nxt;
                         advance(":");
                         value = parse_expression(0);
                         if (
@@ -3504,20 +3527,60 @@ function jslint_phase3_parse(state) {
     });
 
     function do_var() {
-        const the_statement = token_now;
-        const mode_const = the_statement.id === "const";
-        the_statement.names = [];
+        const the_variable = token_now;
+        const mode_const = the_variable.id === "const";
+        switch (
+            Boolean(
+                option_dict.beta
+                && !option_dict.variable
+                && functionage.last_statement
+            )
+            && functionage.last_statement.id
+        ) {
+        case "const":
+
+// cause: "/*jslint beta*/\nfunction aa(){const aa=0;const bb=0;}"
+
+            break;
+        case "import":
+
+// cause: "/*jslint beta*/\nimport aa from \"aa\";\nlet bb=0;"
+
+            break;
+        case "let":
+
+// cause: "/*jslint beta*/\nfunction aa(){let aa=0;let bb=0;}"
+
+            break;
+        case "var":
+
+// cause: "/*jslint beta*/\nfunction aa(){var aa=0;var bb=0;}"
+
+            break;
+        case false:
+
+// cause: "/*jslint beta*/\nfunction aa(){var aa=0;var bb=0;}"
+
+            break;
+        default:
+
+// cause: "/*jslint beta*/\nfunction aa(){aa();let aa=0;}"
+// cause: "/*jslint beta*/\nfunction aa(){try{aa();}catch(aa){let aa=0;}}"
+
+            warn("var_on_top", token_now);
+        }
+        the_variable.names = [];
 
 // A program may use var or let, but not both.
 
         if (!mode_const) {
             if (mode_var === undefined) {
-                mode_var = the_statement.id;
-            } else if (the_statement.id !== mode_var) {
+                mode_var = the_variable.id;
+            } else if (the_variable.id !== mode_var) {
 
 // cause: "let aa;var aa"
 
-                warn("expected_a_b", the_statement, mode_var, the_statement.id);
+                warn("expected_a_b", the_variable, mode_var, the_variable.id);
             }
         }
 
@@ -3527,26 +3590,29 @@ function jslint_phase3_parse(state) {
 
 // cause: "switch(0){case 0:var aa}"
 
-            warn("var_switch", the_statement);
+            warn("var_switch", the_variable);
         }
-        if (functionage.loop > 0 && the_statement.id === "var") {
+        if (functionage.loop > 0 && the_variable.id === "var") {
 
 // cause: "while(0){var aa;}"
 
-            warn("var_loop", the_statement);
+            warn("var_loop", the_variable);
         }
         (function next() {
-            if (token_nxt.id === "{" && the_statement.id !== "var") {
-                const the_brace = token_nxt;
+            let name;
+            let the_brace;
+            let the_bracket;
+            if (token_nxt.id === "{" && the_variable.id !== "var") {
+                the_brace = token_nxt;
                 advance("{");
                 (function pair() {
-                    if (!token_nxt.identifier) {
+                    name = token_nxt;
+                    if (!name.identifier) {
 
 // cause: "let {0}"
 
                         return stop("expected_identifier_a");
                     }
-                    const name = token_nxt;
                     survey(name);
                     advance();
                     if (token_nxt.id === ":") {
@@ -3559,12 +3625,12 @@ function jslint_phase3_parse(state) {
                             return stop("expected_identifier_a");
                         }
                         token_nxt.label = name;
-                        the_statement.names.push(token_nxt);
+                        the_variable.names.push(token_nxt);
                         enroll(token_nxt, "variable", mode_const);
                         advance();
                         the_brace.open = true;
                     } else {
-                        the_statement.names.push(name);
+                        the_variable.names.push(name);
                         enroll(name, "variable", mode_const);
                     }
                     name.dead = false;
@@ -3585,12 +3651,12 @@ function jslint_phase3_parse(state) {
 
 // cause: "let{bb,aa}"
 
-                warn_if_unordered("variable", the_statement.names);
+                warn_if_unordered("variable", the_variable.names);
                 advance("}");
                 advance("=");
-                the_statement.expression = parse_expression(0);
-            } else if (token_nxt.id === "[" && the_statement.id !== "var") {
-                const the_bracket = token_nxt;
+                the_variable.expression = parse_expression(0);
+            } else if (token_nxt.id === "[" && the_variable.id !== "var") {
+                the_bracket = token_nxt;
                 advance("[");
                 (function element() {
                     let ellipsis;
@@ -3604,9 +3670,9 @@ function jslint_phase3_parse(state) {
 
                         return stop("expected_identifier_a");
                     }
-                    const name = token_nxt;
+                    name = token_nxt;
                     advance();
-                    the_statement.names.push(name);
+                    the_variable.names.push(name);
                     enroll(name, "variable", mode_const);
                     name.dead = false;
                     name.init = true;
@@ -3626,9 +3692,9 @@ function jslint_phase3_parse(state) {
                 }());
                 advance("]");
                 advance("=");
-                the_statement.expression = parse_expression(0);
+                the_variable.expression = parse_expression(0);
             } else if (token_nxt.identifier) {
-                const name = token_nxt;
+                name = token_nxt;
                 advance();
                 if (name.id === "ignore") {
 
@@ -3643,7 +3709,7 @@ function jslint_phase3_parse(state) {
                     name.init = true;
                     name.expression = parse_expression(0);
                 }
-                the_statement.names.push(name);
+                the_variable.names.push(name);
             } else {
 
 // cause: "let 0"
@@ -3653,7 +3719,7 @@ function jslint_phase3_parse(state) {
             }
         }());
         semicolon();
-        return the_statement;
+        return the_variable;
     }
 
     stmt("const", do_var);
@@ -3943,6 +4009,7 @@ function jslint_phase3_parse(state) {
     stmt("import", function () {
         const the_import = token_now;
         let name;
+        let names;
         if (typeof state.mode_module === "object") {
 
 // cause: "/*global aa*/\nimport aa from \"aa\""
@@ -3966,7 +4033,7 @@ function jslint_phase3_parse(state) {
             enroll(name, "variable", true);
             the_import.name = name;
         } else {
-            const names = [];
+            names = [];
             advance("{");
             if (token_nxt.id !== "}") {
                 while (true) {
@@ -4034,7 +4101,9 @@ function jslint_phase3_parse(state) {
         let dups = [];
         let last;
         let stmts;
+        let the_default;
         let the_disrupt = true;
+        let the_last;
         not_top_level(the_switch);
         if (functionage.finally > 0) {
 
@@ -4054,12 +4123,13 @@ function jslint_phase3_parse(state) {
         advance("{");
         (function major() {
             const the_case = token_nxt;
+            let exp;
             the_case.arity = "statement";
             the_case.expression = [];
             (function minor() {
                 advance("case");
                 token_now.switch = true;
-                const exp = parse_expression(0);
+                exp = parse_expression(0);
                 if (dups.some(function (thing) {
                     return is_equal(thing, exp);
                 })) {
@@ -4119,7 +4189,7 @@ function jslint_phase3_parse(state) {
         }));
         dups = undefined;
         if (token_nxt.id === "default") {
-            const the_default = token_nxt;
+            the_default = token_nxt;
             advance("default");
             token_now.switch = true;
             advance(":");
@@ -4131,7 +4201,7 @@ function jslint_phase3_parse(state) {
                 warn("unexpected_a", the_default);
                 the_disrupt = false;
             } else {
-                const the_last = the_switch.else[
+                the_last = the_switch.else[
                     the_switch.else.length - 1
                 ];
                 if (
@@ -4182,17 +4252,17 @@ function jslint_phase3_parse(state) {
         the_try.block = block();
         the_disrupt = the_try.block.disrupt;
         if (token_nxt.id === "catch") {
-            advance("catch");
-            the_catch = token_nxt;
-            the_catch.context = empty();
-            the_catch.async = functionage.async;
-            the_try.catch = the_catch;
-
-// Create new function-scope for catch-parameter.
-
-            function_stack.push(functionage);
-            functionage = the_catch;
             ignored = "ignore";
+            the_catch = token_nxt;
+            the_try.catch = the_catch;
+            advance("catch");
+
+// Create new catch-scope for catch-parameter.
+
+            catch_stack.push(catchage);
+            catchage = the_catch;
+            catch_list.push(catchage);
+            the_catch.context = empty();
             if (token_nxt.id === "(") {
                 advance("(");
                 if (!token_nxt.identifier) {
@@ -4214,13 +4284,9 @@ function jslint_phase3_parse(state) {
                 the_disrupt = false;
             }
 
-// Restore previous function-scope after catch-block.
+// Restore previous catch-scope after catch-block.
 
-            functionage = function_stack.pop();
-            functionage.async = Math.max(
-                functionage.async,
-                the_catch.async
-            );
+            catchage = catch_stack.pop();
         } else {
 
 // cause: "try{}finally{break;}"
@@ -4349,6 +4415,8 @@ function jslint_phase3_parse(state) {
 
                     const object = empty();
                     const properties = [];
+                    let name;
+                    let value;
                     brace.expression = properties;
                     advance("{");
                     if (token_nxt.id !== "}") {
@@ -4357,8 +4425,6 @@ function jslint_phase3_parse(state) {
 // Parse/loop through each property in {...}.
 
                         while (true) {
-                            let name;
-                            let value;
                             if (token_nxt.quote !== "\"") {
 
 // cause: "{0:0}"
@@ -4434,12 +4500,14 @@ function jslint_phase3_parse(state) {
 
 function jslint_phase4_walk(state) {
 
-// PHASE 4. Walk <token_tree>, traversing all of the nodes of the tree. It is a
+// PHASE 4. Walk <token_tree>, traversing all nodes of the tree. It is a
 //          recursive traversal. Each node may be processed on the way down
 //          (preaction) and on the way up (postaction).
 
     const {
         artifact,
+        catch_stack,
+        function_stack,
         global_dict,
         is_equal,
         is_weird,
@@ -4449,13 +4517,13 @@ function jslint_phase4_walk(state) {
         warn
     } = state;
     const block_stack = [];     // The stack of blocks.
-    const function_stack = [];  // The stack of functions.
     const posts = empty();
     const pres = empty();
     const relationop = populate([       // The relational operators.
         "!=", "!==", "==", "===", "<", "<=", ">", ">="
     ]);
     let blockage = token_global;        // The current block.
+    let catchage = catch_stack[0];      // The current catch-block.
     let functionage = token_global;     // The current function.
     let postaction;
     let postamble;
@@ -4510,7 +4578,7 @@ function jslint_phase4_walk(state) {
 
         return function (the_token) {
 
-// Given a task set that was built by an action function, run all of the
+// Given a task set that was built by an action function, run all
 // relevant tasks on the token.
 
             let a_set = when[the_token.arity];
@@ -4633,11 +4701,14 @@ function jslint_phase4_walk(state) {
     }
 
     function lookup(thing) {
+        let the_variable;
         if (thing.arity === "variable") {
 
 // Look up the variable in the current context.
 
-            let the_variable = functionage.context[thing.id];
+            the_variable = (
+                functionage.context[thing.id] || catchage.context[thing.id]
+            );
 
 // If it isn't local, search all the other contexts. If there are name
 // collisions, take the most recent.
@@ -4662,6 +4733,7 @@ function jslint_phase4_walk(state) {
 // cause: "aa"
 // cause: "class aa{}"
 // cause: "let aa=0;try{aa();}catch(bb){bb();}bb();"
+// cause: "let aa=0;try{aa();}catch(ignore){bb();}"
 
                         warn("undeclared_a", thing);
                         return;
@@ -4900,9 +4972,12 @@ function jslint_phase4_walk(state) {
     preaction("assignment", bitwise_check);
     preaction("binary", bitwise_check);
     preaction("binary", function (thing) {
+        let left;
+        let right;
+        let value;
         if (relationop[thing.id] === true) {
-            const left = thing.expression[0];
-            const right = thing.expression[1];
+            left = thing.expression[0];
+            right = thing.expression[1];
             if (left.id === "NaN" || right.id === "NaN") {
 
 // cause: "NaN===NaN"
@@ -4917,7 +4992,7 @@ function jslint_phase4_walk(state) {
                         warn("expected_string_a", right);
                     }
                 } else {
-                    const value = right.value;
+                    value = right.value;
                     if (value === "null" || value === "undefined") {
 
 // cause: "typeof aa===\"undefined\""
@@ -4965,14 +5040,16 @@ function jslint_phase4_walk(state) {
     });
     preaction("binary", "(", function (thing) {
         const left = thing.expression[0];
+        let left_variable;
+        let parent;
         if (
             left.identifier
             && functionage.context[left.id] === undefined
             && typeof functionage.name === "object"
         ) {
-            const parent = functionage.name.parent;
+            parent = functionage.name.parent;
             if (parent) {
-                const left_variable = parent.context[left.id];
+                left_variable = parent.context[left.id];
                 if (
                     left_variable !== undefined
                     && left_variable.dead
@@ -5004,8 +5081,9 @@ function jslint_phase4_walk(state) {
         thing.live = [];
     });
     preaction("statement", "for", function (thing) {
+        let the_variable;
         if (thing.name !== undefined) {
-            const the_variable = lookup(thing.name);
+            the_variable = lookup(thing.name);
             if (the_variable !== undefined) {
                 the_variable.init = true;
                 if (!the_variable.writable) {
@@ -5022,10 +5100,10 @@ function jslint_phase4_walk(state) {
     preaction("statement", "try", function (thing) {
         if (thing.catch !== undefined) {
 
-// Create new function-scope for catch-parameter.
+// Create new catch-scope for catch-parameter.
 
-            function_stack.push(functionage);
-            functionage = thing.catch;
+            catch_stack.push(catchage);
+            catchage = thing.catch;
         }
     });
     preaction("unary", "~", bitwise_check);
@@ -5060,6 +5138,7 @@ function jslint_phase4_walk(state) {
 // in case of destructuring) in its name property.
 
         const lvalue = thing.expression[0];
+        let right;
         if (thing.id === "=") {
             if (thing.names !== undefined) {
 
@@ -5106,7 +5185,7 @@ function jslint_phase4_walk(state) {
                     warn("bad_assignment_a", lvalue);
                 }
             }
-            const right = syntax_dict[thing.expression[1].id];
+            right = syntax_dict[thing.expression[1].id];
             if (
                 right !== undefined
                 && (
@@ -5234,9 +5313,13 @@ function jslint_phase4_walk(state) {
     });
     postaction("binary", "=>", postaction_function);
     postaction("binary", "(", function (thing) {
-        let left = thing.expression[0];
-        let the_new;
         let arg;
+        let array;
+        let cack;
+        let left = thing.expression[0];
+        let new_date;
+        let paren;
+        let the_new;
         if (left.id === "new") {
             the_new = left;
             left = left.expression;
@@ -5307,7 +5390,7 @@ function jslint_phase4_walk(state) {
                 }
             }
         } else if (left.id === ".") {
-            let cack = the_new !== undefined;
+            cack = the_new !== undefined;
             if (left.expression.id === "Date" && left.name.id === "UTC") {
 
 // cause: "new Date.UTC()"
@@ -5336,11 +5419,11 @@ function jslint_phase4_walk(state) {
                 }
             }
             if (left.name.id === "getTime") {
-                const paren = left.expression;
+                paren = left.expression;
                 if (paren.id === "(") {
-                    const array = paren.expression;
+                    array = paren.expression;
                     if (array.length === 1) {
-                        const new_date = array[0];
+                        new_date = array[0];
                         if (
                             new_date.id === "new"
                             && new_date.expression.id === "Date"
@@ -5400,18 +5483,18 @@ function jslint_phase4_walk(state) {
     });
     postaction("statement", "let", action_var);
     postaction("statement", "try", function (thing) {
-        if (thing.catch !== undefined) {
-            const the_name = thing.catch.name;
-            if (the_name !== undefined) {
-                const the_variable = functionage.context[the_name.id];
-                the_variable.dead = false;
-                the_variable.init = true;
+        if (thing.catch) {
+            if (thing.catch.name) {
+                Object.assign(catchage.context[thing.catch.name.id], {
+                    dead: false,
+                    init: true
+                });
             }
             walk_statement(thing.catch.block);
 
-// Restore previous function-scope after catch-block.
+// Restore previous catch-scope after catch-block.
 
-            functionage = function_stack.pop();
+            catchage = catch_stack.pop();
         }
     });
     postaction("statement", "var", action_var);
@@ -5519,13 +5602,14 @@ function jslint_phase5_whitage(state) {
 
     const {
         artifact,
+        catch_list,
         function_list,
+        function_stack,
         option_dict,
         token_global,
         token_list,
         warn
     } = state;
-    const function_stack = [];  // The stack of functions.
     const spaceop = populate([  // This is the set of infix operators that
                                 // require a space on each side.
         "!=", "!==", "%", "%=", "&", "&=", "&&", "*", "*=", "+=", "-=", "/",
@@ -5593,18 +5677,17 @@ function jslint_phase5_whitage(state) {
 
     function delve(the_function) {
         Object.keys(the_function.context).forEach(function (id) {
-            if (id !== "ignore") {
-                const name = the_function.context[id];
-                if (name.parent === the_function) {
+            const name = the_function.context[id];
+            if (id !== "ignore" && name.parent === the_function) {
 
 // cause: "let aa=function bb(){return;};"
 
-                    if (
-                        name.used === 0
-                        && assert_or_throw(
-                            name.role !== "function",
-                            `Expected name.role !== "function".`
-                        )
+                if (
+                    name.used === 0
+                    && assert_or_throw(
+                        name.role !== "function",
+                        `Expected name.role !== "function".`
+                    )
 
 // Probably deadcode.
 // && (
@@ -5612,18 +5695,18 @@ function jslint_phase5_whitage(state) {
 //     || name.parent.arity !== "unary"
 // )
 
-                    ) {
+                ) {
 
 // cause: "/*jslint node*/\nlet aa;"
 // cause: "function aa(aa){return;}"
+// cause: "let aa=0;try{aa();}catch(bb){aa();}"
 
-                        warn("unused_a", name);
-                    } else if (!name.init) {
+                    warn("unused_a", name);
+                } else if (!name.init) {
 
 // cause: "/*jslint node*/\nlet aa;aa();"
 
-                        warn("uninitialized_a", name);
-                    }
+                    warn("uninitialized_a", name);
                 }
             }
 
@@ -5762,6 +5845,7 @@ function jslint_phase5_whitage(state) {
     if (state.mode_module === true || option_dict.node) {
         delve(token_global);
     }
+    catch_list.forEach(delve);
     function_list.forEach(delve);
 
     if (option_dict.white) {
@@ -6158,48 +6242,95 @@ function jslint(
 // usually true. Some options will also predefine some number of global
 // variables.
 
-        bitwise: true,
-        browser: [
-            "caches", "CharacterData", "clearInterval", "clearTimeout",
-            "document",
-            "DocumentType", "DOMException", "Element", "Event", "event",
-            "fetch",
-            "FileReader", "FontFace", "FormData", "history",
+        beta: true,     // Enable features currently in beta.
+        bitwise: true,  // Allow bitwise-operators.
+        browser: [      // Assume browser-environment.
+            "CharacterData",
+            "DOMException",
+            "DocumentType",
+            "Element",
+            "Event",
+            "FileReader",
+            "FontFace",
+            "FormData",
             "IntersectionObserver",
-            "localStorage", "location", "MutationObserver", "name", "navigator",
-            "screen", "sessionStorage", "setInterval", "setTimeout", "Storage",
-            "TextDecoder", "TextEncoder", "URL", "window", "Worker",
-            "XMLHttpRequest"
+            "MutationObserver",
+            "Storage",
+            "TextDecoder",
+            "TextEncoder",
+            "URL",
+            "Worker",
+            "XMLHttpRequest",
+            "caches",
+            "clearInterval",
+            "clearTimeout",
+            "document",
+            "event",
+            "fetch",
+            "history",
+            "localStorage",
+            "location",
+            "name",
+            "navigator",
+            "screen",
+            "sessionStorage",
+            "setInterval",
+            "setTimeout",
+            "window"
         ],
-        convert: true,
-        couch: [
+        convert: true,          // Allow conversion-operators.
+        couch: [                // Assume couchdb-environment.
             "emit", "getRow", "isArray", "log", "provides", "registerType",
             "require", "send", "start", "sum", "toJSON"
         ],
-        debug: true,
-        devel: [
+        debug: true,            // Include jslint stack-trace in warning.
+        devel: [                // Allow logging-functions.
             "alert", "confirm", "console", "prompt"
         ],
-        eval: true,
-        for: true,
-        getset: true,
-        long: true,
-        name: true,
-        node: [
-            "Buffer", "clearImmediate", "clearInterval", "clearTimeout",
-            "console", "exports", "module", "process", "require",
-            "setImmediate", "setInterval", "setTimeout", "TextDecoder",
-            "TextEncoder", "URL", "URLSearchParams", "__dirname", "__filename"
+        eval: true,             // Allow Function() and eval().
+        for: true,              // Allow for-statement.
+        getset: true,           // Allow get() and set().
+        long: true,             // Allow long lines.
+        name: true,             // Allow bad property names.
+        node: [                 // Assume node-environment.
+            "Buffer",
+            "TextDecoder",
+            "TextEncoder",
+            "URL",
+            "URLSearchParams",
+            "__dirname",
+            "__filename",
+            "clearImmediate",
+            "clearInterval",
+            "clearTimeout",
+            "console",
+            "exports",
+            "module",
+            "process",
+            "require",
+            "setImmediate",
+            "setInterval",
+            "setTimeout"
         ],
-        single: true,
-        test_internal_error: true,
-        this: true,
-        unordered: true,
-        white: true
+        single: true,           // Allow single-quote strings.
+        test_internal_error: true,      // Test jslint's internal-error
+                                        // handling-ability.
+        this: true,             // Allow this.
+        unordered: true,        // Allow unordered cases, params, properties.
+        variable: true,         // Allow unordered variable-declarations that
+                                // are not at top of function-scope.
+        white: true             // Allow whitespace mess.
     };
+    const catch_list = [];      // The array containing all catch-blocks.
+    const catch_stack = [       // The stack of catch-blocks.
+        {
+            context: empty()
+        }
+    ];
     const directive_list = [];          // The directive comments.
     const export_dict = empty();        // The exported names and values.
-    const function_list = [];   // The array containing all of the functions.
+    const function_list = [];   // The array containing all functions.
+    const function_stack = [];  // The stack of functions.
     const global_dict = empty();        // The object containing the global
                                         // declarations.
     const import_list = [];     // The array collecting all import-from strings.
@@ -6217,16 +6348,53 @@ function jslint(
                                         // property names.
     const standard = [          // These are the globals that are provided by
                                 // the language standard.
-        "Array", "ArrayBuffer", "Boolean", "DataView", "Date", "Error",
+        "Array",
+        "ArrayBuffer",
+        "Boolean",
+        "DataView",
+        "Date",
+        "Error",
         "EvalError",
-        "Float32Array", "Float64Array", "Generator", "GeneratorFunction",
-        "Int16Array", "Int32Array", "Int8Array", "Intl", "JSON", "Map", "Math",
-        "Number", "Object", "Promise", "Proxy", "RangeError", "ReferenceError",
-        "Reflect", "RegExp", "Set", "String", "Symbol", "SyntaxError", "System",
-        "TypeError", "URIError", "Uint16Array", "Uint32Array", "Uint8Array",
-        "Uint8ClampedArray", "WeakMap", "WeakSet", "decodeURI",
-        "decodeURIComponent", "encodeURI", "encodeURIComponent", "globalThis",
-        "import", "parseFloat", "parseInt"
+        "Float32Array",
+        "Float64Array",
+        "Generator",
+        "GeneratorFunction",
+        "Int16Array",
+        "Int32Array",
+        "Int8Array",
+        "Intl",
+        "JSON",
+        "Map",
+        "Math",
+        "Number",
+        "Object",
+        "Promise",
+        "Proxy",
+        "RangeError",
+        "ReferenceError",
+        "Reflect",
+        "RegExp",
+        "Set",
+        "String",
+        "Symbol",
+        "SyntaxError",
+        "System",
+        "TypeError",
+        "URIError",
+        "Uint16Array",
+        "Uint32Array",
+        "Uint8Array",
+        "Uint8ClampedArray",
+        "WeakMap",
+        "WeakSet",
+        "decodeURI",
+        "decodeURIComponent",
+        "encodeURI",
+        "encodeURIComponent",
+        "globalThis",
+        "import",
+        "parseFloat",
+        "parseInt"
     ];
     const state = empty();      // jslint state-object to be passed between
                                 // jslint functions.
@@ -6659,6 +6827,9 @@ function jslint(
         case "var_loop":
             mm = `Don't declare variables in a loop.`;
             break;
+        case "var_on_top":
+            mm = `Move const, let, var declarations to top of function-scope.`;
+            break;
         case "var_switch":
             mm = `Don't declare variables in a switch.`;
             break;
@@ -6763,20 +6934,21 @@ function jslint(
         populate(global_list, global_dict, false);
         populate(standard, global_dict, false);
         Object.keys(option_dict).forEach(function (name) {
-            if (option_dict[name] === true) {
-                const allowed = allowed_option[name];
-                if (Array.isArray(allowed)) {
-                    populate(allowed, global_dict, false);
-                }
+            const allowed = allowed_option[name];
+            if (option_dict[name] === true && Array.isArray(allowed)) {
+                populate(allowed, global_dict, false);
             }
         });
 
         Object.assign(state, {
             allowed_option,
             artifact,
+            catch_list,
+            catch_stack,
             directive_list,
             export_dict,
             function_list,
+            function_stack,
             global_dict,
             import_list,
             is_equal,
@@ -6805,28 +6977,53 @@ function jslint(
 // PHASE 1. Split <source> by newlines into <line_list>.
 
         jslint_phase1_split(state);
+        assert_or_throw(catch_stack.length === 1, `catch_stack.length === 1.`);
+        assert_or_throw(
+            function_stack.length === 0,
+            `function_stack.length === 0.`
+        );
 
 // PHASE 2. Lex <line_list> into <token_list>.
 
         jslint_phase2_lex(state);
+        assert_or_throw(catch_stack.length === 1, `catch_stack.length === 1.`);
+        assert_or_throw(
+            function_stack.length === 0,
+            `function_stack.length === 0.`
+        );
 
 // PHASE 3. Parse <token_list> into <token_tree> using the Pratt-parser.
 
         jslint_phase3_parse(state);
+        assert_or_throw(catch_stack.length === 1, `catch_stack.length === 1.`);
+        assert_or_throw(
+            function_stack.length === 0,
+            `function_stack.length === 0.`
+        );
 
-// PHASE 4. Walk <token_tree>, traversing all of the nodes of the tree. It is a
+// PHASE 4. Walk <token_tree>, traversing all nodes of the tree. It is a
 //          recursive traversal. Each node may be processed on the way down
 //          (preaction) and on the way up (postaction).
 
         if (!state.mode_json) {
             jslint_phase4_walk(state);
         }
+        assert_or_throw(catch_stack.length === 1, `catch_stack.length === 1.`);
+        assert_or_throw(
+            function_stack.length === 0,
+            `function_stack.length === 0.`
+        );
 
 // PHASE 5. Check whitespace between tokens in <token_list>.
 
         if (!state.mode_json && warning_list.length === 0) {
             jslint_phase5_whitage(state);
         }
+        assert_or_throw(catch_stack.length === 1, `catch_stack.length === 1.`);
+        assert_or_throw(
+            function_stack.length === 0,
+            `function_stack.length === 0.`
+        );
 
         if (!option_dict.browser) {
             directive_list.forEach(function (comment) {

--- a/jslint.js
+++ b/jslint.js
@@ -250,14 +250,14 @@ function jslint_phase2_lex(state) {
     let line_whole = "";        // The whole line source string.
     let mode_directive = true;  // true if directives are still allowed.
     let mode_mega = false;      // true if currently parsing a megastring
-                                // literal.
+                                //     literal.
     let mode_regexp;    // true if regular expression literal seen on this line.
     let snippet = "";   // A piece of string.
     let token_1;        // The first token.
     let token_before_slash = token_global;      // The previous token excluding
-                                                // comments.
+                                                //     comments.
     let token_prv = token_global;       // The previous token including
-                                        // comments.
+                                        //     comments.
 
 // Most tokens, including the identifiers, operators, and punctuators, can be
 // found with a regular expression. Regular expressions cannot correctly match
@@ -1545,9 +1545,9 @@ function jslint_phase3_parse(state) {
     let mode_var;               // "var" if using var; "let" if using let.
     let token_ii = 0;           // The number of the next token.
     let token_now = token_global;       // The current token being examined in
-                                        // the parse.
+                                        //     the parse.
     let token_nxt = token_global;       // The next token to be examined in
-                                        // <token_list>.
+                                        //     <token_list>.
 
     function warn_if_unordered(type, token_list) {
 
@@ -3564,6 +3564,7 @@ function jslint_phase3_parse(state) {
             break;
         default:
 
+// cause: "/*jslint beta*/\nconsole.log();let aa=0;"
 // cause: "/*jslint beta*/\nfunction aa(){aa();let aa=0;}"
 // cause: "/*jslint beta*/\nfunction aa(){try{aa();}catch(aa){let aa=0;}}"
 
@@ -5611,7 +5612,7 @@ function jslint_phase5_whitage(state) {
         warn
     } = state;
     const spaceop = populate([  // This is the set of infix operators that
-                                // require a space on each side.
+                                //     require a space on each side.
         "!=", "!==", "%", "%=", "&", "&=", "&&", "*", "*=", "+=", "-=", "/",
         "/=", "<", "<=", "<<", "<<=", "=", "==", "===", "=>", ">", ">=",
         ">>", ">>=", ">>>", ">>>=", "^", "^=", "|", "|=", "||"
@@ -6230,7 +6231,7 @@ function jslint(
     source = "",        // A text to analyze, a string or an array of strings.
     option_dict = empty(),  // An object whose keys correspond to option names.
     global_list = []    // An array of strings containing global variables that
-                        // the file is allowed readonly access.
+                        //     the file is allowed readonly access.
 ) {
 
 // The jslint function itself.
@@ -6242,9 +6243,9 @@ function jslint(
 // usually true. Some options will also predefine some number of global
 // variables.
 
-        beta: true,     // Enable features currently in beta.
-        bitwise: true,  // Allow bitwise-operators.
-        browser: [      // Assume browser-environment.
+        beta: true,             // Enable experimental features.
+        bitwise: true,          // Allow bitwise operators.
+        browser: [              // Assume browser environment.
             "CharacterData",
             "DOMException",
             "DocumentType",
@@ -6278,21 +6279,21 @@ function jslint(
             "setTimeout",
             "window"
         ],
-        convert: true,          // Allow conversion-operators.
-        couch: [                // Assume couchdb-environment.
+        convert: true,          // Allow conversion operators.
+        couch: [                // Assume CouchDb environment.
             "emit", "getRow", "isArray", "log", "provides", "registerType",
             "require", "send", "start", "sum", "toJSON"
         ],
-        debug: true,            // Include jslint stack-trace in warning.
-        devel: [                // Allow logging-functions.
+        debug: true,            // Include jslint stack-trace in warnings.
+        devel: [                // Allow console.log() and friends.
             "alert", "confirm", "console", "prompt"
         ],
-        eval: true,             // Allow Function() and eval().
+        eval: true,             // Allow eval().
         for: true,              // Allow for-statement.
         getset: true,           // Allow get() and set().
-        long: true,             // Allow long lines.
-        name: true,             // Allow bad property names.
-        node: [                 // Assume node-environment.
+        long: true,             // Allow long-lines.
+        name: true,             // Allow weird property-names.
+        node: [                 // Assume Node.js environment.
             "Buffer",
             "TextDecoder",
             "TextEncoder",
@@ -6314,12 +6315,12 @@ function jslint(
         ],
         single: true,           // Allow single-quote strings.
         test_internal_error: true,      // Test jslint's internal-error
-                                        // handling-ability.
-        this: true,             // Allow this.
+                                        //     handling-ability.
+        this: true,             // Allow 'this'.
         unordered: true,        // Allow unordered cases, params, properties.
         variable: true,         // Allow unordered variable-declarations that
-                                // are not at top of function-scope.
-        white: true             // Allow whitespace mess.
+                                //     are not at top of function-scope.
+        white: true             // Allow messy whitespace.
     };
     const catch_list = [];      // The array containing all catch-blocks.
     const catch_stack = [       // The stack of catch-blocks.
@@ -6332,7 +6333,7 @@ function jslint(
     const function_list = [];   // The array containing all functions.
     const function_stack = [];  // The stack of functions.
     const global_dict = empty();        // The object containing the global
-                                        // declarations.
+                                        //     declarations.
     const import_list = [];     // The array collecting all import-from strings.
     const line_list = String(   // The array containing source lines.
         "\n" + source
@@ -6345,9 +6346,9 @@ function jslint(
         };
     });
     const property_dict = empty();      // The object containing the tallied
-                                        // property names.
+                                        //     property names.
     const standard = [          // These are the globals that are provided by
-                                // the language standard.
+                                //     the language standard.
         "Array",
         "ArrayBuffer",
         "Boolean",

--- a/test.js
+++ b/test.js
@@ -62,24 +62,6 @@ function noop() {
 /*
  * this function will test jslint's option handling-behavior
  */
-    assertOrThrow(jslint("", {
-        bitwise: true,
-        browser: true,
-        convert: true,
-        couch: true,
-        debug: true,
-        devel: true,
-        eval: true,
-        for: true,
-        getset: true,
-        long: true,
-        name: true,
-        node: true,
-        single: true,
-        this: true,
-        unordered: true,
-        white: true
-    }).warnings.length === 0);
     [
         [
             "let aa = aa | 0;", {bitwise: true}, []
@@ -132,6 +114,15 @@ function noop() {
             ), {unordered: true}, []
         ], [
             "let {bb, aa} = 0;", {unordered: true}, []
+        ], [
+            (
+                "function aa() {\n"
+                + "    if (aa) {\n"
+                + "        let bb = 0;\n"
+                + "        return bb;\n"
+                + "    }\n"
+                + "}\n"
+            ), {variable: true}, []
         ], [
             "\t", {white: true}, []
         ]


### PR DESCRIPTION
- jslint - add new warning if const/let/var statements are not declared at top of function-scope.
- jslint - add new directive `/*jslint beta*/` - enable features currently in beta.
- bugfix - fix no-warning when exception in catch-block is unused (refactor pr #306).

this pr would fix #279 .

the solution may seem drastic, but i think its the right direction.  the new warning is behind a beta-flag (use directive `/*jslint beta*/` to enable the new warning).

essentially jslint would require all variable declarations (including `const` and `let`) to be placed at top of function-scope (or beginning of script -- after any import-statements).  this pr also contains a bit of code-refactoring to comply with the new warning.