### PR TITLE
- jslint - disable out-of-scope warning for function-statements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@
 - cli - add command `report`.
 - jslint - add `for...of` syntax support.
 - jslint - add html and css linting back into jslint.
-- jslint - remove directive `/*jslint eval*/` (use line-specific ignore-directive "//jslint-quiet" instead).
+- jslint - add new warning against using do-statment.
+- jslint - add syntax-support for continue-label-statement.
 - jslint - require regexp to use open-form.
 - jslint - simplify comments/docs by removing unnecessary grammar-article "the".
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
 - jslint-refactor - migrate recursive-loops to for/while loops.
 - merge function.html and help.html into README.md
-- node - after node-v12 is deprecated, change `require("fs").promises` to `require("fs/promises")`.
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - tests - update function warn_at() with assertion-check matching column with artifact.
 
@@ -19,7 +19,9 @@
 - breaking-change - rename files *.js to *.mjs for better integration with nodejs.
 - ci - auto-screenshot example-shell-commands in README.md.
 - ci - include explicit commonjs (jslint.cjs) and es-module (jslint.mjs) variants of jslint.
+- jslint - disable out-of-scope warning for functions.
 - jslint - reintroduce directive `/*jslint indent2*/` - allow 2-space indent.
+- website - create codemirror-plugin to highlight jslint-warnings in editor.
 
 ## v2021.6.22
 - bugfix - fix global_list being ignored by jslint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - jslint - add `for...of` syntax support.
 - jslint - add html and css linting back into jslint.
 - jslint - add new warning against using do-statment.
+- jslint - add new warning requiring paren around comma-separated concatenations.
 - jslint - add syntax-support for continue-label-statement.
 - jslint - require regexp to use open-form.
 - jslint - simplify comments/docs by removing unnecessary grammar-article "the".
@@ -18,6 +19,7 @@
 
 ## v2021.6.26-beta
 - breaking-change - rename files *.js to *.mjs for better integration with nodejs.
+- bugfix - fix function is_equal() always returning true when comparing string-literals.
 - ci - auto-screenshot example-shell-commands in README.md.
 - ci - include explicit commonjs (jslint.cjs) and es-module (jslint.mjs) variants of jslint.
 - jslint - disable out-of-scope warning for functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - merge function.html and help.html into README.md
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - tests - update function warn_at() with assertion-check matching column with artifact.
+- vim - add vim plugin.
 
 ## v2021.6.26-beta
 - breaking-change - rename files *.js to *.mjs for better integration with nodejs.

--- a/asset-codemirror-rollup.css
+++ b/asset-codemirror-rollup.css
@@ -4,7 +4,10 @@ shRawLibFetch
 {
     "fetchList": [
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.58.3/lib/codemirror.css"
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/lib/codemirror.css"
+        },
+        {
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.css"
         }
     ]
 }
@@ -12,13 +15,13 @@ shRawLibFetch
 
 
 /*
-repo https://github.com/codemirror/CodeMirror/tree/5.58.3
-committed 2020-11-19T08:38:15Z
+repo https://github.com/codemirror/CodeMirror/tree/5.62.0
+committed 2021-06-21T07:13:20Z
 */
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.58.3/lib/codemirror.css
+file https://github.com/codemirror/CodeMirror/blob/5.62.0/lib/codemirror.css
 */
 /* BASICS */
 
@@ -370,6 +373,90 @@ div.CodeMirror-dragcursors {
 
 /* Help users use markselection to safely style text background */
 span.CodeMirror-selectedtext { background: none; }
+
+
+/*
+file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.css
+*/
+/* The lint marker gutter */
+.CodeMirror-lint-markers {
+  width: 16px;
+}
+
+.CodeMirror-lint-tooltip {
+  background-color: #ffd;
+  border: 1px solid black;
+  border-radius: 4px 4px 4px 4px;
+  color: black;
+  font-family: monospace;
+  font-size: 10pt;
+  overflow: hidden;
+  padding: 2px 5px;
+  position: fixed;
+  white-space: pre;
+  white-space: pre-wrap;
+  z-index: 100;
+  max-width: 600px;
+  opacity: 0;
+  transition: opacity .4s;
+  -moz-transition: opacity .4s;
+  -webkit-transition: opacity .4s;
+  -o-transition: opacity .4s;
+  -ms-transition: opacity .4s;
+}
+
+.CodeMirror-lint-mark {
+  background-position: left bottom;
+  background-repeat: repeat-x;
+}
+
+.CodeMirror-lint-mark-warning {
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAADCAYAAAC09K7GAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9sJFhQXEbhTg7YAAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAAMklEQVQI12NkgIIvJ3QXMjAwdDN+OaEbysDA4MPAwNDNwMCwiOHLCd1zX07o6kBVGQEAKBANtobskNMAAAAASUVORK5CYII=");
+}
+
+.CodeMirror-lint-mark-error {
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAADCAYAAAC09K7GAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9sJDw4cOCW1/KIAAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAAHElEQVQI12NggIL/DAz/GdA5/xkY/qPKMDAwAADLZwf5rvm+LQAAAABJRU5ErkJggg==");
+}
+
+.CodeMirror-lint-marker {
+  background-position: center center;
+  background-repeat: no-repeat;
+  cursor: pointer;
+  display: inline-block;
+  height: 16px;
+  width: 16px;
+  vertical-align: middle;
+  position: relative;
+}
+
+.CodeMirror-lint-message {
+  padding-left: 18px;
+  background-position: top left;
+  background-repeat: no-repeat;
+}
+
+.CodeMirror-lint-marker-warning, .CodeMirror-lint-message-warning {
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAANlBMVEX/uwDvrwD/uwD/uwD/uwD/uwD/uwD/uwD/uwD6twD/uwAAAADurwD2tQD7uAD+ugAAAAD/uwDhmeTRAAAADHRSTlMJ8mN1EYcbmiixgACm7WbuAAAAVklEQVR42n3PUQqAIBBFUU1LLc3u/jdbOJoW1P08DA9Gba8+YWJ6gNJoNYIBzAA2chBth5kLmG9YUoG0NHAUwFXwO9LuBQL1giCQb8gC9Oro2vp5rncCIY8L8uEx5ZkAAAAASUVORK5CYII=");
+}
+
+.CodeMirror-lint-marker-error, .CodeMirror-lint-message-error {
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAHlBMVEW7AAC7AACxAAC7AAC7AAAAAAC4AAC5AAD///+7AAAUdclpAAAABnRSTlMXnORSiwCK0ZKSAAAATUlEQVR42mWPOQ7AQAgDuQLx/z8csYRmPRIFIwRGnosRrpamvkKi0FTIiMASR3hhKW+hAN6/tIWhu9PDWiTGNEkTtIOucA5Oyr9ckPgAWm0GPBog6v4AAAAASUVORK5CYII=");
+}
+
+.CodeMirror-lint-marker-multiple {
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAAAHCAMAAADzjKfhAAAACVBMVEUAAAAAAAC/v7914kyHAAAAAXRSTlMAQObYZgAAACNJREFUeNo1ioEJAAAIwmz/H90iFFSGJgFMe3gaLZ0od+9/AQZ0ADosbYraAAAAAElFTkSuQmCC");
+  background-repeat: no-repeat;
+  background-position: right bottom;
+  width: 100%; height: 100%;
+}
+
+.CodeMirror-lint-line-error {
+  background-color: rgba(183, 76, 81, 0.08);
+}
+
+.CodeMirror-lint-line-warning {
+  background-color: rgba(255, 211, 0, 0.1);
+}
 
 
 /*

--- a/asset-codemirror-rollup.js
+++ b/asset-codemirror-rollup.js
@@ -4,17 +4,20 @@ shRawLibFetch
 {
     "fetchList": [
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js",
-            "url2": "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.58.3/codemirror.js"
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js",
+            "url2": "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.62.0/codemirror.js"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.58.3/addon/edit/matchbrackets.js"
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/edit/matchbrackets.js"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.58.3/addon/edit/trailingspace.js"
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.js"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.58.3/mode/javascript/javascript.js"
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/edit/trailingspace.js"
+        },
+        {
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/mode/javascript/javascript.js"
         }
     ]
 }
@@ -22,13 +25,13 @@ shRawLibFetch
 
 
 /*
-repo https://github.com/codemirror/CodeMirror/tree/5.58.3
-committed 2020-11-19T08:38:15Z
+repo https://github.com/codemirror/CodeMirror/tree/5.62.0
+committed 2021-06-21T07:13:20Z
 */
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
+file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
 */
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
@@ -64,7 +67,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
   var mac_geMountainLion = /Mac OS X 1\d\D([8-9]|\d\d)\D/.test(userAgent);
   var phantom = /PhantomJS/.test(userAgent);
 
-  var ios = !edge && /AppleWebKit/.test(userAgent) && /Mobile\/\w+/.test(userAgent);
+  var ios = safari && (/Mobile\/\w+/.test(userAgent) || navigator.maxTouchPoints > 2);
   var android = /Android/.test(userAgent);
   // This is woefully incomplete. Suggestions for alternative methods welcome.
   var mobile = ios || android || /webOS|BlackBerry|Opera Mini|Opera Mobi|IEMobile/i.test(userAgent);
@@ -1343,6 +1346,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
       if (span.marker == marker) { return span }
     } }
   }
+
   // Remove a span from an array, returning undefined if no spans are
   // left (we don't store arrays for lines without spans).
   function removeMarkedSpan(spans, span) {
@@ -1351,9 +1355,16 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
       { if (spans[i] != span) { (r || (r = [])).push(spans[i]); } }
     return r
   }
+
   // Add a span to a line.
-  function addMarkedSpan(line, span) {
-    line.markedSpans = line.markedSpans ? line.markedSpans.concat([span]) : [span];
+  function addMarkedSpan(line, span, op) {
+    var inThisOp = op && window.WeakSet && (op.markedSpans || (op.markedSpans = new WeakSet));
+    if (inThisOp && inThisOp.has(line.markedSpans)) {
+      line.markedSpans.push(span);
+    } else {
+      line.markedSpans = line.markedSpans ? line.markedSpans.concat([span]) : [span];
+      if (inThisOp) { inThisOp.add(line.markedSpans); }
+    }
     span.marker.attachLine(line);
   }
 
@@ -2218,6 +2229,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
     if (cm.options.lineNumbers || markers) {
       var wrap$1 = ensureLineWrapped(lineView);
       var gutterWrap = lineView.gutter = elt("div", null, "CodeMirror-gutter-wrapper", ("left: " + (cm.options.fixedGutter ? dims.fixedPos : -dims.gutterTotalWidth) + "px"));
+      gutterWrap.setAttribute("aria-hidden", "true");
       cm.display.input.setUneditable(gutterWrap);
       wrap$1.insertBefore(gutterWrap, lineView.text);
       if (lineView.line.gutterClass)
@@ -3462,8 +3474,8 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
       // Set pos and end to the cursor positions around the character pos sticks to
       // If pos.sticky == "before", that is around pos.ch - 1, otherwise around pos.ch
       // If pos == Pos(_, 0, "before"), pos and end are unchanged
-      pos = pos.ch ? Pos(pos.line, pos.sticky == "before" ? pos.ch - 1 : pos.ch, "after") : pos;
       end = pos.sticky == "before" ? Pos(pos.line, pos.ch + 1, "before") : pos;
+      pos = pos.ch ? Pos(pos.line, pos.sticky == "before" ? pos.ch - 1 : pos.ch, "after") : pos;
     }
     for (var limit = 0; limit < 5; limit++) {
       var changed = false;
@@ -3814,7 +3826,8 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
       scrollLeft: null, scrollTop: null, // Intermediate scroll position, not pushed to DOM yet
       scrollToPos: null,       // Used to scroll to a specific position
       focus: false,
-      id: ++nextOpId           // Unique ID
+      id: ++nextOpId,          // Unique ID
+      markArrays: null         // Used by addMarkedSpan
     };
     pushOperation(cm.curOp);
   }
@@ -4267,6 +4280,8 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
   function updateGutterSpace(display) {
     var width = display.gutters.offsetWidth;
     display.sizer.style.marginLeft = width + "px";
+    // Send an event to consumers responding to changes in gutter width.
+    signalLater(display, "gutterChanged", display);
   }
 
   function setDocumentHeight(cm, measure) {
@@ -4814,6 +4829,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
     estimateLineHeights(cm);
     loadMode(cm);
     setDirectionClass(cm);
+    cm.options.direction = doc.direction;
     if (!cm.options.lineWrapping) { findMaxLine(cm); }
     cm.options.mode = doc.modeOption;
     regChange(cm);
@@ -4830,19 +4846,19 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
     });
   }
 
-  function History(startGen) {
+  function History(prev) {
     // Arrays of change events and selections. Doing something adds an
     // event to done and clears undo. Undoing moves events from done
     // to undone, redoing moves them in the other direction.
     this.done = []; this.undone = [];
-    this.undoDepth = Infinity;
+    this.undoDepth = prev ? prev.undoDepth : Infinity;
     // Used to track when changes can be merged into a single undo
     // event
     this.lastModTime = this.lastSelTime = 0;
     this.lastOp = this.lastSelOp = null;
     this.lastOrigin = this.lastSelOrigin = null;
     // Used by the isClean() method
-    this.generation = this.maxGeneration = startGen || 1;
+    this.generation = this.maxGeneration = prev ? prev.maxGeneration : 1;
   }
 
   // Create a history change event from an updateDoc-style change
@@ -5147,7 +5163,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
       (cmp(sel.primary().head, doc.sel.primary().head) < 0 ? -1 : 1);
     setSelectionInner(doc, skipAtomicInSelection(doc, sel, bias, true));
 
-    if (!(options && options.scroll === false) && doc.cm)
+    if (!(options && options.scroll === false) && doc.cm && doc.cm.getOption("readOnly") != "nocursor")
       { ensureCursorVisible(doc.cm); }
   }
 
@@ -5990,7 +6006,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
       if (marker.collapsed && curLine != from.line) { updateLineHeight(line, 0); }
       addMarkedSpan(line, new MarkedSpan(marker,
                                          curLine == from.line ? from.ch : null,
-                                         curLine == to.line ? to.ch : null));
+                                         curLine == to.line ? to.ch : null), doc.cm && doc.cm.curOp);
       ++curLine;
     });
     // lineIsHidden depends on the presence of the spans, so needs a second pass
@@ -6162,6 +6178,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
     getRange: function(from, to, lineSep) {
       var lines = getBetween(this, clipPos(this, from), clipPos(this, to));
       if (lineSep === false) { return lines }
+      if (lineSep === '') { return lines.join('') }
       return lines.join(lineSep || this.lineSeparator())
     },
 
@@ -6213,7 +6230,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
       var out = [];
       for (var i = 0; i < ranges.length; i++)
         { out[i] = new Range(clipPos(this, ranges[i].anchor),
-                           clipPos(this, ranges[i].head)); }
+                           clipPos(this, ranges[i].head || ranges[i].anchor)); }
       if (primary == null) { primary = Math.min(ranges.length - 1, this.sel.primIndex); }
       setSelection(this, normalizeSelection(this.cm, out, primary), options);
     }),
@@ -6276,7 +6293,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
     clearHistory: function() {
       var this$1 = this;
 
-      this.history = new History(this.history.maxGeneration);
+      this.history = new History(this.history);
       linkedDocs(this, function (doc) { return doc.history = this$1.history; }, true);
     },
 
@@ -6297,7 +6314,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
               undone: copyHistoryArray(this.history.undone)}
     },
     setHistory: function(histData) {
-      var hist = this.history = new History(this.history.maxGeneration);
+      var hist = this.history = new History(this.history);
       hist.done = copyHistoryArray(histData.done.slice(0), null, true);
       hist.undone = copyHistoryArray(histData.undone.slice(0), null, true);
     },
@@ -6716,10 +6733,9 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
   // Very basic readline/emacs-style bindings, which are standard on Mac.
   keyMap.emacsy = {
     "Ctrl-F": "goCharRight", "Ctrl-B": "goCharLeft", "Ctrl-P": "goLineUp", "Ctrl-N": "goLineDown",
-    "Alt-F": "goWordRight", "Alt-B": "goWordLeft", "Ctrl-A": "goLineStart", "Ctrl-E": "goLineEnd",
-    "Ctrl-V": "goPageDown", "Shift-Ctrl-V": "goPageUp", "Ctrl-D": "delCharAfter", "Ctrl-H": "delCharBefore",
-    "Alt-D": "delWordAfter", "Alt-Backspace": "delWordBefore", "Ctrl-K": "killLine", "Ctrl-T": "transposeChars",
-    "Ctrl-O": "openLine"
+    "Ctrl-A": "goLineStart", "Ctrl-E": "goLineEnd", "Ctrl-V": "goPageDown", "Shift-Ctrl-V": "goPageUp",
+    "Ctrl-D": "delCharAfter", "Ctrl-H": "delCharBefore", "Alt-Backspace": "delWordBefore", "Ctrl-K": "killLine",
+    "Ctrl-T": "transposeChars", "Ctrl-O": "openLine"
   };
   keyMap.macDefault = {
     "Cmd-A": "selectAll", "Cmd-D": "deleteLine", "Cmd-Z": "undo", "Shift-Cmd-Z": "redo", "Cmd-Y": "redo",
@@ -7740,7 +7756,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
       for (var i = newBreaks.length - 1; i >= 0; i--)
         { replaceRange(cm.doc, val, newBreaks[i], Pos(newBreaks[i].line, newBreaks[i].ch + val.length)); }
     });
-    option("specialChars", /[\u0000-\u001f\u007f-\u009f\u00ad\u061c\u200b-\u200c\u200e\u200f\u2028\u2029\ufeff\ufff9-\ufffc]/g, function (cm, val, old) {
+    option("specialChars", /[\u0000-\u001f\u007f-\u009f\u00ad\u061c\u200b\u200e\u200f\u2028\u2029\ufeff\ufff9-\ufffc]/g, function (cm, val, old) {
       cm.state.specialChars = new RegExp(val.source + (val.test("\t") ? "" : "|\t"), "g");
       if (old != Init) { cm.refresh(); }
     });
@@ -8707,10 +8723,13 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
     function moveOnce(boundToLine) {
       var next;
       if (unit == "codepoint") {
-        var ch = lineObj.text.charCodeAt(pos.ch + (unit > 0 ? 0 : -1));
-        if (isNaN(ch)) { next = null; }
-        else { next = new Pos(pos.line, Math.max(0, Math.min(lineObj.text.length, pos.ch + dir * (ch >= 0xD800 && ch < 0xDC00 ? 2 : 1))),
-                            -dir); }
+        var ch = lineObj.text.charCodeAt(pos.ch + (dir > 0 ? 0 : -1));
+        if (isNaN(ch)) {
+          next = null;
+        } else {
+          var astral = dir > 0 ? ch >= 0xD800 && ch < 0xDC00 : ch >= 0xDC00 && ch < 0xDFFF;
+          next = new Pos(pos.line, Math.max(0, Math.min(lineObj.text.length, pos.ch + dir * (astral ? 2 : 1))), -dir);
+        }
       } else if (visually) {
         next = moveVisually(doc.cm, lineObj, pos, dir);
       } else {
@@ -8794,6 +8813,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
 
     var input = this, cm = input.cm;
     var div = input.div = display.lineDiv;
+    div.contentEditable = true;
     disableBrowserMagic(div, cm.options.spellcheck, cm.options.autocorrect, cm.options.autocapitalize);
 
     function belongsToInput(e) {
@@ -8860,7 +8880,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
       var kludge = hiddenTextarea(), te = kludge.firstChild;
       cm.display.lineSpace.insertBefore(kludge, cm.display.lineSpace.firstChild);
       te.value = lastCopied.text.join("\n");
-      var hadFocus = document.activeElement;
+      var hadFocus = activeElt();
       selectInput(te);
       setTimeout(function () {
         cm.display.lineSpace.removeChild(kludge);
@@ -8883,7 +8903,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
 
   ContentEditableInput.prototype.prepareSelection = function () {
     var result = prepareSelection(this.cm, false);
-    result.focus = document.activeElement == this.div;
+    result.focus = activeElt() == this.div;
     return result
   };
 
@@ -8979,7 +8999,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
 
   ContentEditableInput.prototype.focus = function () {
     if (this.cm.options.readOnly != "nocursor") {
-      if (!this.selectionInEditor() || document.activeElement != this.div)
+      if (!this.selectionInEditor() || activeElt() != this.div)
         { this.showSelection(this.prepareSelection(), true); }
       this.div.focus();
     }
@@ -9821,14 +9841,14 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/codemirror.js
 
   addLegacyProps(CodeMirror);
 
-  CodeMirror.version = "5.58.3";
+  CodeMirror.version = "5.62.0";
 
   return CodeMirror;
 })));
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.58.3/addon/edit/matchbrackets.js
+file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/edit/matchbrackets.js
 */
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
@@ -9870,7 +9890,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/addon/edit/matchbracke
     if (config && config.strict && (dir > 0) != (pos == where.ch)) return null;
     var style = cm.getTokenTypeAt(Pos(where.line, pos + 1));
 
-    var found = scanForBracket(cm, Pos(where.line, pos + (dir > 0 ? 1 : 0)), dir, style || null, config);
+    var found = scanForBracket(cm, Pos(where.line, pos + (dir > 0 ? 1 : 0)), dir, style, config);
     if (found == null) return null;
     return {from: Pos(where.line, pos), to: found && found.pos,
             match: found && found.ch == match.charAt(0), forward: dir > 0};
@@ -9899,7 +9919,8 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/addon/edit/matchbracke
       if (lineNo == where.line) pos = where.ch - (dir < 0 ? 1 : 0);
       for (; pos != end; pos += dir) {
         var ch = line.charAt(pos);
-        if (re.test(ch) && (style === undefined || cm.getTokenTypeAt(Pos(lineNo, pos + 1)) == style)) {
+        if (re.test(ch) && (style === undefined ||
+                            (cm.getTokenTypeAt(Pos(lineNo, pos + 1)) || "") == (style || ""))) {
           var match = matching[ch];
           if (match && (match.charAt(1) == ">") == (dir > 0)) stack.push(ch);
           else if (!stack.length) return {pos: Pos(lineNo, pos), ch: ch};
@@ -9912,11 +9933,12 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/addon/edit/matchbracke
 
   function matchBrackets(cm, autoclear, config) {
     // Disable brace matching in long lines, since it'll cause hugely slow updates
-    var maxHighlightLen = cm.state.matchBrackets.maxHighlightLineLength || 1000;
+    var maxHighlightLen = cm.state.matchBrackets.maxHighlightLineLength || 1000,
+      highlightNonMatching = config && config.highlightNonMatching;
     var marks = [], ranges = cm.listSelections();
     for (var i = 0; i < ranges.length; i++) {
       var match = ranges[i].empty() && findMatchingBracket(cm, ranges[i].head, config);
-      if (match && cm.getLine(match.from.line).length <= maxHighlightLen) {
+      if (match && (match.match || highlightNonMatching !== false) && cm.getLine(match.from.line).length <= maxHighlightLen) {
         var style = match.match ? "CodeMirror-matchingbracket" : "CodeMirror-nonmatchingbracket";
         marks.push(cm.markText(match.from, Pos(match.from.line, match.from.ch + 1), {className: style}));
         if (match.to && cm.getLine(match.to.line).length <= maxHighlightLen)
@@ -9926,7 +9948,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/addon/edit/matchbracke
 
     if (marks.length) {
       // Kludge to work around the IE bug from issue #1193, where text
-      // input stops going to the textare whever this fires.
+      // input stops going to the textarea whenever this fires.
       if (ie_lt8 && cm.state.focused) cm.focus();
 
       var clear = function() {
@@ -9949,25 +9971,25 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/addon/edit/matchbracke
     });
   }
 
-  CodeMirror.defineOption("matchBrackets", false, function(cm, val, old) {
-    function clear(cm) {
-      if (cm.state.matchBrackets && cm.state.matchBrackets.currentlyHighlighted) {
-        cm.state.matchBrackets.currentlyHighlighted();
-        cm.state.matchBrackets.currentlyHighlighted = null;
-      }
+  function clearHighlighted(cm) {
+    if (cm.state.matchBrackets && cm.state.matchBrackets.currentlyHighlighted) {
+      cm.state.matchBrackets.currentlyHighlighted();
+      cm.state.matchBrackets.currentlyHighlighted = null;
     }
+  }
 
+  CodeMirror.defineOption("matchBrackets", false, function(cm, val, old) {
     if (old && old != CodeMirror.Init) {
       cm.off("cursorActivity", doMatchBrackets);
       cm.off("focus", doMatchBrackets)
-      cm.off("blur", clear)
-      clear(cm);
+      cm.off("blur", clearHighlighted)
+      clearHighlighted(cm);
     }
     if (val) {
       cm.state.matchBrackets = typeof val == "object" ? val : {};
       cm.on("cursorActivity", doMatchBrackets);
       cm.on("focus", doMatchBrackets)
-      cm.on("blur", clear)
+      cm.on("blur", clearHighlighted)
     }
   });
 
@@ -9991,7 +10013,291 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/addon/edit/matchbracke
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.58.3/addon/edit/trailingspace.js
+file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.js
+*/
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: https://codemirror.net/LICENSE
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+  "use strict";
+  var GUTTER_ID = "CodeMirror-lint-markers";
+  var LINT_LINE_ID = "CodeMirror-lint-line-";
+
+  function showTooltip(cm, e, content) {
+    var tt = document.createElement("div");
+    tt.className = "CodeMirror-lint-tooltip cm-s-" + cm.options.theme;
+    tt.appendChild(content.cloneNode(true));
+    if (cm.state.lint.options.selfContain)
+      cm.getWrapperElement().appendChild(tt);
+    else
+      document.body.appendChild(tt);
+
+    function position(e) {
+      if (!tt.parentNode) return CodeMirror.off(document, "mousemove", position);
+      tt.style.top = Math.max(0, e.clientY - tt.offsetHeight - 5) + "px";
+      tt.style.left = (e.clientX + 5) + "px";
+    }
+    CodeMirror.on(document, "mousemove", position);
+    position(e);
+    if (tt.style.opacity != null) tt.style.opacity = 1;
+    return tt;
+  }
+  function rm(elt) {
+    if (elt.parentNode) elt.parentNode.removeChild(elt);
+  }
+  function hideTooltip(tt) {
+    if (!tt.parentNode) return;
+    if (tt.style.opacity == null) rm(tt);
+    tt.style.opacity = 0;
+    setTimeout(function() { rm(tt); }, 600);
+  }
+
+  function showTooltipFor(cm, e, content, node) {
+    var tooltip = showTooltip(cm, e, content);
+    function hide() {
+      CodeMirror.off(node, "mouseout", hide);
+      if (tooltip) { hideTooltip(tooltip); tooltip = null; }
+    }
+    var poll = setInterval(function() {
+      if (tooltip) for (var n = node;; n = n.parentNode) {
+        if (n && n.nodeType == 11) n = n.host;
+        if (n == document.body) return;
+        if (!n) { hide(); break; }
+      }
+      if (!tooltip) return clearInterval(poll);
+    }, 400);
+    CodeMirror.on(node, "mouseout", hide);
+  }
+
+  function LintState(cm, options, hasGutter) {
+    this.marked = [];
+    this.options = options;
+    this.timeout = null;
+    this.hasGutter = hasGutter;
+    this.onMouseOver = function(e) { onMouseOver(cm, e); };
+    this.waitingFor = 0
+  }
+
+  function parseOptions(_cm, options) {
+    if (options instanceof Function) return {getAnnotations: options};
+    if (!options || options === true) options = {};
+    return options;
+  }
+
+  function clearMarks(cm) {
+    var state = cm.state.lint;
+    if (state.hasGutter) cm.clearGutter(GUTTER_ID);
+    if (isHighlightErrorLinesEnabled(state)) clearErrorLines(cm);
+    for (var i = 0; i < state.marked.length; ++i)
+      state.marked[i].clear();
+    state.marked.length = 0;
+  }
+
+  function clearErrorLines(cm) {
+    cm.eachLine(function(line) {
+      var has = line.wrapClass && /\bCodeMirror-lint-line-\w+\b/.exec(line.wrapClass);
+      if (has) cm.removeLineClass(line, "wrap", has[0]);
+    })
+  }
+
+  function isHighlightErrorLinesEnabled(state) {
+    return state.options.highlightLines;
+  }
+
+  function makeMarker(cm, labels, severity, multiple, tooltips) {
+    var marker = document.createElement("div"), inner = marker;
+    marker.className = "CodeMirror-lint-marker CodeMirror-lint-marker-" + severity;
+    if (multiple) {
+      inner = marker.appendChild(document.createElement("div"));
+      inner.className = "CodeMirror-lint-marker CodeMirror-lint-marker-multiple";
+    }
+
+    if (tooltips != false) CodeMirror.on(inner, "mouseover", function(e) {
+      showTooltipFor(cm, e, labels, inner);
+    });
+
+    return marker;
+  }
+
+  function getMaxSeverity(a, b) {
+    if (a == "error") return a;
+    else return b;
+  }
+
+  function groupByLine(annotations) {
+    var lines = [];
+    for (var i = 0; i < annotations.length; ++i) {
+      var ann = annotations[i], line = ann.from.line;
+      (lines[line] || (lines[line] = [])).push(ann);
+    }
+    return lines;
+  }
+
+  function annotationTooltip(ann) {
+    var severity = ann.severity;
+    if (!severity) severity = "error";
+    var tip = document.createElement("div");
+    tip.className = "CodeMirror-lint-message CodeMirror-lint-message-" + severity;
+    if (typeof ann.messageHTML != 'undefined') {
+      tip.innerHTML = ann.messageHTML;
+    } else {
+      tip.appendChild(document.createTextNode(ann.message));
+    }
+    return tip;
+  }
+
+  function lintAsync(cm, getAnnotations, passOptions) {
+    var state = cm.state.lint
+    var id = ++state.waitingFor
+    function abort() {
+      id = -1
+      cm.off("change", abort)
+    }
+    cm.on("change", abort)
+    getAnnotations(cm.getValue(), function(annotations, arg2) {
+      cm.off("change", abort)
+      if (state.waitingFor != id) return
+      if (arg2 && annotations instanceof CodeMirror) annotations = arg2
+      cm.operation(function() {updateLinting(cm, annotations)})
+    }, passOptions, cm);
+  }
+
+  function startLinting(cm) {
+    var state = cm.state.lint;
+    if (!state) return;
+    var options = state.options;
+    /*
+     * Passing rules in `options` property prevents JSHint (and other linters) from complaining
+     * about unrecognized rules like `onUpdateLinting`, `delay`, `lintOnChange`, etc.
+     */
+    var passOptions = options.options || options;
+    var getAnnotations = options.getAnnotations || cm.getHelper(CodeMirror.Pos(0, 0), "lint");
+    if (!getAnnotations) return;
+    if (options.async || getAnnotations.async) {
+      lintAsync(cm, getAnnotations, passOptions)
+    } else {
+      var annotations = getAnnotations(cm.getValue(), passOptions, cm);
+      if (!annotations) return;
+      if (annotations.then) annotations.then(function(issues) {
+        cm.operation(function() {updateLinting(cm, issues)})
+      });
+      else cm.operation(function() {updateLinting(cm, annotations)})
+    }
+  }
+
+  function updateLinting(cm, annotationsNotSorted) {
+    var state = cm.state.lint;
+    if (!state) return;
+    var options = state.options;
+    clearMarks(cm);
+
+    var annotations = groupByLine(annotationsNotSorted);
+
+    for (var line = 0; line < annotations.length; ++line) {
+      var anns = annotations[line];
+      if (!anns) continue;
+
+      // filter out duplicate messages
+      var message = [];
+      anns = anns.filter(function(item) { return message.indexOf(item.message) > -1 ? false : message.push(item.message) });
+
+      var maxSeverity = null;
+      var tipLabel = state.hasGutter && document.createDocumentFragment();
+
+      for (var i = 0; i < anns.length; ++i) {
+        var ann = anns[i];
+        var severity = ann.severity;
+        if (!severity) severity = "error";
+        maxSeverity = getMaxSeverity(maxSeverity, severity);
+
+        if (options.formatAnnotation) ann = options.formatAnnotation(ann);
+        if (state.hasGutter) tipLabel.appendChild(annotationTooltip(ann));
+
+        if (ann.to) state.marked.push(cm.markText(ann.from, ann.to, {
+          className: "CodeMirror-lint-mark CodeMirror-lint-mark-" + severity,
+          __annotation: ann
+        }));
+      }
+      // use original annotations[line] to show multiple messages
+      if (state.hasGutter)
+        cm.setGutterMarker(line, GUTTER_ID, makeMarker(cm, tipLabel, maxSeverity, annotations[line].length > 1,
+                                                       state.options.tooltips));
+
+      if (isHighlightErrorLinesEnabled(state))
+        cm.addLineClass(line, "wrap", LINT_LINE_ID + maxSeverity);
+    }
+    if (options.onUpdateLinting) options.onUpdateLinting(annotationsNotSorted, annotations, cm);
+  }
+
+  function onChange(cm) {
+    var state = cm.state.lint;
+    if (!state) return;
+    clearTimeout(state.timeout);
+    state.timeout = setTimeout(function(){startLinting(cm);}, state.options.delay || 500);
+  }
+
+  function popupTooltips(cm, annotations, e) {
+    var target = e.target || e.srcElement;
+    var tooltip = document.createDocumentFragment();
+    for (var i = 0; i < annotations.length; i++) {
+      var ann = annotations[i];
+      tooltip.appendChild(annotationTooltip(ann));
+    }
+    showTooltipFor(cm, e, tooltip, target);
+  }
+
+  function onMouseOver(cm, e) {
+    var target = e.target || e.srcElement;
+    if (!/\bCodeMirror-lint-mark-/.test(target.className)) return;
+    var box = target.getBoundingClientRect(), x = (box.left + box.right) / 2, y = (box.top + box.bottom) / 2;
+    var spans = cm.findMarksAt(cm.coordsChar({left: x, top: y}, "client"));
+
+    var annotations = [];
+    for (var i = 0; i < spans.length; ++i) {
+      var ann = spans[i].__annotation;
+      if (ann) annotations.push(ann);
+    }
+    if (annotations.length) popupTooltips(cm, annotations, e);
+  }
+
+  CodeMirror.defineOption("lint", false, function(cm, val, old) {
+    if (old && old != CodeMirror.Init) {
+      clearMarks(cm);
+      if (cm.state.lint.options.lintOnChange !== false)
+        cm.off("change", onChange);
+      CodeMirror.off(cm.getWrapperElement(), "mouseover", cm.state.lint.onMouseOver);
+      clearTimeout(cm.state.lint.timeout);
+      delete cm.state.lint;
+    }
+
+    if (val) {
+      var gutters = cm.getOption("gutters"), hasLintGutter = false;
+      for (var i = 0; i < gutters.length; ++i) if (gutters[i] == GUTTER_ID) hasLintGutter = true;
+      var state = cm.state.lint = new LintState(cm, parseOptions(cm, val), hasLintGutter);
+      if (state.options.lintOnChange !== false)
+        cm.on("change", onChange);
+      if (state.options.tooltips != false && state.options.tooltips != "gutter")
+        CodeMirror.on(cm.getWrapperElement(), "mouseover", state.onMouseOver);
+
+      startLinting(cm);
+    }
+  });
+
+  CodeMirror.defineExtension("performLint", function() {
+    startLinting(this);
+  });
+});
+
+
+/*
+file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/edit/trailingspace.js
 */
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
@@ -10023,7 +10329,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.58.3/addon/edit/trailingspa
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.58.3/mode/javascript/javascript.js
+file https://github.com/codemirror/CodeMirror/blob/5.62.0/mode/javascript/javascript.js
 */
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
@@ -10043,6 +10349,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   var statementIndent = parserConfig.statementIndent;
   var jsonldMode = parserConfig.jsonld;
   var jsonMode = parserConfig.json || jsonldMode;
+  var trackScope = parserConfig.trackScope !== false
   var isTS = parserConfig.typescript;
   var wordRE = parserConfig.wordCharacters || /[\w$\xa1-\uffff]/;
 
@@ -10245,7 +10552,8 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
 
   // Parser
 
-  var atomicTypes = {"atom": true, "number": true, "variable": true, "string": true, "regexp": true, "this": true, "jsonld-keyword": true};
+  var atomicTypes = {"atom": true, "number": true, "variable": true, "string": true,
+                     "regexp": true, "this": true, "import": true, "jsonld-keyword": true};
 
   function JSLexical(indented, column, type, align, prev, info) {
     this.indented = indented;
@@ -10257,6 +10565,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   }
 
   function inScope(state, varname) {
+    if (!trackScope) return false
     for (var v = state.localVars; v; v = v.next)
       if (v.name == varname) return true;
     for (var cx = state.context; cx; cx = cx.prev) {
@@ -10303,6 +10612,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   function register(varname) {
     var state = cx.state;
     cx.marked = "def";
+    if (!trackScope) return
     if (state.context) {
       if (state.lexical.info == "var" && state.context && state.context.block) {
         // FIXME function decls are also not block scoped
@@ -10402,7 +10712,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
       return cont(pushlex("form"), parenExpr, statement, poplex, maybeelse);
     }
     if (type == "function") return cont(functiondef);
-    if (type == "for") return cont(pushlex("form"), forspec, statement, poplex);
+    if (type == "for") return cont(pushlex("form"), pushblockcontext, forspec, statement, popcontext, poplex);
     if (type == "class" || (isTS && value == "interface")) {
       cx.marked = "keyword"
       return cont(pushlex("form", type == "class" ? type : value), className, poplex)
@@ -10468,7 +10778,6 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (type == "{") return contCommasep(objprop, "}", null, maybeop);
     if (type == "quasi") return pass(quasi, maybeop);
     if (type == "new") return cont(maybeTarget(noComma));
-    if (type == "import") return cont(expression);
     return cont();
   }
   function maybeexpression(type) {
@@ -10506,7 +10815,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   function quasi(type, value) {
     if (type != "quasi") return pass();
     if (value.slice(value.length - 2) != "${") return cont(quasi);
-    return cont(expression, continueQuasi);
+    return cont(maybeexpression, continueQuasi);
   }
   function continueQuasi(type) {
     if (type == "}") {
@@ -10632,7 +10941,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     }
   }
   function typeexpr(type, value) {
-    if (value == "keyof" || value == "typeof" || value == "infer") {
+    if (value == "keyof" || value == "typeof" || value == "infer" || value == "readonly") {
       cx.marked = "keyword"
       return cont(value == "typeof" ? expressionNoComma : typeexpr)
     }
@@ -10643,12 +10952,18 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (value == "|" || value == "&") return cont(typeexpr)
     if (type == "string" || type == "number" || type == "atom") return cont(afterType);
     if (type == "[") return cont(pushlex("]"), commasep(typeexpr, "]", ","), poplex, afterType)
-    if (type == "{") return cont(pushlex("}"), commasep(typeprop, "}", ",;"), poplex, afterType)
+    if (type == "{") return cont(pushlex("}"), typeprops, poplex, afterType)
     if (type == "(") return cont(commasep(typearg, ")"), maybeReturnType, afterType)
     if (type == "<") return cont(commasep(typeexpr, ">"), typeexpr)
+    if (type == "quasi") { return pass(quasiType, afterType); }
   }
   function maybeReturnType(type) {
     if (type == "=>") return cont(typeexpr)
+  }
+  function typeprops(type) {
+    if (type.match(/[\}\)\]]/)) return cont()
+    if (type == "," || type == ";") return cont(typeprops)
+    return pass(typeprop, typeprops)
   }
   function typeprop(type, value) {
     if (type == "variable" || cx.style == "keyword") {
@@ -10662,6 +10977,20 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
       return cont(expect("variable"), maybetypeOrIn, expect("]"), typeprop)
     } else if (type == "(") {
       return pass(functiondecl, typeprop)
+    } else if (!type.match(/[;\}\)\],]/)) {
+      return cont()
+    }
+  }
+  function quasiType(type, value) {
+    if (type != "quasi") return pass();
+    if (value.slice(value.length - 2) != "${") return cont(quasiType);
+    return cont(typeexpr, continueQuasiType);
+  }
+  function continueQuasiType(type) {
+    if (type == "}") {
+      cx.marked = "string-2";
+      cx.state.tokenize = tokenQuasi;
+      return cont(quasiType);
     }
   }
   function typearg(type, value) {
@@ -10803,6 +11132,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     if (value == "@") return cont(expression, classBody)
   }
   function classfield(type, value) {
+    if (value == "!") return cont(classfield)
     if (value == "?") return cont(classfield)
     if (type == ":") return cont(typeexpr, maybeAssign)
     if (value == "=") return cont(expressionNoComma)
@@ -10822,6 +11152,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
   function afterImport(type) {
     if (type == "string") return cont();
     if (type == "(") return pass(expression);
+    if (type == ".") return pass(maybeoperatorComma);
     return pass(importSpec, maybeMoreImports, maybeFrom);
   }
   function importSpec(type, value) {
@@ -10902,7 +11233,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
       if (!/^\s*else\b/.test(textAfter)) for (var i = state.cc.length - 1; i >= 0; --i) {
         var c = state.cc[i];
         if (c == poplex) lexical = lexical.prev;
-        else if (c != maybeelse) break;
+        else if (c != maybeelse && c != popcontext) break;
       }
       while ((lexical.type == "stat" || lexical.type == "form") &&
              (firstChar == "}" || ((top = state.cc[state.cc.length - 1]) &&
@@ -10939,8 +11270,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     expressionAllowed: expressionAllowed,
 
     skipExpression: function(state) {
-      var top = state.cc[state.cc.length - 1]
-      if (top == expression || top == expressionNoComma) state.cc.pop()
+      parseJS(state, "atom", "atom", "true", new CodeMirror.StringStream("", 2, null))
     }
   };
 });
@@ -10952,9 +11282,10 @@ CodeMirror.defineMIME("text/ecmascript", "javascript");
 CodeMirror.defineMIME("application/javascript", "javascript");
 CodeMirror.defineMIME("application/x-javascript", "javascript");
 CodeMirror.defineMIME("application/ecmascript", "javascript");
-CodeMirror.defineMIME("application/json", {name: "javascript", json: true});
-CodeMirror.defineMIME("application/x-json", {name: "javascript", json: true});
-CodeMirror.defineMIME("application/ld+json", {name: "javascript", jsonld: true});
+CodeMirror.defineMIME("application/json", { name: "javascript", json: true });
+CodeMirror.defineMIME("application/x-json", { name: "javascript", json: true });
+CodeMirror.defineMIME("application/manifest+json", { name: "javascript", json: true })
+CodeMirror.defineMIME("application/ld+json", { name: "javascript", jsonld: true });
 CodeMirror.defineMIME("text/typescript", { name: "javascript", typescript: true });
 CodeMirror.defineMIME("application/typescript", { name: "javascript", typescript: true });
 });

--- a/asset-codemirror-rollup.js
+++ b/asset-codemirror-rollup.js
@@ -11,10 +11,10 @@ shRawLibFetch
             "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/edit/matchbrackets.js"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.js"
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/edit/trailingspace.js"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/edit/trailingspace.js"
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.js"
         },
         {
             "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/mode/javascript/javascript.js"
@@ -10013,6 +10013,38 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/edit/matchbracke
 
 
 /*
+file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/edit/trailingspace.js
+*/
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: https://codemirror.net/LICENSE
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+  CodeMirror.defineOption("showTrailingSpace", false, function(cm, val, prev) {
+    if (prev == CodeMirror.Init) prev = false;
+    if (prev && !val)
+      cm.removeOverlay("trailingspace");
+    else if (!prev && val)
+      cm.addOverlay({
+        token: function(stream) {
+          for (var l = stream.string.length, i = l; i && /\s/.test(stream.string.charAt(i - 1)); --i) {}
+          if (i > stream.pos) { stream.pos = i; return null; }
+          stream.pos = l;
+          return "trailingspace";
+        },
+        name: "trailingspace"
+      });
+  });
+});
+
+
+/*
 file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.js
 */
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
@@ -10292,38 +10324,6 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.js
 
   CodeMirror.defineExtension("performLint", function() {
     startLinting(this);
-  });
-});
-
-
-/*
-file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/edit/trailingspace.js
-*/
-// CodeMirror, copyright (c) by Marijn Haverbeke and others
-// Distributed under an MIT license: https://codemirror.net/LICENSE
-
-(function(mod) {
-  if (typeof exports == "object" && typeof module == "object") // CommonJS
-    mod(require("../../lib/codemirror"));
-  else if (typeof define == "function" && define.amd) // AMD
-    define(["../../lib/codemirror"], mod);
-  else // Plain browser env
-    mod(CodeMirror);
-})(function(CodeMirror) {
-  CodeMirror.defineOption("showTrailingSpace", false, function(cm, val, prev) {
-    if (prev == CodeMirror.Init) prev = false;
-    if (prev && !val)
-      cm.removeOverlay("trailingspace");
-    else if (!prev && val)
-      cm.addOverlay({
-        token: function(stream) {
-          for (var l = stream.string.length, i = l; i && /\s/.test(stream.string.charAt(i - 1)); --i) {}
-          if (i > stream.pos) { stream.pos = i; return null; }
-          stream.pos = l;
-          return "trailingspace";
-        },
-        name: "trailingspace"
-      });
   });
 });
 

--- a/browser.mjs
+++ b/browser.mjs
@@ -20,6 +20,7 @@
     registerHelper, result,
     search, setSize, severity, stopPropagation,
     target, test, to, trim,
+    width,
     CodeMirror, Tab, addEventListener, checked, closure, column, context,
     create, ctrlKey, display, edition, exports, extraKeys, filter, forEach,
     fromTextArea, froms, functions, getElementById, getValue, global, id,
@@ -125,15 +126,146 @@ function jslint_report_html({
 /*csslint ignore:start*/
 @font-face {
     font-display: swap;
-    font-family: "Programma";
-    font-weight: bold;
-    src: url("asset-font-programma-bold.woff2") format("woff2");
-}
-@font-face {
-    font-display: swap;
     font-family: "Daley";
-    font-weight: bold;
-    src: url("asset-font-daley-bold.woff2") format("woff2");
+    src: url(
+"data:font/woff2;base64,d09GMgABAAAAABy4AA4AAAAAThwAABxiAAEAAAAAAAAAAAAA\
+AAAAAAAAAAAAAAAABmAAgiQINAmcDBEICuc41DEBNgIkA4R2C4I+AAQgBYkuByAMgScfYUIF\
+7NgjsHGAbcDVFkXZ5Jwd+P96IGPc9rl9ETBEaCzCJkvY2UpziRZ7zftZWk8052U9+NqX6vXL\
+KDflSQnlJ0bP+QnPQAy744n9mup6H9PaCDFwM5zjf8exB89bZ1cdrYOP0NgnuRDRWlk9u/fE\
+llkxqmfH8lmRQ/DAmER9opk9wR6suc1LvTiXNEe1vbhUCH2USgnEwH3vUm05JQqejGvZvOtz\
+7sIKEGgLdDNl/IrfqWVZG/wr42ekomEm91VA1p4LhHBuFzHF8//u7vvbREHMQqGtNLmiOOD/\
+X7WWiwqyCE98qt0jk5JJmgR5WJJElBmzRb1F7a66MmSLTNWZ2XSHfKBSKHoVteSEJ6EOdvVw\
+fNZOtXKDe39jXdRlkmMnOWIOFBgeEK/b0mFsgffnPyyAitNyutKky7J8a8MSEkAKGLgfptnS\
+/gDRSo7vwdNUmQDB7oP6pK7QF5d9SrY8M/tkrXcurSIQAmX7tz7pd33LIB7GQkBQ/k81s/0D\
+gpt4gbw7x0Cn/PocitK5KIGPGQIzQzAMuCeC2ERAidx9TySVqX06goT0SFFOOV9Kuxdi5Rg7\
+l6n3c+nKRemidOm2dtFV1jXMk4rP2m6RJ8xEdPYONLTbeMgaJ1nwS2W4su3MHwqkkvJ2PdDU\
+r7pgAnVRt4Kh789FXlD0r3p6jUtNO19O1s74U9pnIxqFpw+mBgF+8y30PAyw1dzlknLLVcSB\
+J2OuCr9eV5Efew6cOGd47ZEfhrW7HXI+FBNFvWgWnugUU4UvlrV63niv2ZPeKu8M76y/HQaG\
+weU+4Gzp+Y+cfb9R9djDWcd1Svr1xG7l+j/yf3eM996548qlC+dOzOqQ8//Lo0uaSEQCFuLD\
+/bXyWhJ6aPmyaRonVPxGABFL4/0slcKI6f+PmT0M+QRsplmWnv4F49VT+JsPifoa6aeyr2Hz\
+EeLdP1FEOV/ZN+c9sAuoNh0BRS0xgCCc9wME5s0HOKj/wc0fWYsTbFQpsZL5SayJPkL45kDo\
+DcJJ10MvD0ZSq7FEIr1TfqZ7NC6s75zSp8viaNO5/PczYCV9z6NTa0KBdnGBg6kbdeBkRLfU\
+qRd3D9Pqw5jWCc5WM/i95OE8731MBd1u2EmsXIa5dCvavY32U1Ytza4nfbERg6OVRZka7jq0\
+r2FcXNDyEhXheaHtaU1o1kvO9MuBOHqugLUEzN+4jznu0oK9wZPur1lWVFfxl8lZzn2XwcjZ\
+Csg/RJy0mAMMmgnqXS8ELhOCRUSLzvsM5gAPudEh2lVoRxGgyUVnArZMruE0YS1PqFMD3upb\
+jVoecGj1KpWl6/ZysuyzkG4SGA4bps6FBQSg4e4IxNUgdmosmoDn0TpIex/s1BFau6GBNO4z\
+cvWXypm4hEg5k3llelySFqNmUtRZ3PHBA7p4MBX1nK4awwAV6kWzIVbUA67A55QKYbMsgVaH\
+c1ZxKuZ0DCyqxCsJjLyCEY36gf0wjAu3t0zemc87PmBCJbU9Lso0YAaYJUx8wsR02hYz5hGy\
+Js0+A4uHGZgfuf5SOR9iBQuLhpOExaIFrHj6JlXanebzGHp2ELDh6av09PVE1fmdsj2oHRWs\
+fOtYrV6wRCyx7XogHqvpnZiPBBdNcL6kIoS9UI/DOIlumlveSgv9oqMBYp7WZ2fGxAXmZmaG\
+OCyJG6+wAszZFCQw/EXVjx+YA2uVyN6bhNWiZhgtYjAwR5U/7uV1scghiTGiAPZbA5ZqHw5u\
+Yu1cDjhRwREBFyq2wa0R8GgceDUKPo2BX+MhoAkQ1EQIaZqVHMwH3xM+P32TTA34tmOMNZ4n\
+mHXqn49fmE3qX1+wMNYoYetOsPx6wxKzkURImERJIjGSSJwkkiCJJEkiKZJImiSSIYlkSYqK\
+UBu0UOopuLMmasiJW0PMFOO2UgbDif2NaQUqkBbyaGjdTUvuyamEQwCq9DWsxsG9qPt+VFqV\
+6cIsXcyWujWIEtNFdeia9ssNrJUpe3IDMPQZOReC8x+qvt17drPWdcHeL0gTarWwoQ6o828o\
+0EJzrA20yZsgVyVHdlCJOF3NaACxHbP38TA+MGx3St9c5t2CxbGtunB4J9AF4Px2rSr1wyK9\
+9KoXBR13vw9Fk9qhTX0ivZoanrvhLa5oiJO8cqR0lX7QtJ2c1a62V3PMtutaaoit+hxtXuC5\
+ZUXJePSR6btQlt5g7PqPQ822g7F8D123pc4kaGXz7qYztJxDXCxJr7foKqxwy4rikI/NvINx\
+bkArRTTnnMWy6YA8J39LfTweThKsqlt7Mz078NDSOPOGgtGTpeG8ZRBF+xKBjdSoNe8gE6uC\
+ucOH98jE4+cv1JEjI555TFjYj4+0KdFlojzJGWp2wc1tCaYGSeO8dBfT0u3lpDY3tazzu4wn\
+lF9wzy2nK+sTr/qEVdANoZ0ToBdD+MY4ewOHNnkXPBvKVXLSbEGfGVD0Nzr0Fs3HID3Y1Kqx\
+mzJ6p1C1/R6Xneyw/q9YRDLahbnsI1u76XzMLPqsK0yvQDeQ4TMR41709sIssmEgs0XH1lcj\
+7HLnUG6u2Xpy5vbOowIGqrR6cwF0TLGI5PF7pkbzIVYQU0sIaoNgul3LGAH2B1nREFYXUMia\
+prCeAzggGxrC5gIK2dK0exs/AIRKdlIIuxkUspdSsU+rqXagqXaooXakqTiWS/a0E7zA6QIK\
+OdMUznMAh+RCQ7hcQCFXmspr3ciuds/6gPsZFPIgpfJhwUIepRAeZ1DIk5Tue4oKfSfKZyNV\
+pKU/J7J4Abx1EMV5mXSRDl6lMfU6jfBmBww4k7f6gLzTB+J9od/kA/uGj2mET2nkn7+zQ/JF\
+H5Kv+pB804fkOyvwI43wM438V5sdkd/6iPzRR+SvPiL/WIH/aYRxGqMb/Oqe3d54+LWR1vr2\
+knnnc467iD247eXBA3YYBAiFfierClXz/8jyL3Qh/zP8y+Y/1eN8jq+SKZAML/lIidjwZ8N4\
+aLthvhxGUkGPo+p0eHKZ0sT5FsqJcQCy9UhHIvcJFIlIvANTPFWUTUhSiVdsNRnvwEQxm5uc\
+ksjdv5evJfpOgI6c7juH8pnG2RKwlXaDYe9g8rMwYfML3A2SMWeBDopJJsmS5dUE2KttnmQa\
+JZlMspvEpJioiEDFNpPUTbwqG3Zjhx2VCeJrIf60s2mI6blZMZVyAyYzI+1a2Y0AIqcbLUgR\
+6iRbNtnp82GrImXW0YbcbczDgqQDWNdTenvtTAlT9iPHenluV+d3eed1/5MjMBrX2LgrK2ml\
+FuoDOz036n/kaHbAeszR3jHoI4NWB3lusTfuVgkMUkLQaH0F6+pSCS11fXRwT421vs9s7axd\
+nvtF7/eeIeq9s1aCLsLWdh+w7sXz3IYdEsSQ0LVsebmES/vXDU9k653W4MiNq8bMj5nLioCY\
+edGgOT6tmYwqiOW1ugiEmew6iwjvvYb3SaeZJb7XNufOo9oH8FTneWGL+BLiclptpnhPwcui\
+T+rzcF34+ycsL7p3AveuML9i9h13beylyg8CzEz5HppadqmmDxKrAquG9L3ztedRoWxEsAYt\
+OM1Eu0G0gyTHkxf7cSkHJQRbA4xmlqHWkv1C0KhFhBq1z81Wq1CZoWic8TJ570WfSj5qsM+Q\
+nl4k3H5+P+P3zlv9ltQrzv41qyiSwV/gOadyQBchsmwDGu/JI8tXflE8jqUVA0Zw0SKbdDC9\
+c4FR+fak95SdF7uqpoRe9z6YRv+85YUzF4qJy6Q8GOVNwUn/ymyjNNbmcuVfXYeH2osLdCte\
+ebmZRyUfQQZA1BSCLK4PWA/z1kBvDZm0t+i3or1LkMD6en95pGG0UOa8ZJXgS9TdEA1I2mZw\
+1JOWWxDu0NEh4rM19H55rvueMBUZV1RjkmB3oxkXhAckpa5gzzxUDA2VLOrWFAXx+4gmfU17\
+5o3v9H7EYdvGFuM+tDB3TA4ITjVUKduO/R4bXRAcPXZusWkN+t59sFz7Hyi0FkSdzrHXQVFq\
+b8c9k9eLRjVlBbNvt4172CanYg/F3Rket1zCTc77UZ61Gq/Be9J8hrKrxbDZMEotf5o8zHDc\
+/UJaEtdhgwHEcBEQKM+6NBWIewLmI1sHuWYAedZCw8U1hJfSWcld+2tv3jpCFc5FnosLWC0+\
+DnAlnOXUXLoMXrmCVerNQkZHvRm8YtE12vG8+N/vOnPcu3vM1uOnzE3u3VP2ppmLZawm2NuO\
+tPa7xwHFCgVKpox5PVrOmaDHrThk1tX864a2+/qhJd3nCFRQ+bfUKI4O+Wgk5byB3saMcUfV\
+C8G137yMd16zRm3ZSq+UrDlk5ha3TiAj0b74prWO/vYG+RC+ronP1/McDtefBtY1XhZE0PIB\
+wTe7CBTte2U6KPbYd5GffApQlDGssdfmxYGSlnHrQt7++KEwUg3ikkoQyKPixgUDB6Lozjv5\
+vM5PBnllt+UzMnP6DStFsOfossbXOefWhQApACCNpkTYGAONIowDfndqDKRFuzn685nthZPe\
+vEL7TIWkXAG2yxKBH90+yMzuRzWn3KMmyKGwZWnIErlJ9Vwt8OtR6+4TKad5y9+ViBtTzVG+\
+tpv/xiLrcGKJRtYvCUlGeL4Dwy1jo1CSQe0X71EXK1YG44ztxTONjIslL8SwY0Cki0k0vsX/\
+/xz7CxkAc9dEdJZhMy/JCGzD2FAGtUcag0tc2e2miJkp477V2qTKB+nFnDl/noxpXJ+yqVdO\
+wNjbplmeiuburg9ii1Z1zwtG8QjcJAiVPSOV2mHzq1Qt7p2+YCcIKPmFusE5O+m8s+Wd8o3t\
+qO1b1IZF8N0tx6RQnZ9Ux3gXijHlolixst6vhJV6ao0ZFzSprfAc3x0MLvxU0OsmXEVddMVK\
+29CC6mPgPtXTUW7tVnZxwm0DTJwNOeVRV4axMSPlpgyv1Va1MQhQqWwUOb0s+gVLOecos4Nf\
+eqlFW3fLQrlP86R4XRxrDHF0VIx6ArM5/sTWtObY6U2aosgxbN6FUa1iNTUpMThk1sUfJOC6\
+s1SKo9D0g1NfiVmavyful/K7nZdDgutV1A26i7FR3r16bv3zz1cGw+ta17IX/+ripyutix3C\
+xNmCxs7uiqKu9/Zjjn06tblXpJxlaLF5Od0d5W9QhQrs2u6UN0trQlCyEK2j9VYgCEIDrhQN\
+c00rxg/FOfZ1N+nLV7RXDsYP+p0EzqKcuPujzuzEQsu2mFf4nYvf3Yp32rq/RYLetDLuOOTc\
+0WXBtgoech7AHUxAxPBg81qWCsYlzTofRU5/MpuyNoegR6mCJO5ckrLOhWbG7xo/VGwGgpRb\
++Ch+TmlcuY6Qct/2x3gxzeDUU9u+ltexrjelJ0VRR9KXH/AqrbYxHa0vmQ/kBnE5EORBK1ZH\
+mTSy7A8DJMgzzqDsu9ML5J3ufkuUNDCfN5UKAjBgw2I/QlS8MQ6o/ll9dTAdoM7HYtV4cNWE\
+U4pOl5Y4SIzdMbNSjXFmsBV1uXXf7GaBZZslpFGFiIpokSzxWj4hjlGl4VKJDACo7ScxQf29\
+kM8gHD3nUJkwkN2aW2TGttqwOrygJ7r9nYX2tYqy7Z3TQV5ocWzUI8l871y3LsQLoTgEO76B\
+Upp69hy6VKRpZvpvgfQ2T06qgXjxh38eatREitX6bzKggIYmN4sAkA3a5oeJZDK3ahQrVJwa\
+AD65cEGBkS/tKH9TtybiREEWCMcKD0HH0gELtjB+KNSk7bspmpr6eb0CscIiFyZpmXu8+gxw\
+O7pJNbAK2h9q2c5dMHBaoi5DylbNGdweVVdN3Jm9u6YXXlmx4nYY2vIPfSkrE/vyv9gn/Z+j\
+R3HKExaUhdV0Az77YWbQPhNfjw+F0vTteSMin+wIfxyPe0DEoI4uz6o2IXwsZC7sg8MicQ3o\
+wys+NJYKVW72YiVQ5LKDVwrEg2jNVM6XdNjbsHlRDcAkD08o5iWtFB2dVoydRmmDRLalE+4t\
+3gBbAPa7n7qXXXbTZTJXZKy5+1W0K7dgYEcIlu90ovC0C+5gxXiKtZisT14qDJ7f2ksyK59U\
+r3QeHtBb24mPz7YDB3rgMTyUZ/fxM8h2i1Z21B8/VA5+9l7BKaOJZ15lWsyPv/z6CjU32ZKq\
++QFeyUywxYnUxUmcQfGc1Sp69oE2n6zFL8BXf5rc3cJMM6S97gagTT1bi7cmAV4MibkC4rz/\
+icmmFtMlo5aN1Wp3uxsBfd4+9T42xmxvd79FV/hfuviBcrIaX092PrY5rle9FR4wTnDzrwj4\
+7frD2d0KsMcdcADQ1Yu1LECg9Wj3yOS8OhrJdQBqXqsam17vmt2wjjjouHE/EO9sGPdqt23v\
+j8rL6wid6ulagtNK5p1hjRkFtUxTIaZnIXk63Zb3P0t5MQ+3vxHIFrmgAdWwiDuA67tbVIF6\
+wJ53z0uhyhsfH9bgF0kPT9v2hrT3HKIBgUXIYoxsVU+uryemiUiQEwh+BfxP//qLShlumR26\
+I8OqjD+x3hHDj/IrEWmvyL6ioG/atfxe+5GzIqRgfaoayWOiTk+YixO15KDO6Os3XACDjboe\
+ryXXOuEmTpDsc7czk+H04Kw1PNJazW32CAURHwBldqK0/nqYHtcrtLyyTYmoD8hbcnJUfa3U\
+3FxWNus7uic3Qm1BzEecJW0MAz+W2CyN9FLIy+EpSy6CjkXsllZw1uBs1SxrQWM97/vnHu7m\
+OtrkRl8AtBN3RDxI/fg7dZLLtDFYuCYYPMwXiO6ZIpwJ1GGydI9oUYYgnQQKDKoMTcwsjrfe\
+Tcht6y18bLcpNfX41WE27447vLNzHuF+j15co5N7Py8vKUpTCoghHMEYKkM6y02lvX+9XiFg\
+xBKMRNiwX69+LJb2Xa5WGqo7Rlk0cxsLVd0l2UXAW5jORg31sFMKYWXsDcRUKRDP8Q87OjiM\
+dI1hNEt43netf8rOyfp+L58fq3holY9gxXwRJLY6gahgLQi4hS8w9LS+rFcJtdSCBrQLWsMs\
+aDg/n8/P8/N+fcyoLepYr3W/CIUT7HsRQTtkduddbVfbo6Twt6fyJVPRrUGqRkWp3rdry65v\
+sPYInyq1mPHrQDrqGJYI/LzA/QAzAXLnx+lu9uxHTEka9xgWgRvqEioskh+UWgD4nDvTAxaz\
+3v9BqqmFuQwy1wSXye1Df1NXVF7G8bUFxUE4F9axG5fm+vFQJvP8iuYjrFveB6++AqmJTQJ0\
+9GHjbPhzdSzkZGxokQzONVs0R0FCPJz1hJKbvDKsaj9hT0vp/gH5oiT8pAbWsBChwAbxHgDd\
+59iJVZE3bAzPRN1RuG+MT7th+J3i6KFwVJvPvsGRDIZW4P2rVfiKjDVBM2Va+w6PgI0c5u3K\
+O7MrWryPhXFFdBoAwi2JCaW9sZ3fTagQ4Tld6u4djwcWzeCdiYoeNbfalsRYo740afYQ1Rid\
+Bp/E9mbcTemEjoWWXIU7I5nK5H/BEqmZnPMyhDV234BTLQKCe6nhU+frwQo1gNFWf+eQGN62\
+aeF7BuzaN/94W2xlKd8t8KMA/3uoxymFt19OlCjYZeaMWbTKM9Yog9zDhptYMOzIQAoO7kn6\
+nTao8CxjrRRgjKe7mKa+tzuufhAAZtgjA92THkulWvIzEi0++j1DvXMnupDUS8aVusWain+c\
+CcvmR5orC+RcJs3wVahLYyEcqbvAS2e0QJ6BlU36R/IEd9Aol9q+M+UGvlo8EyRzISvqusNS\
+7ePQ6cQzG1s725db4jNYNHAfF3KFG8wHqDwZDpWDsJ5qRLXR1ulFx85GhkypPubYaCiOQ5DR\
+PQUiNpgk4fLJHenSMLMiswXsqW4Cpln1rFoHzpOoBbuZIixmVyhKajeqlFmp8zNAEsbEJz0g\
+X0qlQuykZhf82pkhq2hWtCtYUdBODn6iPTBJT5Zk8IqFxqfBeFKjXk/sMeumhT8muOtq2Bgn\
+dR4fj6RoOi0zI25kajAXlDZhUhS39jipk39h/69AfDPBLmOxhDj7Lg/WUTbOwJiJ3p7WtOpm\
+ypARmhorQifINNm1CNS99GfDcLbD8sn8Fvlmvn7CmW65Pdmu6bKtuE0tn7NglIX1e/JAJP+G\
+gB3At7cSOp92rl0lp0pp0xVb5YaQedwGgcJA1pT4cy24lS+jvzDw86YTfb2igJm5MysHmejW\
+ZTGXpoAoLBLucUGEz/DwbjqOdzGAl5jy5VoCQws5zNYl4SVt030aZulYMgpDBPZd+kL0wV+w\
+nob2LPRDQGEbdUoeFm4fEKio9c/ferVlpSO8Bx7OFZyHip1PIizvoqFe02kpmS17TvIOty42\
++Q0QaCnOpeLsPwwo+vixIeIeUjucUsKejVlez35qyuC0mm5pJJJLEVP2JAe/LTOwUUfKJkNy\
+lEe3Kdth241ZNQmkVcAIh6DZJBzvQov5fn3JZA0phBWdNq5iTsm5N2D8gyve3V3X2o3zF3VY\
+OqEBgTIADAbC69z7vOKJjGOzHRmUUwLU66iabtIbqR6SPOHCL+fCTfvpKcB/oG2p3wRKErEJ\
+v1YOfu9iaKEMLXS3ptdH8fwN2Rdww9bZ7rFa2bwrzcyux3o+hPV6bJZpb71j7lLAdzge3VX7\
+9uSCdz6f/FDb7+wzWnbbDSPj9R20+PybDUm/lVAsTuF0aycFQwJfPCUwcBvCGWEq6xoTIEOy\
+b0bLta20+LYRYdyEceX7ypfezQKIy5OvJTAHCJy/WyOYaDVyPucMsHnZ0GCH75Cd//te1Bv2\
+RkMykqYurBiNbuH3Xfuprirr4Dd453O6abAYGb5tw1d6wrBL8p1J1Sx9Lgw7yxqYn0FTrc0y\
+59yLlV+4zIkLfZlPFRVnanHpTyrIlpn4lGkt269+JXnIWhEQWNvuVsrt531jr+8AHkVZfQU8\
+8U/4AUZMuOj5iliigFrof/usmloYEI1f8erhJku75snYW7YmFmUcoC7UtG/KfJRuz6j0tWPa\
+56J5QA0rJHwSIhNT4GWvez19HT2lia+Pz7/+MVEWlvjY6+9P85a0y9qWkTzQ7nF0wDXpQpw3\
+K4xnfK2L08b5MrxdeI+DDfVDeV2JY0Fp6KH602tj2MbxxKM8oG+wTkE/dr8jyo4Sfs/IV6uf\
++IIXpH2Nca1+WCJV5qEv193bcUELLR4iFu83xUedKy9353tn+3o01dF2bNEQ3fK9Q5tCXrCi\
+La+woCuvEeYrr+PiN2+i2V/eDJck580pyra8BV5ZIZbpe3kr5vJD3pqoGsnbcl/d+ndvR23b\
+K41M4dKwaAwDaMA1gZGBoQWAcYE9mYkmQOnAjkaG41FkGkIP2BAIgKvUvzhpE5JbA6lze2iL\
+5Nr+AwiDo2W4BStvK30dKy0JGNbzAY5akexsrV0xo5K8rY50LOTLvDyukIZNbRLKOCk18mD3\
+WxmZGlsCMxNdGFYGNJnetUWyCPgo4BONEL4I9b8UeEBGYXuCdCd+DkctrqVLYXGSfE46kvAu\
++ltK5SRxQPnjUqyJXsSYs6VY6WPKfns9+IXjHhd5wQvGipgFdMwVEQ+A7a2AAS0clQwH7KHW\
+SEGjhnklSVRghMtPy6gEtJRIKJeYkpQyQiequQunFOOU4BLdK1yp55olZS6npyPhMnvK7xIa\
+pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
+1R8uVi8Zu9nRFqk/t0gR6wmWOlzuKRqk33HpO8qQ+nbGoEZLL/0Va156SJ+u+t86/os7ic49\
+/7xoEqvL+2E8VOyCTuT/7j269Zy4jUtN+g4="
+    ) format("woff2");
 }
 *,
 *:after,
@@ -144,44 +276,38 @@ function jslint_report_html({
     padding: 0;
 }
 /*csslint ignore:end*/
+.JSLINT_ {
+    font-family: daley, sans-serif;
+    font-size: 14px;
+}
 .JSLINT_ address,
 .JSLINT_ cite,
-.JSLINT_ dt {
-    font-family: serif;
-}
-.JSLINT_ dd,
-.JSLINT_ dfn,
-.JSLINT_ samp {
-    font-family: programma, monospace;
-}
+.JSLINT_ dt,
 .JSLINT_ textarea {
-    font-family: monospace;
     font-size: 12px;
 }
+.JSLINT_ textarea,
+#JSLINT_REPORT_FUNCTIONS > div {
+    font-family: monospace;
+}
 
-
-.JSLINT_ {
+body {
     background: antiquewhite;
 }
 .JSLINT_ address {
     float: right;
-    font-size: 90%;
-    margin-left: 16px;
 }
 .JSLINT_ dd {
-    font-weight: bold;
-    margin-left: 8em;
-    padding-bottom: 2px;
+    padding-left: 128px;
 }
 .JSLINT_ dfn {
     display: block;
     font-style: normal;
-    font-weight: bold;
-    padding-bottom: 2px;
+    padding-bottom: 4px;
 }
 .JSLINT_ dl {
     background: cornsilk;
-    padding: 4px 16px 0 16px;
+    padding: 8px 16px 4px 16px;
 }
 .JSLINT_ dl.level0 {
     background: white;
@@ -194,45 +320,45 @@ function jslint_report_html({
 .JSLINT_ dl.level2 {
     /* green */
     background: #e0ffe0;
-    margin-left: 2em;
+    margin-left: 32px;
 }
 .JSLINT_ dl.level3 {
     /* blue */
     background: #D0D0ff;
-    margin-left: 3em;
+    margin-left: 48px;
 }
 .JSLINT_ dl.level4 {
     /* purple */
     background: #ffe0ff;
-    margin-left: 4em;
+    margin-left: 64px;
 }
 .JSLINT_ dl.level5 {
     /* red */
     background: #ffe0e0;
-    margin-left: 5em;
+    margin-left: 80px;
 }
 .JSLINT_ dl.level6 {
     /* orange */
     background: #ffe390;
-    margin-left: 6em;
+    margin-left: 96px;
 }
 .JSLINT_ dl.level7 {
     /* gray */
     background: #e0e0e0;
-    margin-left: 7em;
+    margin-left: 112px;
 }
 .JSLINT_ dl.level8 {
-    margin-left: 8em;
+    margin-left: 128px;
 }
 .JSLINT_ dl.level9 {
-    margin-left: 9em;
+    margin-left: 144px;
 }
 .JSLINT_ dt {
     float: left;
-    font-size: 75%;
     font-style: italic;
+    padding-top: 2px;
     text-align: right;
-    width: 8em;
+    width: 100px;
 }
 .JSLINT_ fieldset {
     background: gainsboro;
@@ -243,18 +369,17 @@ function jslint_report_html({
 .JSLINT_ fieldset > div {
     padding: 16px;
     width: 100%;
+    word-wrap: break-word;
 }
 .JSLINT_ legend {
     background: darkslategray;
     color: white;
-    font-style: normal;
-    font-weight: normal;
-    padding: 0.25em 0;
+    padding: 4px 0;
     text-align: center;
     width: 100%;
 }
 .JSLINT_ textarea {
-    padding: 0.5%;
+    padding: 4px;
     resize: none;
     white-space: pre;
     width: 100%;
@@ -271,8 +396,7 @@ function jslint_report_html({
 }
 #JSLINT_REPORT_WARNINGS cite {
     display: block;
-    font-style: normal;
-    margin-top: 16px;
+    margin: 16px 0 4px 0;
     overflow-x: hidden;
 }
 #JSLINT_REPORT_WARNINGS cite:nth-child(1) {
@@ -281,8 +405,6 @@ function jslint_report_html({
 #JSLINT_REPORT_WARNINGS samp {
     background: lavenderblush;
     display: block;
-    font-style: normal;
-    font-weight: bold;
     padding: 4px;
     white-space: pre-wrap;
 }
@@ -308,10 +430,10 @@ function jslint_report_html({
         line_source,
         message,
         stack_trace = ""
-    }) {
+    }, ii) {
         html += `<cite>`;
         html += `<address>${entityify(line)}.${entityify(column)}</address>`;
-        html += entityify(message);
+        html += entityify(`${ii + 1}. ${message}`);
         html += `</cite>`;
         html += `<samp>${entityify(line_source + "\n" + stack_trace)}</samp>`;
     });
@@ -325,8 +447,8 @@ function jslint_report_html({
 
     html += `<fieldset id="JSLINT_REPORT_PROPERTIES">`;
     html += `<legend>Report: Properties</legend>`;
-    html += `<textarea rows="4" readonly>`;
-    html += `/\*property`;
+    html += `<textarea readonly>`;
+    html += `/*property`;
     Object.keys(property).sort().forEach(function (key, ii) {
         if (ii !== 0) {
             html += ",";
@@ -459,11 +581,33 @@ function jslint_report_html({
     });
     html += `</div>`;
     html += `</fieldset>`;
-    html += `</div>`;
+    html += String(`
+<script>
+/*jslint browser*/
+(function () {
+    "use strict";
+    function jslint_ui_onresize() {
+        let width = document.querySelector(
+            "#JSLINT_REPORT_PROPERTIES"
+        ).offsetWidth;
+        document.querySelectorAll(
+            ".JSLINT_ fieldset > div"
+        ).forEach(function (elem) {
+            if (!elem.closest("#JSLINT_REPORT_PROPERTIES")) {
+                elem.style.width = width + "px";
+            }
+        });
+    }
+    window.onload = jslint_ui_onresize;
+    window.onresize = jslint_ui_onresize;
+}());
+</script>
+    `).trim();
+    html += `</div>\n`;
     return html;
 }
 
-function jslint_with_ui() {
+function jslint_ui_call() {
 // This function will run jslint in browser and create html-reports.
 
 // Show ui-loader-animation.
@@ -480,12 +624,27 @@ function jslint_with_ui() {
     document.querySelector(
         "#JSLINT_REPORT_HTML"
     ).outerHTML = jslint_report_html(jslint_option_dict.result);
+    jslint_ui_onresize();
 
 // Hide ui-loader-animation.
 
     setTimeout(function () {
         document.getElementById("uiLoader1").style.display = "none";
     }, 500);
+}
+
+function jslint_ui_onresize() {
+    let width = document.querySelector(
+        "#JSLINT_OPTIONS"
+    ).offsetWidth;
+    document.querySelectorAll(
+        ".JSLINT_ fieldset > div"
+    ).forEach(function (elem) {
+        if (!elem.closest("#JSLINT_OPTIONS")) {
+            elem.style.width = width + "px";
+        }
+    });
+    editor.setSize(width);
 }
 
 (function () {
@@ -536,7 +695,7 @@ function jslint_with_ui() {
         case "e":
             evt.preventDefault();
             evt.stopPropagation();
-            jslint_with_ui();
+            jslint_ui_call();
             break;
         }
     });
@@ -547,7 +706,7 @@ function jslint_with_ui() {
     }) {
         switch (target.name) {
         case "JSLint":
-            jslint_with_ui();
+            jslint_ui_call();
             break;
         case "clear_options":
             document.querySelectorAll(
@@ -594,14 +753,8 @@ function jslint_with_ui() {
             jslint_option_dict[elem.value] = elem.checked;
         });
     };
-    window.addEventListener("resize", function () {
-        editor.setSize(document.querySelector(
-            "#JSLINT_OPTIONS"
-        ).offsetWidth);
-    });
-    window.addEventListener("load", function () {
-        window.dispatchEvent(new Event("resize"));
-    });
+    window.addEventListener("load", jslint_ui_onresize);
+    window.addEventListener("resize", jslint_ui_onresize);
     if (!mode_debug) {
         editor.setValue(`#!/usr/bin/env node
 

--- a/browser.mjs
+++ b/browser.mjs
@@ -276,8 +276,9 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
     padding: 0;
 }
 /*csslint ignore:end*/
+
 .JSLINT_ {
-    font-family: daley, sans-serif;
+    font-family: sans-serif;
     font-size: 14px;
 }
 .JSLINT_ address,
@@ -285,6 +286,12 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
 .JSLINT_ dt,
 .JSLINT_ textarea {
     font-size: 12px;
+}
+.JSLINT_ legend,
+.JSLINT_ .center {
+    font-family: daley, sans-serif;
+    font-size: 14px;
+    text-align: center;
 }
 .JSLINT_ textarea,
 #JSLINT_REPORT_FUNCTIONS > div {
@@ -375,7 +382,6 @@ body {
     background: darkslategray;
     color: white;
     padding: 4px 0;
-    text-align: center;
     width: 100%;
 }
 .JSLINT_ textarea {
@@ -422,7 +428,7 @@ body {
     html += `<legend>Report: Warnings</legend>`;
     html += `<div>`;
     if (stop) {
-        html += "<center>JSLint was unable to finish.</center>";
+        html += `<div class="center">JSLint was unable to finish.</div>`;
     }
     warnings.forEach(function ({
         column,
@@ -438,7 +444,7 @@ body {
         html += `<samp>${entityify(line_source + "\n" + stack_trace)}</samp>`;
     });
     if (warnings.length === 0) {
-        html += "<center>There are no warnings.</center>";
+        html += `<div class="center">There are no warnings.</div>`;
     }
     html += `</div>`;
     html += `</fieldset>`;
@@ -476,12 +482,12 @@ body {
     if (json) {
         return (
             warnings.length === 0
-            ? "<center>JSON: good.</center>"
-            : "<center>JSON: bad.</center>"
+            ? `<div class="center">JSON: good.</div>`
+            : `<div class="center">JSON: bad.</div>`
         );
     }
     if (functions.length === 0) {
-        html += "<center>There are no functions.</center>";
+        html += `<div class="center">There are no functions.</div>`;
     }
     exports = Object.keys(exports).sort();
     froms.sort();

--- a/browser.mjs
+++ b/browser.mjs
@@ -5,12 +5,25 @@
 /*jslint beta, browser*/
 
 /*property
-    closest, target, preventDefault, stopPropagation,
-    click, debug, search, test, trim,
+    CodeMirror, Pos,
+    bind,
+    click, currentTarget,
+    closest,
+    debug, dispatchEvent,
+    editor,
+    from,
+    globals, gutters,
+    lint, lintOnChange,
+    map, mode_stop,
+    offsetWidth, onchange, onkeyup,
+    performLint, preventDefault,
+    registerHelper, result,
+    search, setSize, severity, stopPropagation,
+    target, test, to, trim,
     CodeMirror, Tab, addEventListener, checked, closure, column, context,
     create, ctrlKey, display, edition, exports, extraKeys, filter, forEach,
     fromTextArea, froms, functions, getElementById, getValue, global, id,
-    indentUnit, indentWithTabs, innerHTML, isArray, join, jslint_result, json,
+    indentUnit, indentWithTabs, outerHTML, isArray, join, jslint_result, json,
     key, keys, length, level, line, lineNumbers, lineWrapping, line_source,
     matchBrackets, message, metaKey, mode, module, name, names, onclick,
     parameters, parent, property, push, querySelector, querySelectorAll,
@@ -25,264 +38,448 @@ import jslint from "./jslint.mjs";
 // interacting with the browser and displaying the reports.
 
 let editor;
+let jslint_option_dict = {
+    lintOnChange: false
+};
 let mode_debug;
 
-function entityify(string) {
+function jslint_plugin_codemirror(CodeMirror) {
 
-// Replace & < > with less destructive entities.
+// This function will integrate jslint with CodeMirror's lint addon.
+// Requires CodeMirror and jslint.
 
-    return String(string).replace((
-        /&/g
-    ), "&amp;").replace((
-        /</g
-    ), "&lt;").replace((
-        />/g
-    ), "&gt;");
+    CodeMirror.registerHelper("lint", "javascript", function (text, options) {
+        options.result = jslint(text, options, options.globals);
+        return options.result.warnings.map(function ({
+            column,
+            line,
+            message,
+            mode_stop
+        }) {
+            return {
+                from: CodeMirror.Pos(line - 1, column - 1), //jslint-quiet
+                message,
+                severity: (
+                    mode_stop
+                    ? "error"
+                    : "warning"
+                ),
+                to: CodeMirror.Pos(line - 1, column) //jslint-quiet
+            };
+        });
+    });
 }
 
-function error_report(data) {
+function jslint_report_html({
+    exports,
+    froms,
+    functions,
+    global,
+    json,
+    module,
+    property,
+    stop,
+    warnings
+}) {
+
+// This function will create html-reports for warnings, properties, and
+// functions from jslint's results.
+// example usage:
+//  let result = jslint("console.log('hello world')");
+//  let html = jslint_report_html(result);
+
+    let html = "";
+    let length_80 = 1111;
+
+    function detail(title, list) {
+        if (Array.isArray(list) && list.length > 0) {
+            html += `<dt>${entityify(title)}</dt><dd>${list.join(", ")}</dd>`;
+        }
+    }
+
+    function entityify(str) {
+
+// Replace & < > with less destructive html-entities.
+
+        return String(str).replace((
+            /&/g
+        ), "&amp;").replace((
+            /</g
+        ), "&lt;").replace((
+            />/g
+        ), "&gt;");
+    }
 
 // Produce the HTML Error Report.
-
 // <cite><address>LINE_NUMBER</address>MESSAGE</cite>
 // <samp>EVIDENCE</samp>
 
-    let output = [];
-    if (data.stop) {
-        output.push("<center>JSLint was unable to finish.</center>");
+    html += `<div class="JSLINT_" id="JSLINT_REPORT_HTML">`;
+    html += String(`
+<style id="#JSLINT_REPORT_STYLE">
+/*csslint
+    box-model: false,
+    ids:false,
+    overqualified-elements: false
+*/
+/*csslint ignore:start*/
+@font-face {
+    font-display: swap;
+    font-family: "Programma";
+    font-weight: bold;
+    src: url("asset-font-programma-bold.woff2") format("woff2");
+}
+@font-face {
+    font-display: swap;
+    font-family: "Daley";
+    font-weight: bold;
+    src: url("asset-font-daley-bold.woff2") format("woff2");
+}
+*,
+*:after,
+*:before {
+    border: 0;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+/*csslint ignore:end*/
+.JSLINT_ address,
+.JSLINT_ cite,
+.JSLINT_ dt {
+    font-family: serif;
+}
+.JSLINT_ dd,
+.JSLINT_ dfn,
+.JSLINT_ samp {
+    font-family: programma, monospace;
+}
+.JSLINT_ textarea {
+    font-family: monospace;
+    font-size: 12px;
+}
+
+
+.JSLINT_ {
+    background: antiquewhite;
+}
+.JSLINT_ address {
+    float: right;
+    font-size: 90%;
+    margin-left: 16px;
+}
+.JSLINT_ dd {
+    font-weight: bold;
+    margin-left: 8em;
+    padding-bottom: 2px;
+}
+.JSLINT_ dfn {
+    display: block;
+    font-style: normal;
+    font-weight: bold;
+    padding-bottom: 2px;
+}
+.JSLINT_ dl {
+    background: cornsilk;
+    padding: 4px 16px 0 16px;
+}
+.JSLINT_ dl.level0 {
+    background: white;
+}
+.JSLINT_ dl.level1 {
+    /* yellow */
+    background: #ffffe0;
+    margin-left: 16px;
+}
+.JSLINT_ dl.level2 {
+    /* green */
+    background: #e0ffe0;
+    margin-left: 2em;
+}
+.JSLINT_ dl.level3 {
+    /* blue */
+    background: #D0D0ff;
+    margin-left: 3em;
+}
+.JSLINT_ dl.level4 {
+    /* purple */
+    background: #ffe0ff;
+    margin-left: 4em;
+}
+.JSLINT_ dl.level5 {
+    /* red */
+    background: #ffe0e0;
+    margin-left: 5em;
+}
+.JSLINT_ dl.level6 {
+    /* orange */
+    background: #ffe390;
+    margin-left: 6em;
+}
+.JSLINT_ dl.level7 {
+    /* gray */
+    background: #e0e0e0;
+    margin-left: 7em;
+}
+.JSLINT_ dl.level8 {
+    margin-left: 8em;
+}
+.JSLINT_ dl.level9 {
+    margin-left: 9em;
+}
+.JSLINT_ dt {
+    float: left;
+    font-size: 75%;
+    font-style: italic;
+    text-align: right;
+    width: 8em;
+}
+.JSLINT_ fieldset {
+    background: gainsboro;
+    clear: both;
+    margin: 16px 40px;
+    width: auto;
+}
+.JSLINT_ fieldset > div {
+    padding: 16px;
+    width: 100%;
+}
+.JSLINT_ legend {
+    background: darkslategray;
+    color: white;
+    font-style: normal;
+    font-weight: normal;
+    padding: 0.25em 0;
+    text-align: center;
+    width: 100%;
+}
+.JSLINT_ textarea {
+    padding: 0.5%;
+    resize: none;
+    white-space: pre;
+    width: 100%;
+}
+.JSLINT_ textarea::selection {
+    background: wheat;
+}
+#JSLINT_REPORT_PROPERTIES {
+    background: transparent;
+}
+#JSLINT_REPORT_PROPERTIES textarea {
+    background: honeydew;
+    height: 100px;
+}
+#JSLINT_REPORT_WARNINGS cite {
+    display: block;
+    font-style: normal;
+    margin-top: 16px;
+    overflow-x: hidden;
+}
+#JSLINT_REPORT_WARNINGS cite:nth-child(1) {
+    margin-top: 0;
+}
+#JSLINT_REPORT_WARNINGS samp {
+    background: lavenderblush;
+    display: block;
+    font-style: normal;
+    font-weight: bold;
+    padding: 4px;
+    white-space: pre-wrap;
+}
+#JSLINT_REPORT_WARNINGS > div {
+    background: pink;
+    max-height: 400px;
+    overflow-y: auto;
+}
+#JSLINT_REPORT_WARNINGS > legend {
+    background: indianred;
+}
+</style>
+            `).trim();
+    html += `<fieldset id="JSLINT_REPORT_WARNINGS">`;
+    html += `<legend>Report: Warnings</legend>`;
+    html += `<div>`;
+    if (stop) {
+        html += "<center>JSLint was unable to finish.</center>";
     }
-    data.warnings.forEach(function ({
+    warnings.forEach(function ({
         column,
         line,
         line_source,
         message,
         stack_trace = ""
     }) {
-        output.push(
-            "<cite><address>",
-            entityify(line),
-            ".",
-            entityify(column),
-            "</address>",
-            entityify(message),
-            "</cite><samp>",
-            entityify(line_source + "\n" + stack_trace),
-            "</samp>"
-        );
+        html += `<cite>`;
+        html += `<address>${entityify(line)}.${entityify(column)}</address>`;
+        html += entityify(message);
+        html += `</cite>`;
+        html += `<samp>${entityify(line_source + "\n" + stack_trace)}</samp>`;
     });
-    if (output.length === 0) {
-        output.push("<center>There are no warnings.</center>");
+    if (warnings.length === 0) {
+        html += "<center>There are no warnings.</center>";
     }
-    return output.join("");
-}
+    html += `</div>`;
+    html += `</fieldset>`;
 
-function function_report(data) {
+// Produce the /*property*/ directive.
+
+    html += `<fieldset id="JSLINT_REPORT_PROPERTIES">`;
+    html += `<legend>Report: Properties</legend>`;
+    html += `<textarea rows="4" readonly>`;
+    html += `/\*property`;
+    Object.keys(property).sort().forEach(function (key, ii) {
+        if (ii !== 0) {
+            html += ",";
+            length_80 += 2;
+        }
+        if (length_80 + key.length >= 80) {
+            length_80 = 4;
+            html += "\n   ";
+        }
+        html += " " + key;
+        length_80 += key.length;
+    });
+    html += "\n*/\n";
+    html += `</textarea>`;
+    html += `</fieldset>`;
 
 // Produce the HTML Function Report.
-
 // <dl class=LEVEL><address>LINE_NUMBER</address>FUNCTION_NAME_AND_SIGNATURE
 //     <dt>DETAIL</dt><dd>NAMES</dd>
 // </dl>
 
-    let exports;
-    let froms;
-    let global;
-    let mode = (
-        data.module
-        ? "module"
-        : "global"
-    );
-    let output = [];
-
-    if (data.json) {
+    html += `<fieldset id="JSLINT_REPORT_FUNCTIONS">`;
+    html += `<legend>Report: Functions</legend>`;
+    html += `<div>`;
+    if (json) {
         return (
-            data.warnings.length === 0
+            warnings.length === 0
             ? "<center>JSON: good.</center>"
             : "<center>JSON: bad.</center>"
         );
     }
-
-    function detail(title, array) {
-        if (Array.isArray(array) && array.length > 0) {
-            output.push(
-                "<dt>",
-                entityify(title),
-                "</dt><dd>",
-                array.join(", "),
-                "</dd>"
-            );
-        }
+    if (functions.length === 0) {
+        html += "<center>There are no functions.</center>";
     }
-
-    if (data.functions.length === 0) {
-        output.push("<center>There are no functions.</center>");
-    }
-    global = Object.keys(data.global.context).sort();
-    froms = data.froms.sort();
-    exports = Object.keys(data.exports).sort();
+    exports = Object.keys(exports).sort();
+    froms.sort();
+    global = Object.keys(global.context).sort();
+    module = (
+        module
+        ? "module"
+        : "global"
+    );
     if (global.length + froms.length + exports.length > 0) {
-        output.push("<dl class=level0>");
-        detail(mode, global);
+        html += "<dl class=level0>";
+        detail(module, global);
         detail("import from", froms);
         detail("export", exports);
-        output.push("</dl>");
+        html += "</dl>";
     }
-
-    if (data.functions.length > 0) {
-        data.functions.forEach(function (the_function) {
-            let context = the_function.context;
-            let list = Object.keys(context);
-            let params;
-            output.push(
-                "<dl class=level",
-                entityify(the_function.level),
-                "><address>",
-                entityify(the_function.line),
-                "</address><dfn>",
-                (
-                    the_function.name === "=>"
-                    ? entityify(the_function.signature) + " =>"
-                    : (
-                        typeof the_function.name === "string"
-                        ? (
-                            "<b>\u00ab" + entityify(the_function.name)
-                            + "\u00bb</b>"
-                        )
-                        : "<b>" + entityify(the_function.name.id) + "</b>"
+    functions.forEach(function (the_function) {
+        let {
+            context,
+            level,
+            line,
+            name,
+            parameters,
+            signature
+        } = the_function;
+        let list = Object.keys(context);
+        let params;
+        html += (
+            "<dl class=level"
+            + entityify(level)
+            + "><address>"
+            + entityify(line)
+            + "</address><dfn>"
+            + (
+                name === "=>"
+                ? entityify(signature) + " =>"
+                : (
+                    typeof name === "string"
+                    ? (
+                        "<b>\u00ab" + entityify(name)
+                        + "\u00bb</b>"
                     )
-                ) + entityify(the_function.signature),
-                "</dfn>"
-            );
-            if (Array.isArray(the_function.parameters)) {
-                params = [];
-                the_function.parameters.forEach(function extract(name) {
-                    if (name.id === "{" || name.id === "[") {
-                        name.names.forEach(extract);
-                    } else {
-                        if (name.id !== "ignore") {
-                            params.push(name.id);
-                        }
-                    }
-                });
-                detail(
-                    "parameter",
-                    params.sort()
-                );
+                    : "<b>" + entityify(name.id) + "</b>"
+                )
+            ) + entityify(signature)
+            + "</dfn>"
+        );
+        params = [];
+        parameters.forEach(function extract({
+            id,
+            names
+        }) {
+            switch (id) {
+            case "[":
+            case "{":
+
+// Recurse extract.
+
+                names.forEach(extract);
+                break;
+            case "ignore":
+                break;
+            default:
+                params.push(id);
             }
-            list.sort();
-            detail("variable", list.filter(function (id) {
-                let the_variable = context[id];
-                return (
-                    the_variable.role === "variable"
-                    && the_variable.parent === the_function
-                );
-            }));
-            detail("exception", list.filter(function (id) {
-                return context[id].role === "exception";
-            }));
-            detail("closure", list.filter(function (id) {
-                let the_variable = context[id];
-                return (
-                    the_variable.closure === true
-                    && the_variable.parent === the_function
-                );
-            }));
-            detail("outer", list.filter(function (id) {
-                let the_variable = context[id];
-                return (
-                    the_variable.parent !== the_function
-                    && the_variable.parent.id !== "(global)"
-                );
-            }));
-            detail(mode, list.filter(function (id) {
-                return context[id].parent.id === "(global)";
-            }));
-            detail("label", list.filter(function (id) {
-                return context[id].role === "label";
-            }));
-            output.push("</dl>");
         });
-    }
-    return output.join("");
-}
-
-function property_directive(data) {
-
-// Produce the /*property*/ directive.
-
-    let length = 1111;
-    let not_first = false;
-    let output = ["/*property"];
-    let properties = Object.keys(data.property);
-
-    properties.sort().forEach(function (key) {
-        if (not_first) {
-            output.push(",");
-            length += 2;
-        }
-        not_first = true;
-        if (length + key.length >= 80) {
-            length = 4;
-            output.push("\n   ");
-        }
-        output.push(" ", key);
-        length += key.length;
+        detail("parameter", params.sort());
+        list.sort();
+        detail("variable", list.filter(function (id) {
+            return (
+                context[id].role === "variable"
+                && context[id].parent === the_function
+            );
+        }));
+        detail("exception", list.filter(function (id) {
+            return context[id].role === "exception";
+        }));
+        detail("closure", list.filter(function (id) {
+            return (
+                context[id].closure === true
+                && context[id].parent === the_function
+            );
+        }));
+        detail("outer", list.filter(function (id) {
+            return (
+                context[id].parent !== the_function
+                && context[id].parent.id !== "(global)"
+            );
+        }));
+        detail(module, list.filter(function (id) {
+            return context[id].parent.id === "(global)";
+        }));
+        detail("label", list.filter(function (id) {
+            return context[id].role === "label";
+        }));
+        html += "</dl>";
     });
-    output.push("\n*/\n");
-    return output.join("");
+    html += `</div>`;
+    html += `</fieldset>`;
+    html += `</div>`;
+    return html;
 }
 
-function call_jslint() {
-    let global_string;
-    let option;
-    let result;
+function jslint_with_ui() {
+// This function will run jslint in browser and create html-reports.
 
 // Show ui-loader-animation.
 
     document.getElementById("uiLoader1").style.display = "flex";
 
-// First build the option object.
+// Execute linter.
 
-    option = Object.create(null);
-    option.debug = mode_debug;
-    document.querySelectorAll("input[type=checkbox]").forEach(function (elem) {
-        if (elem.checked) {
-            option[elem.value] = true;
-        }
-    });
-
-// Call JSLint with the source text, the options, and the predefined globals.
-
-    global_string = document.getElementById("JSLINT_GLOBAL").value;
-    result = jslint(
-        editor.getValue(),
-        option,
-        (
-            global_string.trim() === ""
-            ? undefined
-            : global_string.split(
-                /[\s,;'"]+/
-            )
-        )
-    );
-
-// Debug result.
-
-    globalThis.jslint_result = result;
+    editor.performLint();
 
 // Generate the reports.
 // Display the reports.
 
-    document.getElementById(
-        "JSLINT_WARNINGS_LIST"
-    ).innerHTML = error_report(result);
-    document.getElementById(
-        "JSLINT_REPORT_LIST"
-    ).innerHTML = function_report(result);
-    document.getElementById(
-        "JSLINT_PROPERTY"
-    ).value = property_directive(result);
-    document.getElementById("JSLINT_PROPERTY").scrollTop = 0;
+    document.querySelector(
+        "#JSLINT_REPORT_HTML"
+    ).outerHTML = jslint_report_html(jslint_option_dict.result);
 
 // Hide ui-loader-animation.
 
@@ -292,6 +489,7 @@ function call_jslint() {
 }
 
 (function () {
+    let CodeMirror = window.CodeMirror;
 
 // Init edition.
 
@@ -299,49 +497,14 @@ function call_jslint() {
         `Edition: ${jslint.edition}`
     );
 
-// Init event-handling.
-
-    document.addEventListener("keydown", function (evt) {
-        if ((evt.ctrlKey || evt.metaKey) && evt.key === "Enter") {
-            evt.preventDefault();
-            evt.stopPropagation();
-            call_jslint();
-        }
-    });
-    document.querySelector("button[name='JSLint']").onclick = call_jslint;
-    document.querySelector(
-        "button[name='clear_source']"
-    ).onclick = function () {
-        editor.setValue("");
-    };
-    document.querySelector(
-        "button[name='clear_options']"
-    ).onclick = function () {
-        document.querySelectorAll(
-            "input[type=checkbox]"
-        ).forEach(function (elem) {
-            elem.checked = false;
-        });
-        document.getElementById("JSLINT_GLOBAL").value = "";
-    };
-    document.querySelector(
-        "#JSLINT_OPTIONS"
-    ).onclick = function (evt) {
-        let elem;
-        elem = evt.target.closest(
-            "#JSLINT_OPTIONS div[title]"
-        );
-        elem = elem && elem.querySelector("input[type=checkbox]");
-        if (elem && elem !== evt.target) {
-            evt.preventDefault();
-            evt.stopPropagation();
-            elem.checked = !elem.checked;
-        }
-    };
+// Init mode_debug.
+    mode_debug = (
+        /\bdebug=1\b/
+    ).test(location.search);
 
 // Init CodeMirror editor.
 
-    editor = globalThis.CodeMirror.fromTextArea(document.getElementById(
+    editor = CodeMirror.fromTextArea(document.getElementById(
         "JSLINT_SOURCE"
     ), {
         extraKeys: {
@@ -349,21 +512,98 @@ function call_jslint() {
                 editor.replaceSelection("    ");
             }
         },
+        gutters: ["CodeMirror-lint-markers"],
         indentUnit: 4,
         indentWithTabs: false,
         lineNumbers: true,
         lineWrapping: true,
+        lint: jslint_option_dict,
         matchBrackets: true,
         mode: "text/javascript",
         showTrailingSpace: true
     });
-    mode_debug = (
-        /\bdebug=1\b/
-    ).test(location.search);
-    if (mode_debug) {
-        return;
-    }
-    editor.setValue(`#!/usr/bin/env node
+    window.editor = editor;
+
+// Init CodeMirror linter.
+
+    jslint_plugin_codemirror(CodeMirror);
+
+// Init event-handling.
+
+    document.addEventListener("keydown", function (evt) {
+        switch ((evt.ctrlKey || evt.metaKey) && evt.key) {
+        case "Enter":
+        case "e":
+            evt.preventDefault();
+            evt.stopPropagation();
+            jslint_with_ui();
+            break;
+        }
+    });
+    document.querySelector(
+        "#JSLINT_BUTTONS"
+    ).onclick = function ({
+        target
+    }) {
+        switch (target.name) {
+        case "JSLint":
+            jslint_with_ui();
+            break;
+        case "clear_options":
+            document.querySelectorAll(
+                "#JSLINT_OPTIONS input[type=checkbox]"
+            ).forEach(function (elem) {
+                elem.checked = false;
+            });
+            document.querySelector("#JSLINT_GLOBALS").value = "";
+            document.querySelector("#JSLINT_OPTIONS").click();
+            document.querySelector("#JSLINT_GLOBALS").dispatchEvent(
+                new Event("keyup")
+            );
+            break;
+        case "clear_source":
+            editor.setValue("");
+            break;
+        }
+    };
+    document.querySelector(
+        "#JSLINT_GLOBALS"
+    ).onkeyup = function ({
+        currentTarget
+    }) {
+        jslint_option_dict.globals = currentTarget.value.trim().split(
+            /[\s,;'"]+/
+        );
+    };
+    document.querySelector(
+        "#JSLINT_OPTIONS"
+    ).onclick = function ({
+        target
+    }) {
+        let elem;
+        elem = target.closest(
+            "#JSLINT_OPTIONS div[title]"
+        );
+        elem = elem && elem.querySelector("input[type=checkbox]");
+        if (elem && elem !== target) {
+            elem.checked = !elem.checked;
+        }
+        document.querySelectorAll(
+            "#JSLINT_OPTIONS input[type=checkbox]"
+        ).forEach(function (elem) {
+            jslint_option_dict[elem.value] = elem.checked;
+        });
+    };
+    window.addEventListener("resize", function () {
+        editor.setSize(document.querySelector(
+            "#JSLINT_OPTIONS"
+        ).offsetWidth);
+    });
+    window.addEventListener("load", function () {
+        window.dispatchEvent(new Event("resize"));
+    });
+    if (!mode_debug) {
+        editor.setValue(`#!/usr/bin/env node
 
 /*jslint browser, node*/
 /*global $, jQuery*/ //jslint-quiet
@@ -426,5 +666,6 @@ eval( //jslint-quiet
     });
 }());
 `);
+    }
     document.querySelector("button[name='JSLint']").click();
 }());

--- a/browser.mjs
+++ b/browser.mjs
@@ -13,11 +13,12 @@
     editor,
     from,
     globals, gutters,
+    innerHTML,
     lint, lintOnChange,
     map, mode_stop,
     offsetWidth, onchange, onkeyup,
     performLint, preventDefault,
-    registerHelper, result,
+    registerHelper, result, reverse,
     search, setSize, severity, stopPropagation,
     target, test, to, trim,
     width,
@@ -278,94 +279,30 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
 /*csslint ignore:end*/
 
 .JSLINT_ {
-    font-family: sans-serif;
+    font-family: daley, sans-serif;
     font-size: 14px;
 }
-.JSLINT_ address,
-.JSLINT_ cite,
-.JSLINT_ dt,
-.JSLINT_ textarea {
-    font-size: 12px;
-}
-.JSLINT_ legend,
+.JSLINT_ fieldset legend,
 .JSLINT_ .center {
     font-family: daley, sans-serif;
     font-size: 14px;
     text-align: center;
 }
-.JSLINT_ textarea,
-#JSLINT_REPORT_FUNCTIONS > div {
+.JSLINT_ fieldset textarea,
+.JSLINT_ #JSLINT_REPORT_FUNCTIONS dt,
+.JSLINT_ #JSLINT_REPORT_WARNINGS samp {
+    font-size: 12px;
+}
+.JSLINT_ fieldset textarea,
+.JSLINT_ #JSLINT_REPORT_FUNCTIONS > div {
     font-family: monospace;
+}
+.JSLINT_ fieldset > div {
+    font-family: sans-serif;
 }
 
 body {
     background: antiquewhite;
-}
-.JSLINT_ address {
-    float: right;
-}
-.JSLINT_ dd {
-    padding-left: 128px;
-}
-.JSLINT_ dfn {
-    display: block;
-    font-style: normal;
-    padding-bottom: 4px;
-}
-.JSLINT_ dl {
-    background: cornsilk;
-    padding: 8px 16px 4px 16px;
-}
-.JSLINT_ dl.level0 {
-    background: white;
-}
-.JSLINT_ dl.level1 {
-    /* yellow */
-    background: #ffffe0;
-    margin-left: 16px;
-}
-.JSLINT_ dl.level2 {
-    /* green */
-    background: #e0ffe0;
-    margin-left: 32px;
-}
-.JSLINT_ dl.level3 {
-    /* blue */
-    background: #D0D0ff;
-    margin-left: 48px;
-}
-.JSLINT_ dl.level4 {
-    /* purple */
-    background: #ffe0ff;
-    margin-left: 64px;
-}
-.JSLINT_ dl.level5 {
-    /* red */
-    background: #ffe0e0;
-    margin-left: 80px;
-}
-.JSLINT_ dl.level6 {
-    /* orange */
-    background: #ffe390;
-    margin-left: 96px;
-}
-.JSLINT_ dl.level7 {
-    /* gray */
-    background: #e0e0e0;
-    margin-left: 112px;
-}
-.JSLINT_ dl.level8 {
-    margin-left: 128px;
-}
-.JSLINT_ dl.level9 {
-    margin-left: 144px;
-}
-.JSLINT_ dt {
-    float: left;
-    font-style: italic;
-    padding-top: 2px;
-    text-align: right;
-    width: 100px;
 }
 .JSLINT_ fieldset {
     background: gainsboro;
@@ -373,53 +310,120 @@ body {
     margin: 16px 40px;
     width: auto;
 }
-.JSLINT_ fieldset > div {
-    padding: 16px;
-    width: 100%;
-    word-wrap: break-word;
+.JSLINT_ fieldset address {
+    float: right;
 }
-.JSLINT_ legend {
+.JSLINT_ fieldset legend {
     background: darkslategray;
     color: white;
     padding: 4px 0;
     width: 100%;
 }
-.JSLINT_ textarea {
+.JSLINT_ fieldset textarea {
     padding: 4px;
     resize: none;
     white-space: pre;
     width: 100%;
 }
-.JSLINT_ textarea::selection {
+.JSLINT_ fieldset textarea::selection {
     background: wheat;
 }
-#JSLINT_REPORT_PROPERTIES {
+.JSLINT_ fieldset > div {
+    padding: 16px;
+    width: 100%;
+    word-wrap: break-word;
+}
+.JSLINT_ #JSLINT_REPORT_FUNCTIONS dd {
+    padding-left: 128px;
+}
+.JSLINT_ #JSLINT_REPORT_FUNCTIONS dfn {
+    display: block;
+    font-style: normal;
+    padding-bottom: 4px;
+}
+.JSLINT_ #JSLINT_REPORT_FUNCTIONS dl {
+    background: cornsilk;
+    padding: 8px 16px 4px 16px;
+}
+.JSLINT_ #JSLINT_REPORT_FUNCTIONS dl.level0 {
+    background: white;
+}
+.JSLINT_ #JSLINT_REPORT_FUNCTIONS dl.level1 {
+    /* yellow */
+    background: #ffffe0;
+    margin-left: 16px;
+}
+.JSLINT_ #JSLINT_REPORT_FUNCTIONS dl.level2 {
+    /* green */
+    background: #e0ffe0;
+    margin-left: 32px;
+}
+.JSLINT_ #JSLINT_REPORT_FUNCTIONS dl.level3 {
+    /* blue */
+    background: #D0D0ff;
+    margin-left: 48px;
+}
+.JSLINT_ #JSLINT_REPORT_FUNCTIONS dl.level4 {
+    /* purple */
+    background: #ffe0ff;
+    margin-left: 64px;
+}
+.JSLINT_ #JSLINT_REPORT_FUNCTIONS dl.level5 {
+    /* red */
+    background: #ffe0e0;
+    margin-left: 80px;
+}
+.JSLINT_ #JSLINT_REPORT_FUNCTIONS dl.level6 {
+    /* orange */
+    background: #ffe390;
+    margin-left: 96px;
+}
+.JSLINT_ #JSLINT_REPORT_FUNCTIONS dl.level7 {
+    /* gray */
+    background: #e0e0e0;
+    margin-left: 112px;
+}
+.JSLINT_ #JSLINT_REPORT_FUNCTIONS dl.level8 {
+    margin-left: 128px;
+}
+.JSLINT_ #JSLINT_REPORT_FUNCTIONS dl.level9 {
+    margin-left: 144px;
+}
+.JSLINT_ #JSLINT_REPORT_FUNCTIONS dt {
+    float: left;
+    font-style: italic;
+    padding-top: 2px;
+    text-align: right;
+    width: 100px;
+}
+.JSLINT_ #JSLINT_REPORT_PROPERTIES {
     background: transparent;
 }
-#JSLINT_REPORT_PROPERTIES textarea {
+.JSLINT_ #JSLINT_REPORT_PROPERTIES textarea {
     background: honeydew;
     height: 100px;
 }
-#JSLINT_REPORT_WARNINGS cite {
+.JSLINT_ #JSLINT_REPORT_WARNINGS cite {
     display: block;
     margin: 16px 0 4px 0;
     overflow-x: hidden;
+    white-space: pre-line;
 }
-#JSLINT_REPORT_WARNINGS cite:nth-child(1) {
+.JSLINT_ #JSLINT_REPORT_WARNINGS cite:nth-child(1) {
     margin-top: 0;
 }
-#JSLINT_REPORT_WARNINGS samp {
+.JSLINT_ #JSLINT_REPORT_WARNINGS samp {
     background: lavenderblush;
     display: block;
     padding: 4px;
     white-space: pre-wrap;
 }
-#JSLINT_REPORT_WARNINGS > div {
+.JSLINT_ #JSLINT_REPORT_WARNINGS > div {
     background: pink;
     max-height: 400px;
     overflow-y: auto;
 }
-#JSLINT_REPORT_WARNINGS > legend {
+.JSLINT_ #JSLINT_REPORT_WARNINGS > legend {
     background: indianred;
 }
 </style>
@@ -437,11 +441,13 @@ body {
         message,
         stack_trace = ""
     }, ii) {
-        html += `<cite>`;
-        html += `<address>${entityify(line)}.${entityify(column)}</address>`;
-        html += entityify(`${ii + 1}. ${message}`);
-        html += `</cite>`;
-        html += `<samp>${entityify(line_source + "\n" + stack_trace)}</samp>`;
+        html += (
+            "<cite>"
+            + "<address>" + entityify(line + ": " + column) + "</address>"
+            + entityify((ii + 1) + ". " + message)
+            + "</cite>"
+            + "<samp>" + entityify(line_source + "\n" + stack_trace) + "</samp>"
+        );
     });
     if (warnings.length === 0) {
         html += `<div class="center">There are no warnings.</div>`;
@@ -516,11 +522,9 @@ body {
         let list = Object.keys(context);
         let params;
         html += (
-            "<dl class=level"
-            + entityify(level)
-            + "><address>"
-            + entityify(line)
-            + "</address><dfn>"
+            "<dl class=level" + entityify(level) + ">"
+            + "<address>" + entityify(line) + "</address>"
+            + "<dfn>"
             + (
                 name === "=>"
                 ? entityify(signature) + " =>"
@@ -613,12 +617,18 @@ body {
     return html;
 }
 
-function jslint_ui_call() {
+async function jslint_ui_call() {
 // This function will run jslint in browser and create html-reports.
 
 // Show ui-loader-animation.
 
-    document.getElementById("uiLoader1").style.display = "flex";
+    document.querySelector("#uiLoader1").style.display = "flex";
+
+// Wait awhile before running cpu-intensive linter so ui-loader doesn't jank.
+
+    await new Promise(function (resolve) {
+        setTimeout(resolve);
+    });
 
 // Execute linter.
 
@@ -635,22 +645,54 @@ function jslint_ui_call() {
 // Hide ui-loader-animation.
 
     setTimeout(function () {
-        document.getElementById("uiLoader1").style.display = "none";
+        document.querySelector("#uiLoader1").style.display = "none";
     }, 500);
 }
 
 function jslint_ui_onresize() {
-    let width = document.querySelector(
+    let content_width = document.querySelector(
         "#JSLINT_OPTIONS"
     ).offsetWidth;
+    let style_list = [];
+
+// Set explicit content-width for overflow to work properly.
+
     document.querySelectorAll(
         ".JSLINT_ fieldset > div"
     ).forEach(function (elem) {
         if (!elem.closest("#JSLINT_OPTIONS")) {
-            elem.style.width = width + "px";
+            elem.style.width = content_width + "px";
         }
     });
-    editor.setSize(width);
+    editor.setSize(content_width);
+
+// Debug css-style.
+
+    Array.from(document.querySelectorAll("style")).forEach(function (elem) {
+        elem.innerHTML.replace((
+            /\/\*[\S\s]*?\*\/|;|\}/g
+        ), "\n").replace((
+            /^([^\n\u0020@].*?)[,{:].*?$/gm
+        ), function (match0, match1) {
+            let ii;
+            try {
+                ii = document.querySelectorAll(match1).length;
+            } catch (err) {
+                console.error(match1 + "\n" + err); //jslint-quiet
+            }
+            if (ii <= 1 && !(
+                /^0\u0020(?:(body\u0020>\u0020)?(?:\.button|\.readonly|\.styleColorError|\.textarea|\.uiAnimateSlide|a|base64|body|code|div|input|pre|textarea)(?:,|\u0020\{))|^[1-9]\d*?\u0020#/m
+            ).test(ii + " " + match0)) {
+                style_list.push(ii + " " + match0);
+            }
+            return "";
+        });
+    });
+    style_list.sort().reverse().forEach(function (elem, ii, list) {
+        console.error( //jslint-quiet
+            "domStyleReportUnmatched " + (list.length - ii) + ". " + elem
+        );
+    });
 }
 
 (function () {
@@ -658,7 +700,7 @@ function jslint_ui_onresize() {
 
 // Init edition.
 
-    document.getElementById("JSLINT_EDITION").textContent = (
+    document.querySelector("#JSLINT_EDITION").textContent = (
         `Edition: ${jslint.edition}`
     );
 
@@ -669,8 +711,8 @@ function jslint_ui_onresize() {
 
 // Init CodeMirror editor.
 
-    editor = CodeMirror.fromTextArea(document.getElementById(
-        "JSLINT_SOURCE"
+    editor = CodeMirror.fromTextArea(document.querySelector(
+        "#JSLINT_SOURCE textarea"
     ), {
         extraKeys: {
             Tab: function (editor) {

--- a/ci.sh
+++ b/ci.sh
@@ -38,7 +38,6 @@ import moduleUrl from "url";
     };
 }());
 (function () {
-    "use strict";
     var file;
     var timeStart;
     var url;
@@ -131,7 +130,6 @@ process.exit(Number(
 import moduleFs from "fs";
 import moduleChildProcess from "child_process";
 (async function () {
-    "use strict";
     [
         // parallel-task - screenshot files
         [
@@ -228,11 +226,22 @@ var cacheKey = Math.random().toString(36).slice(-4);
 // Inline css-assets.
 
     result.replace((
-        /<link\u0020rel="stylesheet"\u0020href="([^"]+?)">/g
+        /\n<link\u0020rel="stylesheet"\u0020href="([^"]+?)">\n/g
     ), async function (match0, url) {
         var data = await moduleFs.promises.readFile(url.split("?")[0], "utf8");
         result = result.replace(match0, function () {
-            return `<style>\n${data.trim()}\n</style>`;
+            return `\n<style>\n${data.trim()}\n</style>\n`;
+        });
+        return "";
+    });
+    result.replace((
+        `\n<style id="#JSLINT_REPORT_STYLE"></style>\n`
+    ), async function (match0) {
+        var data = await moduleFs.promises.readFile("browser.mjs", "utf8");
+        result = result.replace(match0, function () {
+            return data.match(
+                /\n<style\sid="#JSLINT_REPORT_STYLE">\n[\S\s]*?\n<\/style>\n/
+            )[0];
         });
         return "";
     });
@@ -332,7 +341,9 @@ shCiBase() {(set -e
     node --input-type=module -e '
 import moduleFs from "fs";
 (async function () {
-    "use strict";
+
+// Update edition in README.md, jslint.mjs from CHANGELOG.md
+
     var dict;
     var versionBeta;
     var versionMaster;
@@ -402,7 +413,6 @@ import moduleFs from "fs";
 import moduleHttps from "https";
 import moduleUrl from "url";
 (async function () {
-    "use strict";
     var dict = {};
     Array.from(
         await moduleFs.promises.readdir(".")
@@ -524,7 +534,6 @@ shGitLsTree() {(set -e
     node --input-type=module -e '
 import moduleChildProcess from "child_process";
 (async function () {
-    "use strict";
     var result;
     // get file, mode, size
     result = await new Promise(function (resolve) {
@@ -648,7 +657,6 @@ import moduleUrl from "url";
 /*
  * this function will jslint current-directory
  */
-    "use strict";
     moduleFs.stat((
         process.env.HOME + "/jslint.mjs"
     ), function (ignore, exists) {
@@ -667,7 +675,6 @@ import moduleUrl from "url";
 /*
  * this function will start http-file-server
  */
-    "use strict";
     var contentTypeDict = {
         ".bmp": "image/bmp",
         ".cjs": "application/javascript; charset=utf-8",
@@ -756,7 +763,6 @@ import moduleUrl from "url";
 /*
  * this function will start repl-debugger
  */
-    "use strict";
     var that;
     // start repl
     that = moduleRepl.start({
@@ -855,7 +861,6 @@ import moduleUrl from "url";
 /*
  * this function will watch current-directory for changes
  */
-    "use strict";
     moduleFs.readdir(".", function (ignore, fileList) {
         fileList.forEach(function (file) {
             if (file[0] === ".") {
@@ -968,7 +973,6 @@ shJsonNormalize() {(set -e
     node --input-type=module -e '
 import moduleFs from "fs";
 (async function () {
-    "use strict";
     function objectDeepCopyWithKeysSorted(obj) {
 
 // this function will recursively deep-copy <obj> with keys sorted
@@ -1043,7 +1047,6 @@ import modulePath from "path";
     };
 }());
 (async function () {
-    "use strict";
     var fetchList;
     var matchObj;
     var replaceList;
@@ -1325,7 +1328,6 @@ import modulePath from "path";
     };
 }());
 (async function () {
-    "use strict";
     var DIR_COVERAGE = process.env.DIR_COVERAGE;
     var cwd;
     var data;
@@ -1887,7 +1889,6 @@ shRunWithScreenshotTxt() {(set -e
     node --input-type=module -e '
 import moduleFs from "fs";
 (async function () {
-    "use strict";
     var result = await moduleFs.promises.readFile(
         process.argv[1] + ".txt",
         "utf8"

--- a/index.html
+++ b/index.html
@@ -185,7 +185,7 @@ style="
 ">
     <a
         href="https://github.com/jslint-org/jslint"
-        style="color: white; font-family: daley"
+        style="color: white; font-family: daley, sans-serif"
     >
     fork on github
     </a>
@@ -196,6 +196,7 @@ style="
     background: lightslategray;
     color: white;
     display: none;
+    font-family: daley, sans-serif;
     height: 50px;
     justify-content: center;
     left: 50%;

--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@
 <link rel="modulepreload" href="browser.mjs">
 <link rel="modulepreload" href="jslint.mjs">
 <link rel="stylesheet" href="asset-codemirror-rollup.css">
-<style id="#JSLINT_REPORT_STYLE"></style>
 <style>
 /*csslint
     box-model: false,
@@ -57,41 +56,25 @@
 /*csslint ignore:end*/
 
 /* Google PageSpeed - Reduce Cumulative Layout Shift. */
-#JSLINT_SOURCE {
+.JSLINT_ #JSLINT_SOURCE textarea {
     height: 298px;
 }
 
-.JSLINT_ button,
-#JSLINT_OPTIONS,
-#JSLINT_TITLEBOX {
+.JSLINT_ #JSLINT_BUTTONS button,
+.JSLINT_ #JSLINT_OPTIONS > div,
+.JSLINT_ #JSLINT_TITLEBOX {
     font-family: daley, sans-serif;
     font-size: 14px;
 }
-.JSLINT_ label {
+.JSLINT_ #JSLINT_OPTIONS label {
     font-family: sans-serif;
 }
-.JSLINT_ .CodeMirror,
-.JSLINT_ .CodeMirror pre {
+.JSLINT_ #JSLINT_SOURCE .CodeMirror,
+.JSLINT_ #JSLINT_SOURCE .CodeMirror pre {
     font-family: monospace;
     font-size: 12px;
 }
 
-.JSLINT_ a:link {
-    color: black;
-}
-.JSLINT_ a:visited {
-    color: #69565c;
-}
-.JSLINT_ button {
-    background: darkslategray;
-    color: white;
-    cursor: pointer;
-    margin: 16px 16px 0 16px;
-    padding: 4px 16px;
-}
-.JSLINT_ label {
-    padding-left: 4px;
-}
 .JSLINT_ .CodeMirror {
     padding: 0;
 }
@@ -110,51 +93,68 @@
 .JSLINT_ .uiLoaderEllipsis span:first-child + span + span {
     animation-name: uiLoaderEllipsis3;
 }
-#JSLINT_GLOBALS {
+.JSLINT_ #JSLINT_BUTTONS button {
+    background: darkslategray;
+    color: white;
+    cursor: pointer;
+    margin: 16px 16px 0 16px;
+    padding: 4px 16px;
+}
+.JSLINT_ #JSLINT_GLOBALS {
     height: 40px;
     white-space: normal;
 }
-#JSLINT_INPUT > div {
+.JSLINT_ #JSLINT_INPUT > div {
     margin: 16px 40px;
     width: auto;
 }
-#JSLINT_INPUT > #JSLINT_BUTTONS {
+.JSLINT_ #JSLINT_INPUT > #JSLINT_BUTTONS {
     margin-top: -16px;
 }
-#JSLINT_OPTIONS div[title],
-#JSLINT_OPTIONS div[title] input,
-#JSLINT_OPTIONS div[title] label {
+.JSLINT_ #JSLINT_OPTIONS div[title],
+.JSLINT_ #JSLINT_OPTIONS div[title] input,
+.JSLINT_ #JSLINT_OPTIONS div[title] label {
     cursor: pointer;
     user-select: none;
 }
-#JSLINT_OPTIONS div[title] {
+.JSLINT_ #JSLINT_OPTIONS div[title] {
     padding: 0 4px;
 }
-#JSLINT_OPTIONS div[title] input {
+.JSLINT_ #JSLINT_OPTIONS div[title] input {
     vertical-align: middle;
 }
-#JSLINT_OPTIONS > div > div {
+.JSLINT_ #JSLINT_OPTIONS label {
+    padding-left: 4px;
+}
+.JSLINT_ #JSLINT_OPTIONS > div > div {
     float: left;
     line-height: 20px;
     padding: 0 16px 16px 0;
 }
-#JSLINT_TITLEBOX {
+.JSLINT_ #JSLINT_TITLEBOX {
     color: darkslategray;
 }
-#JSLINT_TITLEBOX li {
+.JSLINT_ #JSLINT_TITLEBOX ul li {
     line-height: 20px;
 }
+.JSLINT_ #JSLINT_TITLEBOX ul li a:link {
+    color: black;
+}
+.JSLINT_ #JSLINT_TITLEBOX ul li a:visited {
+    color: #69565c;
+}
 
-.JSLINT_ button:hover,
-#JSLINT_OPTIONS div[title]:hover {
+.JSLINT_ #JSLINT_BUTTONS button:hover,
+.JSLINT_ #JSLINT_OPTIONS div[title]:hover {
     background: slategray;
     color: white;
 }
 
-.JSLINT_ button:active {
+.JSLINT_ #JSLINT_BUTTONS button:active {
     color: black;
 }
 </style>
+<style id="#JSLINT_REPORT_STYLE"></style>
 </head>
 <body class="JSLINT_">
 <div id="bannerFork1"
@@ -185,7 +185,7 @@ style="
 ">
     <a
         href="https://github.com/jslint-org/jslint"
-        style="color: white; font-family: daley, sans-serif"
+        style="color: white;"
     >
     fork on github
     </a>
@@ -196,7 +196,6 @@ style="
     background: lightslategray;
     color: white;
     display: none;
-    font-family: daley, sans-serif;
     height: 50px;
     justify-content: center;
     left: 50%;
@@ -228,9 +227,9 @@ style="
     <li><a href="https://github.com/jslint-org/jslint/issues">Report a bug.</a></li>
     </ul>
 </div>
-<fieldset>
+<fieldset id="JSLINT_SOURCE">
     <legend>Source</legend>
-    <textarea id="JSLINT_SOURCE"></textarea>
+    <textarea></textarea>
 </fieldset>
 <div class="center" id="JSLINT_BUTTONS">
     <button class="center" name="JSLint" title="Ctrl + Enter">JSLint</button>
@@ -311,7 +310,7 @@ style="
         id="JSLINT_GLOBALS"
         placeholder="imported globals (e.g. $, jQuery)"
         spellcheck="false"
-        title="global"
+        title="globals"
     ></textarea>
     </div>
 </fieldset>

--- a/index.html
+++ b/index.html
@@ -11,9 +11,7 @@
 <meta name="author" content="Douglas Crockford"/>
 <link rel="icon" type="image/png" href="asset-image-jslint-512.svg"/>
 <title>JSLint:&nbsp;The&nbsp;JavaScript&nbsp;Code Quality Tool</title>
-
 <!-- Google PageSpeed - Reduce Largest Contentful Paint. -->
-
 <link as="script" rel="preload" href="asset-codemirror-rollup.js">
 <link rel="modulepreload" href="browser.mjs">
 <link rel="modulepreload" href="jslint.mjs">
@@ -59,20 +57,23 @@
 /*csslint ignore:end*/
 
 /* Google PageSpeed - Reduce Cumulative Layout Shift. */
-
 #JSLINT_SOURCE {
     height: 298px;
 }
 
-.JSLINT_ button {
+.JSLINT_ button,
+#JSLINT_OPTIONS,
+#JSLINT_TITLEBOX {
     font-family: daley, sans-serif;
     font-size: 14px;
 }
 .JSLINT_ label {
     font-family: sans-serif;
 }
-.JSLINT_ .CodeMirror {
+.JSLINT_ .CodeMirror,
+.JSLINT_ .CodeMirror pre {
     font-family: monospace;
+    font-size: 12px;
 }
 
 .JSLINT_ a:link {
@@ -87,7 +88,6 @@
     cursor: pointer;
     margin: 16px 16px 0 16px;
     padding: 4px 16px;
-    text-align: center;
 }
 .JSLINT_ label {
     padding-left: 4px;
@@ -120,7 +120,6 @@
 }
 #JSLINT_INPUT > #JSLINT_BUTTONS {
     margin-top: -16px;
-    text-align: center;
 }
 #JSLINT_OPTIONS div[title],
 #JSLINT_OPTIONS div[title] input,
@@ -184,7 +183,10 @@ style="
     transform: rotate(-45deg);
     width: 100%;
 ">
-    <a href="https://github.com/jslint-org/jslint" style="color: white;">
+    <a
+        href="https://github.com/jslint-org/jslint"
+        style="color: white; font-family: daley"
+    >
     fork on github
     </a>
     </div>
@@ -229,10 +231,10 @@ style="
     <legend>Source</legend>
     <textarea id="JSLINT_SOURCE"></textarea>
 </fieldset>
-<div id="JSLINT_BUTTONS">
-    <button name="JSLint" title="Ctrl + Enter">JSLint</button>
-    <button name="clear_source">Clear Source</button>
-    <button name="clear_options">Clear Options</button>
+<div class="center" id="JSLINT_BUTTONS">
+    <button class="center" name="JSLint" title="Ctrl + Enter">JSLint</button>
+    <button class="center" name="clear_source">Clear Source</button>
+    <button class="center" name="clear_options">Clear Options</button>
 </div>
 <fieldset id="JSLINT_OPTIONS">
     <legend>Options</legend>

--- a/index.html
+++ b/index.html
@@ -61,23 +61,45 @@
 /* Google PageSpeed - Reduce Cumulative Layout Shift. */
 
 #JSLINT_SOURCE {
-    height: 297px;
-    overflow-y: scroll;
+    height: 298px;
 }
 
-
-body,
 .JSLINT_ button {
     font-family: daley, sans-serif;
-    font-size: 100%;
+    font-size: 14px;
 }
 .JSLINT_ label {
     font-family: sans-serif;
 }
-.JSLINT_ .CodeMirror pre.CodeMirror-line,
-.JSLINT_ .CodeMirror pre.CodeMirror-line-like {
+.JSLINT_ .CodeMirror {
     font-family: monospace;
-    font-size: 12px;
+}
+
+.JSLINT_ a:link {
+    color: black;
+}
+.JSLINT_ a:visited {
+    color: #69565c;
+}
+.JSLINT_ button {
+    background: darkslategray;
+    color: white;
+    cursor: pointer;
+    margin: 16px 16px 0 16px;
+    padding: 4px 16px;
+    text-align: center;
+}
+.JSLINT_ label {
+    padding-left: 4px;
+}
+.JSLINT_ .CodeMirror {
+    padding: 0;
+}
+.JSLINT_ .CodeMirror-lint-marker {
+    background-position: 1px -1px;
+}
+.JSLINT_ .CodeMirror-selected {
+    background: wheat;
 }
 .JSLINT_ .uiLoaderEllipsis span {
     animation: uiLoaderEllipsis1 1s infinite steps(1);
@@ -88,47 +110,17 @@ body,
 .JSLINT_ .uiLoaderEllipsis span:first-child + span + span {
     animation-name: uiLoaderEllipsis3;
 }
-
-
-a:link {
-    color: black;
-}
-a:visited {
-    color: #69565c;
-}
-.JSLINT_ button {
-    background: darkslategray;
-    color: white;
-    cursor: pointer;
-    font-style: normal;
-    margin: 0 16px;
-    padding: 4px 16px;
-    text-align: center;
-}
-.JSLINT_ label {
-    font-size: 90%;
-    padding-left: 0.25em;
-}
-.JSLINT_ .CodeMirror-selected {
-    background: wheat;
-}
-.JSLINT_ .CodeMirror {
-    padding: 0;
-}
-.JSLINT_ .CodeMirror-lint-marker {
-    background-position: 1px -1px;
-}
-#JSLINT_BUTTONS {
-    text-align: center;
-}
 #JSLINT_GLOBALS {
     height: 40px;
     white-space: normal;
 }
 #JSLINT_INPUT > div {
-    clear: both;
     margin: 16px 40px;
     width: auto;
+}
+#JSLINT_INPUT > #JSLINT_BUTTONS {
+    margin-top: -16px;
+    text-align: center;
 }
 #JSLINT_OPTIONS div[title],
 #JSLINT_OPTIONS div[title] input,
@@ -145,7 +137,7 @@ a:visited {
 #JSLINT_OPTIONS > div > div {
     float: left;
     line-height: 20px;
-    margin: 0 16px 16px 0;
+    padding: 0 16px 16px 0;
 }
 #JSLINT_TITLEBOX {
     color: darkslategray;
@@ -227,7 +219,7 @@ style="
     <div style="font-size: 50px;">JSLint</div>
     <div id="JSLINT_EDITION" style="font-size: 14px;">&nbsp;</div>
     </div>
-    <ul style="float: right;">
+    <ul style="float: right; font-size: 16px;">
     <li><a href="help.html">Read the instructions.</a></li>
     <li><a href="https://www.amazon.com/dp/1949815005/wrrrldwideweb"><i>How JavaScript Works</i> by Douglas Crockford.</a></li>
     <li><a href="https://github.com/jslint-org/jslint/issues">Report a bug.</a></li>

--- a/index.html
+++ b/index.html
@@ -14,10 +14,11 @@
 
 <!-- Google PageSpeed - Reduce Largest Contentful Paint. -->
 
-<link as="script" rel="preload" href="asset-codemirror-v5.58.3-rollup.js">
+<link as="script" rel="preload" href="asset-codemirror-rollup.js">
 <link rel="modulepreload" href="browser.mjs">
 <link rel="modulepreload" href="jslint.mjs">
-<link rel="stylesheet" href="asset-codemirror-v5.58.3-rollup.css">
+<link rel="stylesheet" href="asset-codemirror-rollup.css">
+<style id="#JSLINT_REPORT_STYLE"></style>
 <style>
 /*csslint
     box-model: false,
@@ -25,18 +26,6 @@
     overqualified-elements: false
 */
 /*csslint ignore:start*/
-@font-face {
-    font-display: swap;
-    font-family: "Programma";
-    font-weight: bold;
-    src: url("asset-font-programma-bold.woff2") format("woff2");
-}
-@font-face {
-    font-display: swap;
-    font-family: "Daley";
-    font-weight: bold;
-    src: url("asset-font-daley-bold.woff2") format("woff2");
-}
 @keyframes uiLoaderEllipsis1 {
     from {
         opacity: 0;
@@ -61,47 +50,43 @@
         opacity: 1;
     }
 }
-*,
-*:after,
-*:before {
-    border: 0;
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
+.JSLINT_ .CodeMirror .cm-trailingspace,
+.JSLINT_ .CodeMirror-lint-mark-warning {
+    background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAADCAYAAAC09K7GAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9sJDw4cOCW1/KIAAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAAHElEQVQI12NggIL/DAz/GdA5/xkY/qPKMDAwAADLZwf5rvm+LQAAAABJRU5ErkJggg==");
+    background-position: bottom left;
+    background-repeat: repeat-x;
 }
 /*csslint ignore:end*/
+
+/* Google PageSpeed - Reduce Cumulative Layout Shift. */
+
+#JSLINT_SOURCE {
+    height: 297px;
+    overflow-y: scroll;
+}
+
+
 body,
-#JSLINT_ button {
+.JSLINT_ button {
     font-family: daley, sans-serif;
     font-size: 100%;
 }
-.uiLoaderEllipsis span {
-    animation: uiLoaderEllipsis1 1s infinite steps(1);
-}
-.uiLoaderEllipsis span:first-child + span {
-    animation-name: uiLoaderEllipsis2;
-}
-.uiLoaderEllipsis span:first-child + span + span {
-    animation-name: uiLoaderEllipsis3;
-}
-#JSLINT_ address,
-#JSLINT_ dt,
-#JSLINT_WARNINGS cite {
-    font-family: serif;
-}
-#JSLINT_ dd,
-#JSLINT_ dfn,
-#JSLINT_WARNINGS samp {
-    font-family: programma, monospace;
-}
-#JSLINT_ label {
+.JSLINT_ label {
     font-family: sans-serif;
 }
-#JSLINT_ textarea,
-#JSLINT_ .CodeMirror pre.CodeMirror-line,
-#JSLINT_ .CodeMirror pre.CodeMirror-line-like {
+.JSLINT_ .CodeMirror pre.CodeMirror-line,
+.JSLINT_ .CodeMirror pre.CodeMirror-line-like {
     font-family: monospace;
     font-size: 12px;
+}
+.JSLINT_ .uiLoaderEllipsis span {
+    animation: uiLoaderEllipsis1 1s infinite steps(1);
+}
+.JSLINT_ .uiLoaderEllipsis span:first-child + span {
+    animation-name: uiLoaderEllipsis2;
+}
+.JSLINT_ .uiLoaderEllipsis span:first-child + span + span {
+    animation-name: uiLoaderEllipsis3;
 }
 
 
@@ -111,15 +96,7 @@ a:link {
 a:visited {
     color: #69565c;
 }
-body {
-    background: antiquewhite;
-}
-#JSLINT_ address {
-    float: right;
-    font-size: 90%;
-    margin-left: 16px;
-}
-#JSLINT_ button {
+.JSLINT_ button {
     background: darkslategray;
     color: white;
     cursor: pointer;
@@ -128,115 +105,30 @@ body {
     padding: 4px 16px;
     text-align: center;
 }
-#JSLINT_ dd {
-    font-weight: bold;
-    margin-left: 8em;
-    padding-bottom: 2px;
-}
-#JSLINT_ dfn {
-    display: block;
-    font-style: normal;
-    font-weight: bold;
-    padding-bottom: 2px;
-}
-#JSLINT_ dl {
-    background: cornsilk;
-    padding: 4px 16px 0 16px;
-}
-#JSLINT_ dl.level0 {
-    background: white;
-}
-#JSLINT_ dl.level1 {
-    /* yellow */
-    background: #ffffe0;
-    margin-left: 16px;
-}
-#JSLINT_ dl.level2 {
-    /* green */
-    background: #e0ffe0;
-    margin-left: 2em;
-}
-#JSLINT_ dl.level3 {
-    /* blue */
-    background: #D0D0ff;
-    margin-left: 3em;
-}
-#JSLINT_ dl.level4 {
-    /* purple */
-    background: #ffe0ff;
-    margin-left: 4em;
-}
-#JSLINT_ dl.level5 {
-    /* red */
-    background: #ffe0e0;
-    margin-left: 5em;
-}
-#JSLINT_ dl.level6 {
-    /* orange */
-    background: #ffe390;
-    margin-left: 6em;
-}
-#JSLINT_ dl.level7 {
-    /* gray */
-    background: #e0e0e0;
-    margin-left: 7em;
-}
-#JSLINT_ dl.level8 {
-    margin-left: 8em;
-}
-#JSLINT_ dl.level9 {
-    margin-left: 9em;
-}
-#JSLINT_ dt {
-    float: left;
-    font-size: 75%;
-    font-style: italic;
-    text-align: right;
-    width: 8em;
-}
-#JSLINT_ fieldset,
-#JSLINT_ > div {
-    clear: both;
-    margin: 16px 40px;
-    width: auto;
-}
-#JSLINT_ fieldset {
-    background: gainsboro;
-}
-#JSLINT_ fieldset > div {
-    padding: 16px;
-    width: 100%;
-}
-#JSLINT_ label {
+.JSLINT_ label {
     font-size: 90%;
     padding-left: 0.25em;
 }
-#JSLINT_ legend {
-    background: darkslategray;
-    color: white;
-    font-style: normal;
-    font-weight: normal;
-    padding: 0.25em 0;
-    text-align: center;
-    width: 100%;
-}
-#JSLINT_ textarea {
-    padding: 0.5%;
-    resize: none;
-    white-space: pre;
-    width: 100%;
-}
-#JSLINT_ textarea::selection,
-#JSLINT_ .CodeMirror-selected {
+.JSLINT_ .CodeMirror-selected {
     background: wheat;
 }
-#JSLINT_ .CodeMirror {
+.JSLINT_ .CodeMirror {
     padding: 0;
 }
-#JSLINT_ .CodeMirror .cm-trailingspace {
-    background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAACCAYAAAB/qH1jAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3QUXCToH00Y1UgAAACFJREFUCNdjPMDBUc/AwNDAAAFMTAwMDA0OP34wQgX/AQBYgwYEx4f9lQAAAABJRU5ErkJggg==");
-    background-position: bottom left;
-    background-repeat: repeat-x;
+.JSLINT_ .CodeMirror-lint-marker {
+    background-position: 1px -1px;
+}
+#JSLINT_BUTTONS {
+    text-align: center;
+}
+#JSLINT_GLOBALS {
+    height: 40px;
+    white-space: normal;
+}
+#JSLINT_INPUT > div {
+    clear: both;
+    margin: 16px 40px;
+    width: auto;
 }
 #JSLINT_OPTIONS div[title],
 #JSLINT_OPTIONS div[title] input,
@@ -255,56 +147,25 @@ body {
     line-height: 20px;
     margin: 0 16px 16px 0;
 }
-#JSLINT_PROPERTY {
-    background: honeydew;
-}
 #JSLINT_TITLEBOX {
     color: darkslategray;
 }
 #JSLINT_TITLEBOX li {
     line-height: 20px;
 }
-#JSLINT_WARNINGS cite {
-    display: block;
-    font-style: normal;
-    margin-top: 16px;
-    overflow-x: hidden;
-}
-#JSLINT_WARNINGS cite:nth-child(1) {
-    margin-top: 0;
-}
-#JSLINT_WARNINGS dl address {
-    display: inline;
-    float: none;
-    font-size: 80%;
-}
-#JSLINT_WARNINGS samp {
-    background: lavenderblush;
-    display: block;
-    font-style: normal;
-    font-weight: bold;
-    padding: 4px;
-    white-space: pre-wrap;
-}
-#JSLINT_WARNINGS > div {
-    background: pink;
-}
-#JSLINT_WARNINGS > legend {
-    background: indianred;
-}
 
-#JSLINT_ button:hover,
+.JSLINT_ button:hover,
 #JSLINT_OPTIONS div[title]:hover {
     background: slategray;
     color: white;
 }
 
-#JSLINT_ button:active {
+.JSLINT_ button:active {
     color: black;
 }
 </style>
 </head>
-<body>
+<body class="JSLINT_">
 <div id="bannerFork1"
 style="
     height: 100px;
@@ -360,7 +221,7 @@ style="
     </span>
     </div>
 </div>
-<div id="JSLINT_">
+<div id="JSLINT_INPUT">
 <div id="JSLINT_TITLEBOX">
     <div style="float: left; margin-bottom: 16px;">
     <div style="font-size: 50px;">JSLint</div>
@@ -374,15 +235,12 @@ style="
 </div>
 <fieldset>
     <legend>Source</legend>
-
-<!-- Google PageSpeed - Reduce Cumulative Layout Shift. -->
-
-    <textarea id="JSLINT_SOURCE" style="height: 297px;"></textarea>
+    <textarea id="JSLINT_SOURCE"></textarea>
 </fieldset>
-<div style="text-align: center;">
+<div id="JSLINT_BUTTONS">
     <button name="JSLint" title="Ctrl + Enter">JSLint</button>
-    <button name="clear_source">Clear</button>
-    <button name="clear_options">Clear options</button>
+    <button name="clear_source">Clear Source</button>
+    <button name="clear_options">Clear Options</button>
 </div>
 <fieldset id="JSLINT_OPTIONS">
     <legend>Options</legend>
@@ -455,28 +313,16 @@ style="
         </div>
     </div>
     <textarea
-        id="JSLINT_GLOBAL"
+        id="JSLINT_GLOBALS"
         placeholder="imported globals (e.g. $, jQuery)"
         spellcheck="false"
-        style="white-space: normal;"
         title="global"
     ></textarea>
     </div>
 </fieldset>
-<fieldset id="JSLINT_WARNINGS">
-    <legend>Warnings</legend>
-    <div id="JSLINT_WARNINGS_LIST"></div>
-</fieldset>
-<fieldset>
-    <legend>Property Directive</legend>
-    <div><textarea id="JSLINT_PROPERTY" rows="8" readonly></textarea></div>
-</fieldset>
-<fieldset id="JSLINT_REPORT">
-    <legend>Function Report</legend>
-    <div id="JSLINT_REPORT_LIST"></div>
-</fieldset>
 </div>
-<script defer src="asset-codemirror-v5.58.3-rollup.js"></script>
+<div id="JSLINT_REPORT_HTML"></div>
+<script defer src="asset-codemirror-rollup.js"></script>
 <script src="browser.mjs" type="module"></script>
 <!-- coverage-hack -->
 <script>

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -3118,6 +3118,7 @@ function jslint_phase3_parse(state) {
                 enroll(name, "variable", true);
                 the_function.name = Object.assign(name, {
                     calls: empty(),
+                    dead: false,
                     init: true
                 });
                 advance();
@@ -4850,15 +4851,15 @@ function jslint_phase4_walk(state) {
                 warn("label_a", thing);
             }
             if (
-                the_variable.dead
-                && (
+                (
                     the_variable.calls === undefined
                     || functionage.name === undefined
                     || the_variable.calls[functionage.name.id] === undefined
                 )
+                && the_variable.dead
             ) {
 
-// cause: "function aa(){bb();}\nfunction bb(){}"
+// cause: "let aa;if(aa){let bb;}bb;"
 
                 warn("out_of_scope_a", thing);
             }
@@ -5144,11 +5145,10 @@ function jslint_phase4_walk(state) {
                 left_variable = parent.context[left.id];
                 if (
                     left_variable !== undefined
-                    && left_variable.dead
+                    // && left_variable.dead
                     && left_variable.parent === parent
                     && left_variable.calls !== undefined
-                    && left_variable.calls[functionage.name.id]
-                    !== undefined
+                    && left_variable.calls[functionage.name.id] !== undefined
                 ) {
                     left_variable.dead = false;
                 }

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -7235,7 +7235,7 @@ function jslint(
     }, ii, list) {
         list[ii].formatted_message = String(
             String(ii + 1).padStart(3, " ")
-            + " \u001b[31m" + message + "\u001b[39m"
+            + ". \u001b[31m" + message + "\u001b[39m"
             + " \u001b[90m\/\/ line " + line + ", column " + column
             + "\u001b[39m\n"
             + ("    " + line_source.trim()).slice(0, 72) + "\n"

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -3118,6 +3118,9 @@ function jslint_phase3_parse(state) {
                 enroll(name, "variable", true);
                 the_function.name = Object.assign(name, {
                     calls: empty(),
+
+// Fixes issue #272 - function hoisting not allowed.
+
                     dead: false,
                     init: true
                 });
@@ -5145,6 +5148,7 @@ function jslint_phase4_walk(state) {
                 left_variable = parent.context[left.id];
                 if (
                     left_variable !== undefined
+                    // coverage-hack
                     // && left_variable.dead
                     && left_variable.parent === parent
                     && left_variable.calls !== undefined

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -6646,12 +6646,12 @@ function jslint(
         if (aa.id === "(string)") {
             aa_value = aa.value;
         } else if (aa.id === "`" && aa.constant) {
-            aa_value = aa.value[0];
+            aa_value = aa.value[0].value;
         }
         if (bb.id === "(string)") {
             bb_value = bb.value;
         } else if (bb.id === "`" && bb.constant) {
-            bb_value = bb.value[0];
+            bb_value = bb.value[0].value;
         }
         if (typeof aa_value === "string") {
             return aa_value === bb_value;

--- a/test.mjs
+++ b/test.mjs
@@ -305,8 +305,11 @@ function noop() {
             "let aa = /[\\--\\-]/;"
         ],
         ternary: [
-            "let aa = (\n    aa()\n    ? 0\n    : 1\n) "
-            + "&& (\n    aa()\n    ? 0\n    : 1\n);"
+            (
+                "let aa = (\n    aa()\n    ? 0\n    : 1\n) "
+                + "&& (\n    aa()\n    ? 0\n    : 1\n);"
+            ),
+            "let aa = (\n    aa()\n    ? `0`\n    : `1`\n);"
         ],
         try_catch: [
             "let aa = 0;\n"

--- a/test.mjs
+++ b/test.mjs
@@ -322,6 +322,9 @@ function noop() {
             + "}\n"
             + "aa();\n"
         ],
+        use_strict: [
+            "function aa() {\n    \"use strict\";\n    return;\n}"
+        ],
         var: [
             "\"use strict\";\nvar aa = 0;",
             "let [\n    aa, bb = 0\n] = 0;",


### PR DESCRIPTION
- website - create codemirror-plugin to highlight jslint-warnings in editor.

pr fixes #272.

the following code with cyclic function-calls is now allowed in jslint:

```javascript
/*jslint node*/
function foo() {
    console.log("foo");
    setTimeout(bar, 1000);
}

function bar() {
    console.log("bar");
    setTimeout(foo, 1000);
}

foo();
```

also lays future groundwork for jslint to warn if function-declarations are unordered (similar to unordered vars).