### PR TITLE
- jslint - reintroduce directive `/*jslint indent2*/` - allow 2-space indent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 - cli - add command `report`.
 - jslint - add `for...of` syntax support.
 - jslint - add html and css linting back into jslint.
-- jslint - reintroduce directive `/*jslint indent2*/` - allow 2-space indent.
 - jslint - remove directive `/*jslint eval*/` (use line-specific ignore-directive "//jslint-quiet" instead).
 - jslint - simplify comments/docs by removing unnecessary grammar-article "the".
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
@@ -15,10 +14,11 @@
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - tests - update function warn_at() with assertion-check matching column with artifact.
 
-## v2021.6.24-beta
+## v2021.6.26-beta
 - breaking-change - rename files *.js to *.mjs for better integration with nodejs.
 - ci - auto-screenshot example-shell-commands in README.md.
 - ci - include explicit commonjs (jslint.cjs) and es-module (jslint.mjs) variants of jslint.
+- jslint - reintroduce directive `/*jslint indent2*/` - allow 2-space indent.
 
 ## v2021.6.22
 - bugfix - fix global_list being ignored by jslint.

--- a/browser.mjs
+++ b/browser.mjs
@@ -2,13 +2,10 @@
 // 2018-06-16
 // Copyright (c) 2015 Douglas Crockford  (www.JSLint.com)
 
-/*jslint
-    beta
-    browser
-*/
+/*jslint beta, browser*/
 
 /*property
-    click,
+    click, search, test
     CodeMirror, Tab, addEventListener, checked, closure, column, context,
     create, ctrlKey, display, edition, exports, extraKeys, filter, forEach,
     fromTextArea, froms, functions, getElementById, getValue, global, id,
@@ -341,9 +338,15 @@ function call_jslint() {
         mode: "text/javascript",
         showTrailingSpace: true
     });
+    if ((
+        /\bmode_debug=1\b/
+    ).test(location.search)) {
+        return;
+    }
     editor.setValue(`#!/usr/bin/env node
 
-/*jslint beta node*/
+/*jslint beta, node*/
+/*global atob, btoa*/ //jslint-quiet
 
 import jslint from \u0022./jslint.mjs\u0022;
 import https from "https";
@@ -359,6 +362,7 @@ import https from "https";
 // .... /*jslint eval*/ .......... Allow eval().
 // .... /*jslint for*/ ........... Allow for-statement.
 // .... /*jslint getset*/ ........ Allow get() and set().
+// .... /*jslint indent2*/ ....... Allow 2-space indent.
 // .... /*jslint long*/ .......... Allow long lines.
 // .... /*jslint name*/ .......... Allow weird property names.
 // .... /*jslint node*/ .......... Assume Node.js environment.

--- a/browser.mjs
+++ b/browser.mjs
@@ -345,8 +345,8 @@ function call_jslint() {
     }
     editor.setValue(`#!/usr/bin/env node
 
-/*jslint beta, node*/
-/*global atob, btoa*/ //jslint-quiet
+/*jslint browser, node*/
+/*global $, jQuery*/ //jslint-quiet
 
 import jslint from \u0022./jslint.mjs\u0022;
 import https from "https";
@@ -383,7 +383,7 @@ console.log('hello world');
 
 // Suppress warnings on next-line.
 eval( //jslint-quiet
-    "console.log('hello world');"
+    "console.log(\\"hello world\\");"
 );
 
 (async function () {

--- a/ci.sh
+++ b/ci.sh
@@ -311,7 +311,7 @@ shCiBase() {(set -e
     cat jslint.mjs | sed \
         -e "s|^// module.exports = |module.exports = |" \
         -e "s|^export default Object.freeze(|// &|" \
-        -e "s|^import_meta_url = |// &|" \
+        -e "s|^jslint_import_meta_url = |// &|" \
         > jslint.cjs
     # run test with coverage-report
     # coverage-hack - test jslint's invalid-file handling-behavior
@@ -362,8 +362,8 @@ import moduleFs from "fs";
         }, {
             file: "jslint.mjs",
             src: dict["jslint.mjs"].replace((
-                /^const\u0020edition\u0020=\u0020".*?";$/m
-            ), `const edition = "${versionBeta}";`),
+                /^const\u0020jslint_edition\u0020=\u0020".*?";$/m
+            ), `const jslint_edition = "${versionBeta}";`),
             src0: dict["jslint.mjs"]
         }
     ].forEach(function ({

--- a/index.html
+++ b/index.html
@@ -403,7 +403,7 @@ style="
     </div>
     <textarea
         id="JSLINT_GLOBAL"
-        placeholder="imported globals (e.g. atob, btoa)"
+        placeholder="imported globals (e.g. $, jQuery)"
         spellcheck="false"
         style="white-space: normal;"
         title="global"

--- a/index.html
+++ b/index.html
@@ -388,15 +388,16 @@ style="
         <div><label><input title="eval" type="checkbox">eval</label></div>
         <div><label><input title="for" type="checkbox">for</label></div>
         <div><label><input title="getset" type="checkbox">getset</label></div>
-        <div><label><input title="long" type="checkbox">long</label></div>
+        <div><label><input title="indent2" type="checkbox">indent2</label></div>
     </div>
     <div>&nbsp;
+        <div><label><input title="long" type="checkbox">long</label></div>
         <div><label><input title="name" type="checkbox">name</label></div>
         <div><label><input title="single" type="checkbox">single</label></div>
         <div><label><input title="this" type="checkbox">this</label></div>
-        <div><label><input title="unordered" type="checkbox">unordered</label></div>
     </div>
     <div>&nbsp;
+        <div><label><input title="unordered" type="checkbox">unordered</label></div>
         <div><label><input title="variable" type="checkbox">variable</label></div>
         <div><label><input title="white" type="checkbox">white</label></div>
     </div>


### PR DESCRIPTION
- jslint - add "jslint_" prefix to global variables.
- website - add search-param "mode_debug=1".

i don't necessarily agree with 2-space indent, but directive `/*jslint indent2*/` would make jslint more accessible to existing/legacy projects using 2-space indent.