### PR TITLE
## v2021.6.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - tests - update function warn_at() with assertion-check matching column with artifact.
 
-## v2021.6.14-beta
+## v2021.6.22
 - bugfix - fix global_list being ignored by jslint.
 - bugfix - fix no-warning when exception in catch-block is unused.
 - ci - migrate ci-scripts from cjs to esm.
+- cli - add env-variable \$JSLINT_BETA.
 - jslint - add new directive `/*jslint beta*/` - enable features currently in beta.
 - jslint - add new directive `/*jslint variable*/` - allow unordered variable-declarations that are not at top of function-scope.
 - jslint - add new warning if const/let/var statements are not declared at top of function-scope.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Status
-| Branch | [master<br>(v2021.6.12)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
+| Branch | [master<br>(v2021.6.22)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
 |--:|:--:|:--:|:--:|
 | CI | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jslint-org/jslint/actions?query=branch%3Amaster) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/jslint-org/jslint/actions?query=branch%3Abeta) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/jslint-org/jslint/actions?query=branch%3Aalpha) |
 | Coverage | [![coverage](https://jslint-org.github.io/jslint/branch-master/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch-master/.build/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-beta/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch-beta/.build/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-alpha/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch-alpha/.build/coverage/index.html) |

--- a/browser.js
+++ b/browser.js
@@ -349,7 +349,7 @@ import jslint from \u0022./jslint.mjs\u0022;
 import https from "https";
 
 // Optional directives.
-// .... /*jslint beta*/ .......... Enable experimental features.
+// .... /*jslint beta*/ .......... Enable extra warnings currently in beta.
 // .... /*jslint bitwise*/ ....... Allow bitwise operators.
 // .... /*jslint browser*/ ....... Assume browser environment.
 // .... /*jslint convert*/ ....... Allow conversion operators.
@@ -359,8 +359,8 @@ import https from "https";
 // .... /*jslint eval*/ .......... Allow eval().
 // .... /*jslint for*/ ........... Allow for-statement.
 // .... /*jslint getset*/ ........ Allow get() and set().
-// .... /*jslint long*/ .......... Allow long-lines.
-// .... /*jslint name*/ .......... Allow weird property-names.
+// .... /*jslint long*/ .......... Allow long lines.
+// .... /*jslint name*/ .......... Allow weird property names.
 // .... /*jslint node*/ .......... Assume Node.js environment.
 // .... /*jslint single*/ ........ Allow single-quote strings.
 // .... /*jslint test_internal_error*/ ... Test jslint's internal-error

--- a/ci.sh
+++ b/ci.sh
@@ -284,6 +284,7 @@ shCiBase() {(set -e
     ./jslint.js .
     (set -e
         # coverage-hack - test jslint's cli handling-behavior
+        export JSLINT_BETA=1
         export JSLINT_CLI=1
         shRunWithCoverage node test.js .
     )

--- a/jslint.js
+++ b/jslint.js
@@ -88,6 +88,7 @@
 /*jslint beta, node*/
 
 /*property
+    JSLINT_BETA,
     beta,
     catch_list, catch_stack, cli,
     function_stack,
@@ -119,7 +120,7 @@
     writable
 */
 
-const edition = "v2021.6.14-beta";
+const edition = "v2021.6.22";
 
 const line_fudge = 1;   // Fudge starting line and starting column to 1.
 
@@ -6285,7 +6286,7 @@ function jslint(
 // usually true. Some options will also predefine some number of global
 // variables.
 
-        beta: true,             // Enable experimental features.
+        beta: true,             // Enable extra warnings currently in beta.
         bitwise: true,          // Allow bitwise operators.
         browser: [              // Assume browser environment.
             "CharacterData",
@@ -6333,8 +6334,8 @@ function jslint(
         eval: true,             // Allow eval().
         for: true,              // Allow for-statement.
         getset: true,           // Allow get() and set().
-        long: true,             // Allow long-lines.
-        name: true,             // Allow weird property-names.
+        long: true,             // Allow long lines.
+        name: true,             // Allow weird property names.
         node: [                 // Assume Node.js environment.
             "Buffer",
             "TextDecoder",
@@ -7221,7 +7222,7 @@ async function jslint_cli({
 // Recursively jslint embedded "```javascript\n...\n```".
 
             code.replace((
-                /^```javascript\n([\S\s]*?\n)```$/gm
+                /^```(?:javascript|js)\n([\S\s]*?\n)```$/gm
             ), function (ignore, match1, ii) {
                 jslint_from_file({
                     code: match1,
@@ -7244,6 +7245,12 @@ async function jslint_cli({
                     file: file + ".<node -e>.js",
                     line_offset: string_line_count(code.slice(0, ii)) + 1,
                     option: Object.assign({
+                        beta: Boolean(
+                            process.env.JSLINT_BETA
+                            && !(
+                                /0|false|null|undefined/
+                            ).test(process.env.JSLINT_BETA)
+                        ),
                         node: true
                     }, option)
                 });


### PR DESCRIPTION
- bugfix - fix global_list being ignored by jslint.
- bugfix - fix no-warning when exception in catch-block is unused.
- ci - migrate ci-scripts from cjs to esm.
- cli - add env-variable \$JSLINT_BETA.
- jslint - add new directive `/*jslint beta*/` - enable features currently in beta.
- jslint - add new directive `/*jslint variable*/` - allow unordered variable-declarations that are not at top of function-scope.
- jslint - add new warning if const/let/var statements are not declared at top of function-scope.
- jslint - add new warning if const/let/var statements are unordered.
- website - invalidate url-cache with each deployment.
- website - replace .png logo with .svg logo.
- website - replace current-editor with CodeMirror-editor and change programming-font-family from `Programma` to `consolas, menlo, monospace`.