### PR TITLE
# v2021.6.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Todo
+# Todo
 - app - deploy jslint as chrome-extension.
 - cli - add command `report`.
 - jslint - add `for...of` syntax support.
@@ -17,9 +17,8 @@
 - tests - update function warn_at() with assertion-check matching column with artifact.
 - vim - add vim plugin.
 
-## v2021.6.26-beta
+# v2021.6.30
 - breaking-change - rename files *.js to *.mjs for better integration with nodejs.
-- bugfix - fix function is_equal() always returning true when comparing string-literals.
 - ci - auto-screenshot example-shell-commands in README.md.
 - ci - include explicit commonjs (jslint.cjs) and es-module (jslint.mjs) variants of jslint.
 - jslint - disable out-of-scope warning for functions.
@@ -27,7 +26,7 @@
 - license - change license to public-domain/unlicense.
 - website - create codemirror-plugin to highlight jslint-warnings in editor.
 
-## v2021.6.22
+# v2021.6.22
 - bugfix - fix global_list being ignored by jslint.
 - bugfix - fix no-warning when exception in catch-block is unused.
 - ci - migrate ci-scripts from cjs to esm.
@@ -40,7 +39,7 @@
 - website - replace .png logo with .svg logo.
 - website - replace current-editor with CodeMirror-editor and change programming-font-family from `Programma` to `consolas, menlo, monospace`.
 
-## v2021.6.12
+# v2021.6.12
 - bugfix - fix await expression/statement inside catch-statement not registered by functionage.await.
 - bugfix - fix cli appending slash "/" to normalized filename.
 - bugfix - fix issue #316, #317 - jslint complains about dynamic-import.
@@ -69,7 +68,7 @@
     - update functions artifact(), stop(), warn() with fallback-code `the_token = the_token || state.token_nxt;`.
 - website - add ui-loader-animation.
 
-## v2021.6.3
+# v2021.6.3
 - breaking-change - hardcode `const fudge = 1`
 - breaking-change - remove little-used-feature allowing jslint to accept array-of-strings as source b/c internal lines-object has been changed from array-of-strings to array-of-objects.
 - doc - add svg changelog.
@@ -81,7 +80,7 @@
 - jslint - remove obsolete ie-era warning about duplicate names for caught-errors.
 - website - move options-ui to top of page after editor-ui
 
-## v2021.5.30
+# v2021.5.30
 - bugfix - fix issue #282 - fail to warn trailing semicolon in `export default Object.freeze({})`.
 - ci - 100% code-coverage!
 - ci - auto-update changelog in README.md from CHANGELOG.md.
@@ -100,7 +99,7 @@
 - tests - validate inline-multi-causes are sorted.
 - website - replace links `branch.xxx` with `branch-xxx`.
 
-## v2021.5.27
+# v2021.5.27
 - ci - fix expectedWarningCode not being validated.
 - ci - in windows, disable git-autocrlf.
 - deadcode - replace with assertion-check in function are_similar() - "if (a === b) { return true }".
@@ -112,7 +111,7 @@
 - style - refactor code moving infix-operators from post-position to pre-position in multiline statements.
 - website - add hotkey ctrl-enter to run jslint.
 
-## v2021.5.26
+# v2021.5.26
 - ci - fix ci silently failing in node-v12 and node-v14.
 - cli - add env var JSLINT_CLI to force-trigger cli in jslint.js (used for code-coverage of cli).
 - jslint - add "globalThis" to default globals.
@@ -126,7 +125,7 @@
 - website - load index.html with example code.
 - website - merge file report.js into browser.js.
 
-## v2021.5.23
+# v2021.5.23
 - doc - add section Changelog.
 - doc - update README.md with installation instructions.
 - cli - merge shell-function shJslintCli into jslint.js.
@@ -137,7 +136,7 @@
 - ci - validate non-http/file links in *.md files.
 - ci - add shell-functions shCiBranchPromote.
 
-## v2021.5.21
+# v2021.5.21
 - this ci-release does not change any core-functionality of file jslint.js.
 - doc - add file CHANGELOG.md.
 - ci - begin addng regression tests and improve code-coverage.
@@ -154,17 +153,17 @@
 - ci - ci now fails if jslint-check fails for any of the files in branches.
 - ci - add github-workflows to generate code-coverage for jslint.js.
 
-## v2020.11.6
+# v2020.11.6
 - last jslint version before jslint-org migration.
 
-## v2018.4.25
+# v2018.4.25
 - last jslint version written in commonjs.
 
-## v2017.11.6
+# v2017.11.6
 - last jslint version written in es5.
 
-## v2014.7.8
+# v2014.7.8
 - last jslint version before 2 year hiatus.
 
-## v2013.3.13
+# v2013.3.13
 - last jslint version that can lint .html and .css files.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,3 @@
-JSLint
-Original Author: Douglas Crockford (https://www.jslint.com).
-
 This is free and unencumbered software released into the public domain.
 
 Anyone is free to copy, modify, publish, use, compile, sell, or

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Status
-| Branch | [master<br>(v2021.6.22)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
+| Branch | [master<br>(v2021.6.30)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
 |--:|:--:|:--:|:--:|
 | CI | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jslint-org/jslint/actions?query=branch%3Amaster) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/jslint-org/jslint/actions?query=branch%3Abeta) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/jslint-org/jslint/actions?query=branch%3Aalpha) |
 | Coverage | [![coverage](https://jslint-org.github.io/jslint/branch-master/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch-master/.build/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-beta/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch-beta/.build/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-alpha/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch-alpha/.build/coverage/index.html) |

--- a/browser.mjs
+++ b/browser.mjs
@@ -1,37 +1,48 @@
 // browser.mjs
-// 2018-06-16
-// Copyright (c) 2015 Douglas Crockford  (www.JSLint.com)
+// Original Author: Douglas Crockford (https://www.jslint.com).
+
+// This is free and unencumbered software released into the public domain.
+
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+
+// In jurisdictions that recognize copyright laws, the author or authors
+// of this software dedicate any and all copyright interest in the
+// software to the public domain. We make this dedication for the benefit
+// of the public at large and to the detriment of our heirs and
+// successors. We intend this dedication to be an overt act of
+// relinquishment in perpetuity of all present and future rights to this
+// software under copyright law.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+// For more information, please refer to <http://unlicense.org/>
+
 
 /*jslint beta, browser*/
 
 /*property
-    CodeMirror, Pos,
-    bind,
-    click, currentTarget,
-    closest,
-    debug, dispatchEvent,
-    editor,
-    from,
-    globals, gutters,
-    innerHTML,
-    lint, lintOnChange,
-    map, mode_stop,
-    offsetWidth, onchange, onkeyup,
-    performLint, preventDefault,
-    registerHelper, result, reverse,
-    search, setSize, severity, stopPropagation,
-    target, test, to, trim,
-    width,
-    CodeMirror, Tab, addEventListener, checked, closure, column, context,
-    create, ctrlKey, display, edition, exports, extraKeys, filter, forEach,
-    fromTextArea, froms, functions, getElementById, getValue, global, id,
-    indentUnit, indentWithTabs, outerHTML, isArray, join, jslint_result, json,
-    key, keys, length, level, line, lineNumbers, lineWrapping, line_source,
-    matchBrackets, message, metaKey, mode, module, name, names, onclick,
-    parameters, parent, property, push, querySelector, querySelectorAll,
-    replace, replaceSelection, role, scrollTop, setValue, showTrailingSpace,
-    signature, sort, split, stack_trace, stop, style, textContent, value,
-    warnings
+    CodeMirror, Pos, Tab, addEventListener, checked, click, closest, closure,
+    column, context, ctrlKey, currentTarget, dispatchEvent, display, edition,
+    editor, error, exports, extraKeys, filter, forEach, from, fromTextArea,
+    froms, functions, global, globals, gutters, id, indentUnit, indentWithTabs,
+    innerHTML, isArray, join, json, key, keys, length, level, line, lineNumbers,
+    lineWrapping, line_source, lint, lintOnChange, map, matchBrackets, message,
+    metaKey, mode, mode_stop, module, name, names, offsetWidth, onclick,
+    onkeyup, outerHTML, parameters, parent, performLint, preventDefault,
+    property, push, querySelector, querySelectorAll, registerHelper, replace,
+    replaceSelection, result, reverse, role, search, setSize, setValue,
+    severity, showTrailingSpace, signature, sort, split, stack_trace, stop,
+    stopPropagation, style, target, test, textContent, to, trim, value,
+    warnings, width
 */
 
 import jslint from "./jslint.mjs";
@@ -488,8 +499,8 @@ body {
     if (json) {
         return (
             warnings.length === 0
-            ? `<div class="center">JSON: good.</div>`
-            : `<div class="center">JSON: bad.</div>`
+            ? "<div class=\"center\">JSON: good.</div>"
+            : "<div class=\"center\">JSON: bad.</div>"
         );
     }
     if (functions.length === 0) {

--- a/ci.sh
+++ b/ci.sh
@@ -356,7 +356,7 @@ import moduleFs from "fs";
         dict[file] = await moduleFs.promises.readFile(file, "utf8");
     }));
     Array.from(dict["CHANGELOG.md"].matchAll(
-        /\n##\u0020(v\d\d\d\d\.\d\d?\.\d\d?(.*?)?)\n/g
+        /\n\n#\u0020(v\d\d\d\d\.\d\d?\.\d\d?(.*?)?)\n/g
     )).slice(0, 2).forEach(function ([
         ignore, version, isBeta
     ]) {
@@ -373,8 +373,8 @@ import moduleFs from "fs";
         }, {
             file: "jslint.mjs",
             src: dict["jslint.mjs"].replace((
-                /^const\u0020jslint_edition\u0020=\u0020".*?";$/m
-            ), `const jslint_edition = "${versionBeta}";`),
+                /^let\u0020jslint_edition\u0020=\u0020".*?";$/m
+            ), `let jslint_edition = "${versionBeta}";`),
             src0: dict["jslint.mjs"]
         }
     ].forEach(function ({

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -94,40 +94,30 @@
 /*jslint beta, node*/
 
 /*property
-    JSLINT_BETA,
-    beta,
-    catch_list, catch_stack, cjs_module, cjs_require, cli,
-    function_stack,
-    global_dict,
-    indent2,
-    last_statement,
-    main, mode_force, mode_noop,
-    process_exit,
-    toString, trimRight,
-    variable,
-    execArgv, fileURLToPath, filter, meta, order, reduce, stringify, token, url,
-    a, all, allowed_option, argv, arity, artifact, assign, async, b,
-    bind, bitwise, block, body, browser, c, calls, catch, closer, closure, code,
-    column, concat, console_error, constant, context, convert, couch, create,
-    cwd, d, dead, debug, default, devel, directive, directive_list,
-    directive_quiet, directives, disrupt, dot, edition, ellipsis, else,
-    endsWith, env, error, eval, every, exec, exit, export_dict, exports,
-    expression, extra, file, finally, flag, for, forEach, formatted_message,
-    free, freeze, from, froms, fud, function_list, functions, getset, global,
-    global_list, id, identifier, import, import_list, inc, index, indexOf, init,
-    initial, isArray, isNaN, is_equal, is_weird, join, jslint, json,
-    keys, label, lbp, led, length, level, line, line_list, line_offset,
-    line_source, lines, live, long, loop, m, map, margin, match, max, message,
-    mode_json, mode_module, mode_property, mode_shebang, mode_stop, module,
-    name, names, node, now, nr, nud, ok, open, opening, option, option_dict,
-    padStart, parameters, parent, pop, promises, property, property_dict, push,
-    quote, readFile, readdir, repeat, replace, resolve, role, search, shebang,
-    signature, single, slice, some, sort, source, split, stack, stack_trace,
-    startsWith, statement, stop, stop_at, switch, syntax_dict, tenure, test,
-    test_internal_error, then, this, thru, token_global, token_list, token_nxt,
-    token_tree, tokens, tree, trim, try, type, unordered, used, value, variable,
-    versions, warn, warn_at, warning, warning_list, warnings, white, wrapped,
-    writable
+    JSLINT_BETA, a, all, allowed_option, argv, arity, artifact, assign, async,
+    b, beta, bind, bitwise, block, body, browser, c, calls, catch, catch_list,
+    catch_stack, cjs_module, cjs_require, cli, closer, closure, code, column,
+    concat, console_error, constant, context, convert, couch, create, cwd, d,
+    dead, debug, default, devel, directive, directive_list, directive_quiet,
+    directives, disrupt, dot, edition, ellipsis, else, endsWith, env, error,
+    eval, every, exec, execArgv, exit, export_dict, exports, expression, extra,
+    file, fileURLToPath, filter, finally, flag, for, forEach, formatted_message,
+    free, freeze, from, froms, fud, function_list, function_stack, functions,
+    getset, global, global_dict, id, identifier, import, import_list, inc,
+    indent2, index, indexOf, init, initial, isArray, isNaN, is_equal, is_weird,
+    join, jslint, json, keys, label, last_statement, lbp, led, length, level,
+    line, line_list, line_offset, line_source, lines, live, long, loop, m, main,
+    map, margin, match, message, meta, mode_force, mode_json, mode_module,
+    mode_noop, mode_property, mode_shebang, mode_stop, module, name, names,
+    node, now, nr, nud, ok, open, opening, option, option_dict, order, padStart,
+    parameters, parent, pop, process_exit, promises, property, property_dict,
+    push, quote, readFile, readdir, reduce, repeat, replace, resolve, role,
+    search, shebang, signature, single, slice, some, sort, source, split, stack,
+    stack_trace, startsWith, statement, stop, stop_at, switch, syntax_dict,
+    tenure, test, test_internal_error, this, thru, token, token_global,
+    token_list, token_nxt, token_tree, tokens, tree, trim, trimRight, try, type,
+    unordered, url, used, value, variable, versions, warn, warn_at, warning,
+    warning_list, warnings, white, wrapped, writable
 */
 
 let jslint_charset_ascii = (
@@ -139,7 +129,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2021.6.26-beta";
+let jslint_edition = "v2021.6.30";
 let jslint_export;              // The jslint object to be exported.
 let jslint_fudge = 1;           // Fudge starting line and starting column to 1.
 let jslint_import_meta_url = "";
@@ -6652,12 +6642,12 @@ function jslint(
         if (aa.id === "(string)") {
             aa_value = aa.value;
         } else if (aa.id === "`" && aa.constant) {
-            aa_value = aa.value[0].value;
+            aa_value = aa.value[0];
         }
         if (bb.id === "(string)") {
             bb_value = bb.value;
         } else if (bb.id === "`" && bb.constant) {
-            bb_value = bb.value[0].value;
+            bb_value = bb.value[0];
         }
         if (typeof aa_value === "string") {
             return aa_value === bb_value;

--- a/test.mjs
+++ b/test.mjs
@@ -7,7 +7,7 @@ function assertOrThrow(passed, msg) {
  * this function will throw <msg> if <passed> is falsy
  */
     if (!passed) {
-        throw new Error(msg.slice(0, 1000));
+        throw new Error(String(msg).slice(0, 1000));
     }
 }
 
@@ -309,7 +309,7 @@ function noop() {
                 "let aa = (\n    aa()\n    ? 0\n    : 1\n) "
                 + "&& (\n    aa()\n    ? 0\n    : 1\n);"
             ),
-            "let aa = (\n    aa()\n    ? `0`\n    : `1`\n);"
+            "let aa = (\n    aa()\n    ? `${0}`\n    : `${1}`\n);"
         ],
         try_catch: [
             "let aa = 0;\n"


### PR DESCRIPTION
- breaking-change - rename files *.js to *.mjs for better integration with nodejs.
- ci - auto-screenshot example-shell-commands in README.md.
- ci - include explicit commonjs (jslint.cjs) and es-module (jslint.mjs) variants of jslint.
- jslint - disable out-of-scope warning for functions.
- jslint - reintroduce directive `/*jslint indent2*/` - allow 2-space indent.
- license - change license to public-domain/unlicense.
- website - create codemirror-plugin to highlight jslint-warnings in editor.