### PR TITLE
- ci - include explicit commonjs (jslint.cjs) and es-module (jslint.mjs) variants of jslint.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ undefined
 !.gitconfig
 !.github
 !.gitignore
+
+jslint.cjs
+jslint.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@
 - jslint - simplify comments/docs by removing unnecessary grammar-article "the".
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
 - jslint-refactor - migrate recursive-loops to for/while loops.
+- merge function.html and help.html into README.md
 - node - after node-v12 is deprecated, change `require("fs").promises` to `require("fs/promises")`.
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - tests - update function warn_at() with assertion-check matching column with artifact.
 
 ## v2021.6.24-beta
+- breaking-change - rename files *.js to *.mjs for better integration with nodejs.
 - ci - include explicit commonjs (jslint.cjs) and es-module (jslint.mjs) variants of jslint.
-- jslint - rename files *.js to *.mjs for better integration with nodejs.
 
 ## v2021.6.22
 - bugfix - fix global_list being ignored by jslint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 - app - deploy jslint as chrome-extension.
 - jslint - add `for...of` syntax support.
 - jslint - add html and css linting back into jslint.
-- jslint - include explicit commonjs (jslint.cjs) and es-module (jslint.mjs) variants of jslint.
 - jslint - reintroduce directive `/*jslint indent2*/` - allow 2-space indent.
 - jslint - remove directive `/*jslint eval*/` (use line-specific ignore-directive "//jslint-quiet" instead).
 - jslint - simplify comments/docs by removing unnecessary grammar-article "the".
@@ -13,6 +12,10 @@
 - node - after node-v12 is deprecated, change `require("fs").promises` to `require("fs/promises")`.
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - tests - update function warn_at() with assertion-check matching column with artifact.
+
+## v2021.6.24-beta
+- ci - include explicit commonjs (jslint.cjs) and es-module (jslint.mjs) variants of jslint.
+- jslint - rename files *.js to *.mjs for better integration with nodejs.
 
 ## v2021.6.22
 - bugfix - fix global_list being ignored by jslint.

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Install
-### 1. To install, just download and rename https://www.jslint.com/jslint.js to `jslint.mjs`:
+### 1. To install, just download https://www.jslint.com/jslint.mjs:
 ```shell
 #!/bin/sh
 
-curl -L https://www.jslint.com/jslint.js > jslint.mjs
+curl -L https://www.jslint.com/jslint.mjs > jslint.mjs
 ```
 
 ### 2. To run `jslint.mjs` from command-line:
@@ -81,11 +81,11 @@ node jslint.mjs .
 
 
 # Description
-- [jslint.js](jslint.js) contains the jslint function. It parses and analyzes a source file, returning an object with information about the file. It can also take an object that sets options.
+- [jslint.mjs](jslint.mjs) contains the jslint function. It parses and analyzes a source file, returning an object with information about the file. It can also take an object that sets options.
 
-- [index.html](index.html) runs the jslint.js function in a web page. The page also depends on `browser.js`.
+- [index.html](index.html) runs the jslint.mjs function in a web page. The page also depends on `browser.mjs`.
 
-- [browser.js](browser.js) runs the web user interface and generates the results reports in HTML.
+- [browser.mjs](browser.mjs) runs the web user interface and generates the results reports in HTML.
 
 - [help.html](help.html) describes JSLint's usage. Please [read it](https://jslint-org.github.io/jslint/help.html).
 

--- a/browser.mjs
+++ b/browser.mjs
@@ -1,4 +1,4 @@
-// browser.js
+// browser.mjs
 // 2018-06-16
 // Copyright (c) 2015 Douglas Crockford  (www.JSLint.com)
 
@@ -21,7 +21,7 @@
     warnings
 */
 
-import jslint from "./jslint.js";
+import jslint from "./jslint.mjs";
 
 // This is the web script companion file for JSLint. It includes code for
 // interacting with the browser and displaying the reports.
@@ -385,7 +385,7 @@ eval( //jslint-quiet
 (async function () {
     let result;
     result = await new Promise(function (resolve) {
-        https.request("https://www.jslint.com/jslint.js", function (res) {
+        https.request("https://www.jslint.com/jslint.mjs", function (res) {
             result = "";
             res.on("data", function (chunk) {
                 result += chunk;

--- a/function.html
+++ b/function.html
@@ -190,7 +190,7 @@ a:active {
 <center><table align="center">
 <tr><th>Filename</th><th>Content</th></tr>
 <tr>
-    <td><code>browser.js</code></td>
+    <td><code>browser.mjs</code></td>
 <td>Browser based UI and <code>report</code> object, containing report
     generator functions for HTML.</td></tr>
 <tr><td><code>function.html</code></td>
@@ -200,7 +200,7 @@ a:active {
 <tr><td><code>index.html</code></td>
     <td>Single page JSLint application that uses the
         <code>js</code> files.</td></tr>
-<tr><td><code>jslint.js</code></td>
+<tr><td><code>jslint.mjs</code></td>
 <td>The <code>jslint</code> function.</td></tr>
 </table></center>
 <h1><code>function jslint</code></h1>

--- a/index.html
+++ b/index.html
@@ -24,8 +24,8 @@
 <title>JSLint:&nbsp;The&nbsp;JavaScript&nbsp;Code Quality Tool</title>
 <!-- Google PageSpeed - reduce Largest Contentful Paint -->
 <link as="script" rel="preload" href="asset-codemirror-v5.58.3-rollup.js">
-<link rel="modulepreload" href="browser.js">
-<link rel="modulepreload" href="jslint.js">
+<link rel="modulepreload" href="browser.mjs">
+<link rel="modulepreload" href="jslint.mjs">
 <link rel="stylesheet" href="asset-codemirror-v5.58.3-rollup.css">
 <style>
 /*csslint
@@ -484,5 +484,12 @@ style="
   </fieldset>
 </div>
 <script defer src="asset-codemirror-v5.58.3-rollup.js"></script>
-<script src="browser.js" type="module"></script>
+<script src="browser.mjs" type="module"></script>
+<!-- coverage-hack -->
+<script>
+(function () {
+    return;
+}());
+</script>
+<!-- coverage-hack -->
 </body></html>

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// jslint.js
+// jslint.mjs
 // Copyright (c) 2015 Douglas Crockford  (www.JSLint.com)
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -90,13 +90,17 @@
 /*property
     JSLINT_BETA,
     beta,
-    catch_list, catch_stack, cli,
+    catch_list, catch_stack, cjs_module, cjs_require, cli,
     function_stack,
     global_dict,
     last_statement,
+    main, mode_force,
+    nodejs_process,
+    process_exit,
+    toString,
     variable,
     execArgv, fileURLToPath, filter, meta, order, reduce, stringify, token, url,
-    JSLINT_CLI, a, all, allowed_option, argv, arity, artifact, assign, async, b,
+    a, all, allowed_option, argv, arity, artifact, assign, async, b,
     bind, bitwise, block, body, browser, c, calls, catch, closer, closure, code,
     column, concat, console_error, constant, context, convert, couch, create,
     cwd, d, dead, debug, default, devel, directive, directive_list,
@@ -120,9 +124,12 @@
     writable
 */
 
-const edition = "v2021.6.22";
+const edition = "v2021.6.24-beta";
 
 const line_fudge = 1;   // Fudge starting line and starting column to 1.
+
+let import_meta_url = "";
+let jslint_export;
 
 function assert_or_throw(passed, message) {
 
@@ -163,7 +170,7 @@ function noop() {
     return;
 }
 
-// coverage-hack
+// Coverage-hack.
 noop();
 
 function populate(array, object = empty(), value = true) {
@@ -6393,8 +6400,48 @@ function jslint(
                                         //     property names.
     const standard = [          // These are the globals that are provided by
                                 //     the language standard.
+// node --input-type=module -e '
+// /*jslint beta node*/
+// import https from "https";
+// (async function () {
+//     var dict;
+//     var result = "";
+//     await new Promise(function (resolve) {
+//         https.get((
+//             "https://developer.mozilla.org"
+//             + "/en-US/docs/Web/JavaScript/Reference/Global_Objects"
+//         ), function (res) {
+//             res.on("data", function (chunk) {
+//                 result += chunk;
+//             }).on("end", resolve).setEncoding("utf8");
+//         });
+//     });
+//     dict = {
+//         import: true
+//     };
+//     result.replace(new RegExp((
+//         "href=\"\\/en-US\\/docs\\/Web\\/JavaScript\\/Reference"
+//         + "\\/Global_Objects\\/.*?<code>(\\w+).*?<\\/code>"
+//     ), "g"), function (ignore, key) {
+//         switch (globalThis.hasOwnProperty(key) && key) {
+//         case "escape":
+//         case "unescape":
+//         case "uneval":
+//         case false:
+//             break;
+//         default:
+//             dict[key] = true;
+//         }
+//     });
+//     console.log(JSON.stringify(Object.keys(dict).sort(), undefined, 4));
+// }());
+// '
         "Array",
         "ArrayBuffer",
+        "Atomics",
+        "BigInt",
+        "BigInt64Array",
+        "BigUint64Array",
         "Boolean",
         "DataView",
         "Date",
@@ -6402,8 +6449,8 @@ function jslint(
         "EvalError",
         "Float32Array",
         "Float64Array",
-        "Generator",
-        "GeneratorFunction",
+        "Function",
+        "Infinity",
         "Int16Array",
         "Int32Array",
         "Int8Array",
@@ -6411,6 +6458,7 @@ function jslint(
         "JSON",
         "Map",
         "Math",
+        "NaN",
         "Number",
         "Object",
         "Promise",
@@ -6420,10 +6468,10 @@ function jslint(
         "Reflect",
         "RegExp",
         "Set",
+        "SharedArrayBuffer",
         "String",
         "Symbol",
         "SyntaxError",
-        "System",
         "TypeError",
         "URIError",
         "Uint16Array",
@@ -6432,14 +6480,19 @@ function jslint(
         "Uint8ClampedArray",
         "WeakMap",
         "WeakSet",
+        "WebAssembly",
         "decodeURI",
         "decodeURIComponent",
         "encodeURI",
         "encodeURIComponent",
+        "eval",
         "globalThis",
         "import",
+        "isFinite",
+        "isNaN",
         "parseFloat",
-        "parseInt"
+        "parseInt",
+        "undefined"
     ];
     const state = empty();      // jslint state-object to be passed between
                                 // jslint functions.
@@ -7152,18 +7205,24 @@ function jslint(
 }
 
 async function jslint_cli({
+    cjs_module,
+    cjs_require,
     console_error,
     file,
+    mode_force,
+    nodejs_process,
     option,
+    process_exit,
     source
 }) {
 
 // This function will run jslint from nodejs-cli.
 
-    const module_fs = await import("fs");
-    const module_path = await import("path");
     let data;
-    let exit_code;
+    let exit_code = 0;
+    let module_fs;
+    let module_path;
+    let module_url;
 
     function string_line_count(code) {
 
@@ -7246,10 +7305,10 @@ async function jslint_cli({
                     line_offset: string_line_count(code.slice(0, ii)) + 1,
                     option: Object.assign({
                         beta: Boolean(
-                            process.env.JSLINT_BETA
+                            nodejs_process.env.JSLINT_BETA
                             && !(
                                 /0|false|null|undefined/
-                            ).test(process.env.JSLINT_BETA)
+                            ).test(nodejs_process.env.JSLINT_BETA)
                         ),
                         node: true
                     }, option)
@@ -7279,13 +7338,57 @@ async function jslint_cli({
         }
     }
 
+// Feature-detect nodejs.
+
+    if (mode_force) {
+        nodejs_process = typeof process === "object" && process;
+    }
+    if (!(
+        nodejs_process
+        && nodejs_process.versions
+        && typeof nodejs_process.versions.node === "string"
+    )) {
+        return exit_code;
+    }
     console_error = console_error || console.error;
+    module_fs = await import("fs");
+    module_path = await import("path");
+    module_url = await import("url");
+    process_exit = process_exit || nodejs_process.exit;
+    if (!(
 
-// Normalize file relative to process.cwd().
+// Feature-detect nodejs-cjs-cli.
 
+        (cjs_module && cjs_require)
+        ? cjs_module === cjs_require.main
+
+// Feature-detect nodejs-esm-cli.
+
+        : (
+            nodejs_process.execArgv.indexOf("--eval") === -1
+            && nodejs_process.execArgv.indexOf("-e") === -1
+            && (
+                (
+                    /[\/|\\]jslint(?:\.[cm]?js)?$/m
+                ).test(nodejs_process.argv[1])
+                || mode_force
+            )
+            && module_url.fileURLToPath(import_meta_url)
+            === module_path.resolve(nodejs_process.argv[1])
+        )
+    ) && !mode_force) {
+        return exit_code;
+    }
+
+// Normalize file relative to nodejs_process.cwd().
+
+    file = file || nodejs_process.argv[2];
+    if (!file) {
+        return;
+    }
     file = module_path.resolve(file) + "/";
-    if (file.startsWith(process.cwd() + "/")) {
-        file = file.replace(process.cwd() + "/", "").slice(0, -1) || ".";
+    if (file.startsWith(nodejs_process.cwd() + "/")) {
+        file = file.replace(nodejs_process.cwd() + "/", "").slice(0, -1) || ".";
     }
     file = file.replace((
         /\\/g
@@ -7298,7 +7401,8 @@ async function jslint_cli({
             file,
             option
         });
-        return;
+        process_exit(exit_code);
+        return exit_code;
     }
 
 // jslint_cli - jslint directory.
@@ -7314,16 +7418,12 @@ async function jslint_cli({
             switch ((
                 /\.\w+?$|$/m
             ).exec(file2)[0]) {
+            case ".cjs":
             case ".html":
-                break;
             case ".js":
-                break;
             case ".json":
-                break;
             case ".md":
-                break;
             case ".mjs":
-                break;
             case ".sh":
                 break;
             default:
@@ -7350,6 +7450,7 @@ async function jslint_cli({
                 "jslint - " + (Date.now() - time_start) + "ms - " + file2
             );
         }));
+        process_exit(exit_code);
         return exit_code;
     }
 
@@ -7359,51 +7460,51 @@ async function jslint_cli({
         data = await module_fs.promises.readFile(file, "utf8");
     } catch (err) {
         console_error(err);
-        return 1;
+        exit_code = 1;
+        process_exit(exit_code);
+        return exit_code;
     }
     jslint_from_file({
         code: data,
         file,
         option
     });
+    process_exit(exit_code);
     return exit_code;
 }
-export default Object.freeze(Object.assign(jslint, {
+
+jslint_export = Object.freeze(Object.assign(jslint, {
     cli: Object.freeze(jslint_cli),
     edition,
     jslint: Object.freeze(jslint.bind(undefined))
 }));
 
-(async function () {
+// Export jslint as commonjs/es-module.
 
-// Feature-detect nodejs-cli.
-
-    if (
-        typeof process === "object" && process && process.versions
-        && typeof process.versions.node === "string"
-        && process.execArgv.indexOf("--eval") === -1
-        && process.execArgv.indexOf("-e") === -1
-        && (
-            (
-                /[\/|\\]jslint(?:\.[cm]?js)?$/m
-            ).test(process.argv[1])
-            || process.env.JSLINT_CLI === "1"
-        )
-        && (
-            identity(await import("url")).fileURLToPath(import.meta.url)
-            === identity(await import("path")).resolve(process.argv[1])
-            || process.env.JSLINT_CLI === "1"
-        )
-    ) {
+// module.exports = jslint_export;
+export default Object.freeze(jslint_export);
+import_meta_url = import.meta.url;
 
 // Run jslint_cli.
 
-        jslint_cli({
-            file: process.argv[2]
-        }).then(function (exit_code) {
-            if (exit_code !== 0) {
-                process.exit(exit_code);
-            }
-        });
-    }
+(function () {
+    let cjs_module = {};
+    let cjs_require = {};
+    let nodejs_process = {};
+
+// Coverage-hack.
+// Init commonjs builtins in try-catch-block in case we're in es-module-mode.
+
+    try {
+        cjs_module = module;
+    } catch (ignore) {}
+    try {
+        nodejs_process = process;
+        cjs_require = require;
+    } catch (ignore) {}
+    jslint_cli({
+        cjs_module,
+        cjs_require,
+        nodejs_process
+    });
 }());

--- a/package.json
+++ b/package.json
@@ -1,4 +1,0 @@
-{
-    "name": "jslint",
-    "type": "module"
-}

--- a/test.mjs
+++ b/test.mjs
@@ -30,6 +30,7 @@ function noop() {
     }
     // test null handling-behavior
     jslint.cli({
+        mode_noop: true,
         process_exit: processExit0
     });
     // test file handling-behavior
@@ -147,7 +148,7 @@ function noop() {
         ], [
             "let {bb, aa} = 0;", {unordered: true}, []
         ], [
-            "let bb = 0;\nlet aa = 0;", {beta: true, variable: true}, []
+            "let bb = 0;\nlet aa = 0;", {variable: true}, []
         ], [
             (
                 "function aa() {\n"
@@ -156,13 +157,14 @@ function noop() {
                 + "        return bb;\n"
                 + "    }\n"
                 + "}\n"
-            ), {beta: true, variable: true}, []
+            ), {variable: true}, []
         ], [
             "\t", {white: true}, []
         ]
     ].forEach(function ([
         source, option_dict, global_list
     ]) {
+        option_dict.beta = true;
         // test jslint's option handling-behavior
         assertOrThrow(
             jslint(source, option_dict, global_list).warnings.length === 0,

--- a/test.mjs
+++ b/test.mjs
@@ -1,6 +1,6 @@
 /*jslint node*/
 import fs from "fs";
-import jslint from "./jslint.js";
+import jslint from "./jslint.mjs";
 
 function assertOrThrow(passed, msg) {
 /*
@@ -22,29 +22,61 @@ function noop() {
 /*
  * this function will test jslint's cli handling-behavior
  */
-    process.exit = function (exitCode) {
-        assertOrThrow(!exitCode, exitCode);
-    };
+    function processExit0(exitCode) {
+        assertOrThrow(exitCode === 0, exitCode);
+    }
+    function processExit1(exitCode) {
+        assertOrThrow(exitCode === 1, exitCode);
+    }
+    // test null handling-behavior
     jslint.cli({
-        file: "jslint.js"
+        process_exit: processExit0
     });
+    // test file handling-behavior
+    jslint.cli({
+        file: "jslint.mjs",
+        mode_force: true,
+        process_exit: processExit0
+
+    });
+    // test file-dir handling-behavior
+    jslint.cli({
+        file: ".",
+        mode_force: true,
+        process_exit: processExit0
+    });
+    // test file-error handling-behavior
     jslint.cli({
         // suppress error
         console_error: noop,
-        file: "undefined"
+        file: "undefined",
+        mode_force: true,
+        process_exit: processExit1
     });
+    // test file-undefined handling-behavior
+    jslint.cli({
+        mode_force: true,
+        process_exit: processExit0
+    });
+    // test cjs handling-behavior
+    jslint.cli({
+        cjs_module: {
+            exports: {}
+        },
+        cjs_require: {},
+        process_exit: processExit0
+    });
+    // test syntax-error handling-behavior
     jslint.cli({
         // suppress error
         console_error: noop,
-        file: "syntax_error.js",
+        file: "syntax-error.js",
+        mode_force: true,
         option: {
             debug: true
         },
+        process_exit: processExit1,
         source: "syntax error"
-    });
-    jslint.cli({
-        file: "aa.html",
-        source: "<script>\nlet aa = 0;\n</script>\n"
     });
 }());
 
@@ -305,7 +337,7 @@ function noop() {
  * malformed <code>
  */
     Array.from(String(
-        await fs.promises.readFile("jslint.js", "utf8")
+        await fs.promises.readFile("jslint.mjs", "utf8")
     ).matchAll(new RegExp((
         "\\s*?"
         + "(\\/\\/\\s*?cause:.*?\\n(?:\\/\\/.*?\\n)*?)"


### PR DESCRIPTION
- jslint - rename files *.js to *.mjs for better integration with nodejs.

this pr renames all *.js files to *.mjs so nodejs can import them without any configuration-hints (e.g. package.json).
also remove user-confusion when downloading/installing jslint, that it might be a .cjs file.

the ci will provide a cjs-variant at jslint.com (https://www.jslint.com/jslint.cjs).
for legacy installations, the old .js variant is available at website as well (https://www.jslint.com/jslint.js).

preview of .cjs and .mjs variants available at:
- https://github.com/jslint-org/jslint/blob/gh-pages/branch-alpha/jslint.cjs
- https://github.com/jslint-org/jslint/blob/gh-pages/branch-alpha/jslint.mjs
