### PR TITLE
- tests - revamp cause-based testing with more robust instrumentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 # Todo
 - app - deploy jslint as chrome-extension.
+- ci - use badge to indicate release-version so README.md doesnt have to to be updated every release.
 - cli - add command `report`.
+- compatibility - align with eslint and jshint with new warning that operators should be place at end-of-line.
 - jslint - add `for...of` syntax support.
 - jslint - add html and css linting back into jslint.
 - jslint - add new warning against using do-statment.
@@ -14,13 +16,14 @@
 - jslint-refactor - migrate recursive-loops to for/while loops.
 - merge function.html and help.html into README.md
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
-- tests - update function warn_at() with assertion-check matching column with artifact.
 - vim - add vim plugin.
 
 # v2021.7.1-beta
-- bugfix - fix website crashing from html-report if function.parameters is undefined.
+- bugfix - fix jslint not warning about function-redefinition when function is defined inside a call.
 - bugfix - fix website crashing when linting pure json-object.
 - jslint - comment out shebang in jslint.mjs so older ios devices can use website.
+- tests - revamp cause-based testing with more robust instrumentation.
+- tests - test column position in warnings are correct.
 
 # v2021.6.30
 - breaking-change - rename files *.js to *.mjs for better integration with nodejs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - ci - use badge to indicate release-version so README.md doesnt have to to be updated every release.
 - cli - add command `report`.
 - compatibility - align with eslint and jshint with new warning that operators should be place at end-of-line.
+- coverage - add macros `/*coverage-disable*/` and `/*coverage-enable*/`.
 - jslint - add `for...of` syntax support.
 - jslint - add html and css linting back into jslint.
 - jslint - add new warning against using do-statment.

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -279,11 +279,13 @@ function jslint_phase2_lex(state) {
             return (
                 char === ""
 
-// cause: "aa=/["
+// test_cause:
+// ["aa=/[", "77f", "77c", "7", 77]
 
                 ? stop_at("expected_a", line, column - 1, match)
 
-// cause: "aa=/aa{/"
+// test_cause:
+// ["aa=/aa{/", "77f", "77c", "7", 77]
 
                 : stop_at("expected_a_b", line, column, match, char)
             );
@@ -315,7 +317,8 @@ function jslint_phase2_lex(state) {
         let length = digits.length;
         if (!quiet && length === 0) {
 
-// cause: "0x"
+// test_cause:
+// ["0x", "77f", "77c", "7", 77]
 
             warn_at("expected_digits_after_a", line, column, snippet);
         }
@@ -341,7 +344,8 @@ function jslint_phase2_lex(state) {
             && !mode_regexp
         ) {
 
-// cause: "too_long"
+// test_cause:
+// ["too_long", "77f", "77c", "7", 77]
 
             warn_at("too_long", line);
         }
@@ -363,33 +367,38 @@ function jslint_phase2_lex(state) {
 
         if (line_source === "/*jslint-disable*/") {
 
-// cause: "/*jslint-disable*/"
+// test_cause:
+// ["/*jslint-disable*/", "77f", "77c", "7", 77]
 
             line_disable = line;
         } else if (line_source === "/*jslint-enable*/") {
             if (line_disable === undefined) {
 
-// cause: "/*jslint-enable*/"
+// test_cause:
+// ["/*jslint-enable*/", "77f", "77c", "7", 77]
 
                 stop_at("unopened_enable", line);
             }
             line_disable = undefined;
         } else if (line_source.endsWith(" //jslint-quiet")) {
 
-// cause: "0 //jslint-quiet"
+// test_cause:
+// ["0 //jslint-quiet", "77f", "77c", "7", 77]
 
             line_list[line].directive_quiet = true;
         }
         if (line_disable !== undefined) {
 
-// cause: "/*jslint-disable*/\n0"
+// test_cause:
+// ["/*jslint-disable*/\n0", "77f", "77c", "7", 77]
 
             line_source = "";
         }
         if (line_source.indexOf("\t") >= 0) {
             if (!option_dict.white) {
 
-// cause: "\t"
+// test_cause:
+// ["\t", "77f", "77c", "7", 77]
 
                 warn_at("use_spaces", line, line_source.indexOf("\t") + 1);
             }
@@ -400,7 +409,8 @@ function jslint_phase2_lex(state) {
         }
         if (!option_dict.white && line_source.endsWith(" ")) {
 
-// cause: " "
+// test_cause:
+// [" ", "77f", "77c", "7", 77]
 
             warn_at("unexpected_trailing_space", line, line_source.length - 1);
         }
@@ -445,7 +455,8 @@ function jslint_phase2_lex(state) {
             && (token_prv.id === "(comment)" || token_prv.id === "(regexp)")
         ) {
 
-// cause: "/**//**/"
+// test_cause:
+// ["/**//**/", "77f", "77c", "7", 77]
 
             warn(
                 "expected_space_a_b",
@@ -456,7 +467,8 @@ function jslint_phase2_lex(state) {
         }
         if (token_prv.id === "." && id === "(number)") {
 
-// cause: ".0"
+// test_cause:
+// [".0", "77f", "77c", "7", 77]
 
             warn("expected_a_before_b", token_prv, "0", ".");
         }
@@ -487,7 +499,8 @@ function jslint_phase2_lex(state) {
         switch (char) {
         case "":
 
-// cause: "\"\\"
+// test_cause:
+// ["\"\\", "77f", "77c", "7", 77]
 
             return stop_at("unclosed_string", line, column);
         case "/":
@@ -506,26 +519,30 @@ function jslint_phase2_lex(state) {
             return char_after();
         case "t":
 
-// cause: "\"\\/\\\\\\`\\b\\f\\n\\r\\t\""
+// test_cause:
+// ["\"\\/\\\\\\`\\b\\f\\n\\r\\t\"", "77f", "77c", "7", 77]
 
             return char_after();
         case "u":
             if (char_after("u") === "{") {
                 if (state.mode_json) {
 
-// cause: "[\"\\u{12345}\"]"
+// test_cause:
+// ["[\"\\u{12345}\"]", "77f", "77c", "7", 77]
 
                     warn_at("unexpected_a", line, column, char);
                 }
                 if (read_digits(rx_hexs) > 5) {
 
-// cause: "\"\\u{123456}\""
+// test_cause:
+// ["\"\\u{123456}\"", "77f", "77c", "7", 77]
 
                     warn_at("too_many_digits", line, column);
                 }
                 if (char !== "}") {
 
-// cause: "\"\\u{12345\""
+// test_cause:
+// ["\"\\u{12345\"", "77f", "77c", "7", 77]
 
                     stop_at("expected_a_before_b", line, column, "}", char);
                 }
@@ -534,7 +551,8 @@ function jslint_phase2_lex(state) {
             char_before();
             if (read_digits(rx_hexs, true) < 4) {
 
-// cause: "\"\\u0\""
+// test_cause:
+// ["\"\\u0\"", "77f", "77c", "7", 77]
 
                 warn_at("expected_four_digits", line, column);
             }
@@ -544,7 +562,8 @@ function jslint_phase2_lex(state) {
                 return char_after();
             }
 
-// cause: "\"\\0\""
+// test_cause:
+// ["\"\\0\"", "77f", "77c", "7", 77]
 
             warn_at("unexpected_a_before_b", line, column, "\\", char);
         }
@@ -571,7 +590,8 @@ function jslint_phase2_lex(state) {
             the_comment = token_create("(comment)", snippet);
             if (mode_mega) {
 
-// cause: "`${//}`"
+// test_cause:
+// ["`${//}`", "77f", "77c", "7", 77]
 
                 warn("unexpected_comment", the_comment, "`");
             }
@@ -582,7 +602,8 @@ function jslint_phase2_lex(state) {
             snippet = [];
             if (line_source[0] === "/") {
 
-// cause: "/*/"
+// test_cause:
+// ["/*/", "77f", "77c", "7", 77]
 
                 warn_at("unexpected_a", line, column + ii, "/");
             }
@@ -600,7 +621,8 @@ function jslint_phase2_lex(state) {
                     jj = line_source.indexOf("/*");
                     if (jj >= 0) {
 
-// cause: "/*/*"
+// test_cause:
+// ["/*/*", "77f", "77c", "7", 77]
 
                         warn_at("nested_comment", line, column + jj);
                     }
@@ -609,7 +631,8 @@ function jslint_phase2_lex(state) {
                 line_source = read_line();
                 if (line_source === undefined) {
 
-// cause: "/*"
+// test_cause:
+// ["/*", "77f", "77c", "7", 77]
 
                     return stop_at("unclosed_comment", line, column);
                 }
@@ -620,7 +643,8 @@ function jslint_phase2_lex(state) {
             );
             if (jj >= 0) {
 
-// cause: "/*/**/"
+// test_cause:
+// ["/*/**/", "77f", "77c", "7", 77]
 
                 warn_at("nested_comment", line, column + jj);
             }
@@ -641,7 +665,8 @@ function jslint_phase2_lex(state) {
             ).test(snippet)
         ) {
 
-// cause: "//\u0074odo"
+// test_cause:
+// ["//todo", "77f", "77c", "7", 77] //jslint-quiet
 
             warn("todo_comment", the_comment);
         }
@@ -658,7 +683,8 @@ function jslint_phase2_lex(state) {
         directive_list.push(the_comment);
         if (!mode_directive) {
 
-// cause: "0\n/*global aa*/"
+// test_cause:
+// ["0\n/*global aa*/", "77f", "77c", "7", 77]
 
             warn_at("misplaced_directive_a", line, from, match[1]);
             return the_comment;
@@ -681,7 +707,8 @@ function jslint_phase2_lex(state) {
             if (!match) {
                 if (body) {
 
-// cause: "/*jslint !*/"
+// test_cause:
+// ["/*jslint !*/", "77f", "77c", "7", 77]
 
                     return stop("bad_directive_a", the_comment, body);
                 }
@@ -717,7 +744,8 @@ function jslint_phase2_lex(state) {
                     }
                 } else {
 
-// cause: "/*jslint undefined*/"
+// test_cause:
+// ["/*jslint undefined*/", "77f", "77c", "7", 77]
 
                     warn("bad_option_a", the_comment, name);
                 }
@@ -727,7 +755,8 @@ function jslint_phase2_lex(state) {
             } else if (the_comment.directive === "global") {
                 if (value) {
 
-// cause: "/*global aa:false*/"
+// test_cause:
+// ["/*global aa:false*/", "77f", "77c", "7", 77]
 
                     warn("bad_option_a", the_comment, name + ":" + value);
                 }
@@ -746,7 +775,8 @@ function jslint_phase2_lex(state) {
 
         if (mode_mega) {
 
-// cause: "`${`"
+// test_cause:
+// ["`${`", "77f", "77c", "7", 77]
 
             return stop_at("expected_a_b", line, column, "}", "`");
         }
@@ -798,7 +828,8 @@ function jslint_phase2_lex(state) {
                     id = lex_token().id;
                     if (id === "{") {
 
-// cause: "`${{"
+// test_cause:
+// ["`${{", "77f", "77c", "7", 77]
 
                         return stop_at("expected_a_b", line, column, "}", "{");
                     }
@@ -833,7 +864,8 @@ function jslint_phase2_lex(state) {
                 snippet += line_source + "\n";
                 if (read_line() === undefined) {
 
-// cause: "`"
+// test_cause:
+// ["`", "77f", "77c", "7", 77]
 
                     return stop_at("unclosed_mega", line_mega, from_mega);
                 }
@@ -882,7 +914,8 @@ function jslint_phase2_lex(state) {
             || (char >= "A" && char <= "Z")
         ) {
 
-// cause: "0a"
+// test_cause:
+// ["0a", "77f", "77c", "7", 77]
 
             return stop_at(
                 "unexpected_a_after_b",
@@ -926,19 +959,22 @@ function jslint_phase2_lex(state) {
                 case "":
                 case "]":
 
-// cause: "aa=/["
-// cause: "aa=/[]/"
+// test_cause:
+// ["aa=/[", "77f", "77c", "7", 77]
+// ["aa=/[]/", "77f", "77c", "7", 77]
 
                     if (mode_regexp_range) {
 
-// cause: "aa=/[0-]/"
+// test_cause:
+// ["aa=/[0-]/", "77f", "77c", "7", 77]
 
                         warn_at("unexpected_a", line, column - 1, "-");
                     }
                     return char_after("]");
                 case " ":
 
-// cause: "aa=/[ ]/"
+// test_cause:
+// ["aa=/[ ]/", "77f", "77c", "7", 77]
 
                     warn_at("expected_a_b", line, column, "\\u0020", " ");
                     break;
@@ -947,11 +983,12 @@ function jslint_phase2_lex(state) {
                 case "[":
                 case "^":
 
-// cause: "aa=/[-]/"
-// cause: "aa=/[.^]/"
-// cause: "aa=/[/"
-// cause: "aa=/[\\\\/]/"
-// cause: "aa=/[\\\\[]/"
+// test_cause:
+// ["aa=/[-]/", "77f", "77c", "7", 77]
+// ["aa=/[.^]/", "77f", "77c", "7", 77]
+// ["aa=/[/", "77f", "77c", "7", 77]
+// ["aa=/[\\\\/]/", "77f", "77c", "7", 77]
+// ["aa=/[\\\\[]/", "77f", "77c", "7", 77]
 
                     warn_at("expected_a_before_b", line, column, "\\", char);
                     break;
@@ -962,7 +999,8 @@ function jslint_phase2_lex(state) {
                 case "`":
                     if (mode_mega) {
 
-// cause: "`${/[`]/}`"
+// test_cause:
+// ["`${/[`]/}`", "77f", "77c", "7", 77]
 
                         warn_at("unexpected_a", line, column, "`");
                     }
@@ -995,9 +1033,10 @@ function jslint_phase2_lex(state) {
                 break;
             case "]":
 
-// cause: "/ /"
-// cause: "aa=/)"
-// cause: "aa=/]"
+// test_cause:
+// ["/ /", "77f", "77c", "7", 77]
+// ["aa=/)", "77f", "77c", "7", 77]
+// ["aa=/]", "77f", "77c", "7", 77]
 
                 warn_at("expected_regexp_factor_a", line, column, char);
                 break;
@@ -1011,7 +1050,8 @@ function jslint_phase2_lex(state) {
                     return;
                 case " ":
 
-// cause: "aa=/ /"
+// test_cause:
+// ["aa=/ /", "77f", "77c", "7", 77]
 
                     warn_at("expected_a_b", line, column, "\\s", " ");
                     char_after();
@@ -1037,8 +1077,9 @@ function jslint_phase2_lex(state) {
                         }
                     } else if (char === ":") {
 
-// cause: "aa=/(:)/"
-// cause: "aa=/?/"
+// test_cause:
+// ["aa=/(:)/", "77f", "77c", "7", 77]
+// ["aa=/?/", "77f", "77c", "7", 77]
 
                         warn_at("expected_a_before_b", line, column, "?", ":");
                     }
@@ -1051,21 +1092,24 @@ function jslint_phase2_lex(state) {
                     break;
                 case "*":
 
-// cause: "aa=/.**/"
+// test_cause:
+// ["aa=/.**/", "77f", "77c", "7", 77]
 
                     warn_at("expected_a_before_b", line, column, "\\", char);
                     char_after();
                     break;
                 case "+":
 
-// cause: "aa=/+/"
+// test_cause:
+// ["aa=/+/", "77f", "77c", "7", 77]
 
                     warn_at("expected_a_before_b", line, column, "\\", char);
                     char_after();
                     break;
                 case "?":
 
-// cause: "aa=/?/"
+// test_cause:
+// ["aa=/?/", "77f", "77c", "7", 77]
 
                     warn_at("expected_a_before_b", line, column, "\\", char);
                     char_after();
@@ -1075,7 +1119,8 @@ function jslint_phase2_lex(state) {
                     break;
                 case "\\":
 
-// cause: "aa=/\\/"
+// test_cause:
+// ["aa=/\\/", "77f", "77c", "7", 77]
 
                     char_after_escape("BbDdSsWw^${}[]():=!.|*+?");
                     break;
@@ -1088,7 +1133,8 @@ function jslint_phase2_lex(state) {
                 case "`":
                     if (mode_mega) {
 
-// cause: "`${/`/}`"
+// test_cause:
+// ["`${/`/}`", "77f", "77c", "7", 77]
 
                         warn_at("unexpected_a", line, column, "`");
                     }
@@ -1096,14 +1142,16 @@ function jslint_phase2_lex(state) {
                     break;
                 case "{":
 
-// cause: "aa=/{/"
+// test_cause:
+// ["aa=/{/", "77f", "77c", "7", 77]
 
                     warn_at("expected_a_before_b", line, column, "\\", char);
                     char_after();
                     break;
                 case "}":
 
-// cause: "aa=/}/"
+// test_cause:
+// ["aa=/}/", "77f", "77c", "7", 77]
 
                     warn_at("expected_a_before_b", line, column, "\\", char);
                     char_after();
@@ -1129,7 +1177,8 @@ function jslint_phase2_lex(state) {
                 case "?":
                     if (char_after("?") === "?") {
 
-// cause: "aa=/.??/"
+// test_cause:
+// ["aa=/.??/", "77f", "77c", "7", 77]
 
                         warn_at("unexpected_a", line, column, char);
                         char_after("?");
@@ -1138,19 +1187,22 @@ function jslint_phase2_lex(state) {
                 case "{":
                     if (read_digits(rx_digits, true) === 0) {
 
-// cause: "aa=/aa{/"
+// test_cause:
+// ["aa=/aa{/", "77f", "77c", "7", 77]
 
                         warn_at("expected_a_before_b", line, column, "0", ",");
                     }
                     if (char === ",") {
 
-// cause: "aa=/.{,/"
+// test_cause:
+// ["aa=/.{,/", "77f", "77c", "7", 77]
 
                         read_digits(rx_digits, true);
                     }
                     if (char_after("}") === "?") {
 
-// cause: "aa=/.{0}?/"
+// test_cause:
+// ["aa=/.{0}?/", "77f", "77c", "7", 77]
 
                         warn_at("unexpected_a", line, column, char);
                         char_after("?");
@@ -1168,7 +1220,8 @@ function jslint_phase2_lex(state) {
         char_after();
         if (char === "=") {
 
-// cause: "aa=/=/"
+// test_cause:
+// ["aa=/=/", "77f", "77c", "7", 77]
 
             warn_at("expected_a_before_b", line, column, "\\", "=");
         }
@@ -1212,13 +1265,15 @@ function jslint_phase2_lex(state) {
                 break;
             case "y":
 
-// cause: "aa=/./gimuy"
+// test_cause:
+// ["aa=/./gimuy", "77f", "77c", "7", 77]
 
                 break;
             default:
 
-// cause: "aa=/./gg"
-// cause: "aa=/./z"
+// test_cause:
+// ["aa=/./gg", "77f", "77c", "7", 77]
+// ["aa=/./z", "77f", "77c", "7", 77]
 
                 warn_at("unexpected_a", line, column, char);
             }
@@ -1228,7 +1283,8 @@ function jslint_phase2_lex(state) {
         char_before();
         if (char === "/" || char === "*") {
 
-// cause: "aa=/.//"
+// test_cause:
+// ["aa=/.//", "77f", "77c", "7", 77]
 
             return stop_at("unexpected_a", line, from, char);
         }
@@ -1237,7 +1293,8 @@ function jslint_phase2_lex(state) {
         result.value = value;
         if (mode_regexp_multiline && !flag.m) {
 
-// cause: "aa=/$^/"
+// test_cause:
+// ["aa=/$^/", "77f", "77c", "7", 77]
 
             warn_at("missing_m", line, column);
         }
@@ -1287,14 +1344,15 @@ function jslint_phase2_lex(state) {
         case "yield":
             the_token = lex_regexp();
 
-// cause: "case /./"
-// cause: "delete /./"
-// cause: "in /./"
-// cause: "instanceof /./"
-// cause: "new /./"
-// cause: "typeof /./"
-// cause: "void /./"
-// cause: "yield /./"
+// test_cause:
+// ["case /./", "77f", "77c", "7", 77]
+// ["delete /./", "77f", "77c", "7", 77]
+// ["in /./", "77f", "77c", "7", 77]
+// ["instanceof /./", "77f", "77c", "7", 77]
+// ["new /./", "77f", "77c", "7", 77]
+// ["typeof /./", "77f", "77c", "7", 77]
+// ["void /./", "77f", "77c", "7", 77]
+// ["yield /./", "77f", "77c", "7", 77]
 
             return stop("unexpected_a", the_token);
         }
@@ -1316,21 +1374,22 @@ function jslint_phase2_lex(state) {
         case "~":
             the_token = lex_regexp();
 
-// cause: "!/./"
-// cause: "%/./"
-// cause: "&/./"
-// cause: "+/./"
-// cause: "-/./"
-// cause: "0 * /./"
-// cause: "0 / /./"
-// cause: ";/./"
-// cause: "</./"
-// cause: ">/./"
-// cause: "^/./"
-// cause: "{/./"
-// cause: "|/./"
-// cause: "}/./"
-// cause: "~/./"
+// test_cause:
+// ["!/./", "77f", "77c", "7", 77]
+// ["%/./", "77f", "77c", "7", 77]
+// ["&/./", "77f", "77c", "7", 77]
+// ["+/./", "77f", "77c", "7", 77]
+// ["-/./", "77f", "77c", "7", 77]
+// ["0 * /./", "77f", "77c", "7", 77]
+// ["0 / /./", "77f", "77c", "7", 77]
+// [";/./", "77f", "77c", "7", 77]
+// ["</./", "77f", "77c", "7", 77]
+// [">/./", "77f", "77c", "7", 77]
+// ["^/./", "77f", "77c", "7", 77]
+// ["{/./", "77f", "77c", "7", 77]
+// ["|/./", "77f", "77c", "7", 77]
+// ["}/./", "77f", "77c", "7", 77]
+// ["~/./", "77f", "77c", "7", 77]
 
             warn("wrap_regexp", the_token);
             return the_token;
@@ -1341,12 +1400,13 @@ function jslint_phase2_lex(state) {
         case "?":
         case "[":
 
-// cause: "(/./"
-// cause: ",/./"
-// cause: ":/./"
-// cause: "=/./"
-// cause: "?/./"
-// cause: "aa[/./"
+// test_cause:
+// ["(/./", "77f", "77c", "7", 77]
+// [",/./", "77f", "77c", "7", 77]
+// [":/./", "77f", "77c", "7", 77]
+// ["=/./", "77f", "77c", "7", 77]
+// ["?/./", "77f", "77c", "7", 77]
+// ["aa[/./", "77f", "77c", "7", 77]
 
             return lex_regexp();
         }
@@ -1366,7 +1426,8 @@ function jslint_phase2_lex(state) {
         let the_token;
         if (!option_dict.single && quote === "'") {
 
-// cause: "''"
+// test_cause:
+// ["''", "77f", "77c", "7", 77]
 
             warn_at("use_double", line, column);
         }
@@ -1379,7 +1440,8 @@ function jslint_phase2_lex(state) {
             switch (char) {
             case "":
 
-// cause: "\""
+// test_cause:
+// ["\"", "77f", "77c", "7", 77]
 
                 return stop_at("unclosed_string", line, column);
             case "\\":
@@ -1388,7 +1450,8 @@ function jslint_phase2_lex(state) {
             case "`":
                 if (mode_mega) {
 
-// cause: "`${\"`\"}`"
+// test_cause:
+// ["`${\"`\"}`", "77f", "77c", "7", 77]
 
                     warn_at("unexpected_a", line, column, "`");
                 }
@@ -1424,12 +1487,14 @@ function jslint_phase2_lex(state) {
                     return (
                         mode_mega
 
-// cause: "`${//}`"
+// test_cause:
+// ["`${//}`", "77f", "77c", "7", 77]
 
                         ? stop_at("unclosed_mega", line_mega, from_mega)
                         : line_disable !== undefined
 
-// cause: "/*jslint-disable*/"
+// test_cause:
+// ["/*jslint-disable*/", "77f", "77c", "7", 77]
 
                         ? stop_at("unclosed_disable", line_disable)
                         : token_create("(end)")
@@ -1447,7 +1512,8 @@ function jslint_phase2_lex(state) {
 
             if (!match) {
 
-// cause: "#"
+// test_cause:
+// ["#", "77f", "77c", "7", 77]
 
                 return stop_at(
                     "unexpected_char_a",
@@ -1664,11 +1730,13 @@ function jslint_phase3_parse(state) {
             return (
                 match === undefined
 
-// cause: "()"
+// test_cause:
+// ["()", "77f", "77c", "7", 77]
 
                 ? stop("expected_a_b", token_nxt, id, artifact())
 
-// cause: "{\"aa\":0"
+// test_cause:
+// ["{\"aa\":0", "77f", "77c", "7", 77]
 
                 : stop(
                     "expected_a_b_from_c_d",
@@ -1696,7 +1764,8 @@ function jslint_phase3_parse(state) {
             }
             if (state.mode_json) {
 
-// cause: "[//]"
+// test_cause:
+// ["[//]", "77f", "77c", "7", 77]
 
                 warn("unexpected_a");
             }
@@ -1733,7 +1802,8 @@ function jslint_phase3_parse(state) {
 
         if (syntax_dict[id] !== undefined && id !== "ignore") {
 
-// cause: "let undefined"
+// test_cause:
+// ["let undefined", "77f", "77c", "7", 77]
 
             warn("reserved_a", name);
         } else {
@@ -1743,7 +1813,8 @@ function jslint_phase3_parse(state) {
             earlier = functionage.context[id] || catchage.context[id];
             if (earlier) {
 
-// cause: "let aa;let aa"
+// test_cause:
+// ["let aa;let aa", "77f", "77c", "7", 77]
 
                 warn("redefinition_a_b", name, name.id, earlier.line);
 
@@ -1760,7 +1831,8 @@ function jslint_phase3_parse(state) {
                     if (id === "ignore") {
                         if (earlier.role === "variable") {
 
-// cause: "let ignore;function aa(ignore){}"
+// test_cause:
+// ["let ignore;function aa(ignore){}", "77f", "77c", "7", 77]
 
                             warn("unexpected_a", name);
                         }
@@ -1773,8 +1845,9 @@ function jslint_phase3_parse(state) {
                             && role !== "parameter" && role !== "function"
                         ) {
 
-// cause: "function aa(){try{aa();}catch(aa){aa();}}"
-// cause: "function aa(){var aa;}"
+// test_cause:
+// ["function aa(){try{aa();}catch(aa){aa();}}", "77f", "77c", "7", 77]
+// ["function aa(){var aa;}", "77f", "77c", "7", 77]
 
                             warn(
                                 "redefinition_a_b",
@@ -1831,20 +1904,23 @@ function jslint_phase3_parse(state) {
         the_symbol = syntax_dict[token_now.id];
         if (the_symbol !== undefined && the_symbol.nud !== undefined) {
 
-// cause: "0"
+// test_cause:
+// ["0", "77f", "77c", "7", 77]
 
             left = the_symbol.nud();
         } else if (token_now.identifier) {
 
-// cause: "aa"
+// test_cause:
+// ["aa", "77f", "77c", "7", 77]
 
             left = token_now;
             left.arity = "variable";
         } else {
 
-// cause: "!"
-// cause: "/./"
-// cause: "let aa=`${}`;"
+// test_cause:
+// ["!", "77f", "77c", "7", 77]
+// ["/./", "77f", "77c", "7", 77]
+// ["let aa=`${}`;", "77f", "77c", "7", 77]
 
             return stop("unexpected_a", token_now);
         }
@@ -1873,9 +1949,10 @@ function jslint_phase3_parse(state) {
         const the_paren = token_nxt;
         let the_value;
 
-// cause: "do{}while()"
-// cause: "if(){}"
-// cause: "while(){}"
+// test_cause:
+// ["do{}while()", "77f", "77c", "7", 77]
+// ["if(){}", "77f", "77c", "7", 77]
+// ["while(){}", "77f", "77c", "7", 77]
 
         the_paren.free = true;
         advance("(");
@@ -1883,7 +1960,8 @@ function jslint_phase3_parse(state) {
         advance(")");
         if (the_value.wrapped === true) {
 
-// cause: "while((0)){}"
+// test_cause:
+// ["while((0)){}", "77f", "77c", "7", 77]
 
             warn("unexpected_a", the_paren);
         }
@@ -1938,22 +2016,23 @@ function jslint_phase3_parse(state) {
             break;
         case "~":
 
-// cause: "if(\"aa\"){}"
-// cause: "if(0%0){}"
-// cause: "if(0&0){}"
-// cause: "if(0){}"
-// cause: "if(0*0){}"
-// cause: "if(0+0){}"
-// cause: "if(0-0){}"
-// cause: "if(0/0){}"
-// cause: "if(0<<0){}"
-// cause: "if(0>>0){}"
-// cause: "if(0>>>0){}"
-// cause: "if(0?0:0){}"
-// cause: "if(0^0){}"
-// cause: "if(0|0){}"
-// cause: "if(typeof 0){}"
-// cause: "if(~0){}"
+// test_cause:
+// ["if(0%0){}", "77f", "77c", "7", 77]
+// ["if(0&0){}", "77f", "77c", "7", 77]
+// ["if(0){}", "77f", "77c", "7", 77]
+// ["if(0*0){}", "77f", "77c", "7", 77]
+// ["if(0+0){}", "77f", "77c", "7", 77]
+// ["if(0-0){}", "77f", "77c", "7", 77]
+// ["if(0/0){}", "77f", "77c", "7", 77]
+// ["if(0<<0){}", "77f", "77c", "7", 77]
+// ["if(0>>0){}", "77f", "77c", "7", 77]
+// ["if(0>>>0){}", "77f", "77c", "7", 77]
+// ["if(0?0:0){}", "77f", "77c", "7", 77]
+// ["if(0^0){}", "77f", "77c", "7", 77]
+// ["if(0|0){}", "77f", "77c", "7", 77]
+// ["if(\"aa\"){}", "77f", "77c", "7", 77]
+// ["if(typeof 0){}", "77f", "77c", "7", 77]
+// ["if(~0){}", "77f", "77c", "7", 77]
 
             warn("unexpected_a", the_value);
             break;
@@ -1969,7 +2048,8 @@ function jslint_phase3_parse(state) {
             advance(";");
         } else {
 
-// cause: "0"
+// test_cause:
+// ["0", "77f", "77c", "7", 77]
 
             warn_at(
                 "expected_a_b",
@@ -1997,7 +2077,8 @@ function jslint_phase3_parse(state) {
             the_label = token_now;
             if (the_label.id === "ignore") {
 
-// cause: "ignore:"
+// test_cause:
+// ["ignore:", "77f", "77c", "7", 77]
 
                 warn("unexpected_a", the_label);
             }
@@ -2019,7 +2100,8 @@ function jslint_phase3_parse(state) {
             }
             advance();
 
-// cause: "aa:"
+// test_cause:
+// ["aa:", "77f", "77c", "7", 77]
 
             warn("unexpected_label_a", the_label);
         }
@@ -2049,7 +2131,8 @@ function jslint_phase3_parse(state) {
             functionage.last_statement = the_statement;
             if (the_statement.wrapped && the_statement.id !== "(") {
 
-// cause: "(0)"
+// test_cause:
+// ["(0)", "77f", "77c", "7", 77]
 
                 warn("unexpected_a", first);
             }
@@ -2084,11 +2167,12 @@ function jslint_phase3_parse(state) {
                 return statement_list;
             case "}":
 
-// cause: ";"
-// cause: "case"
-// cause: "default"
-// cause: "else"
-// cause: "}"
+// test_cause:
+// [";", "77f", "77c", "7", 77]
+// ["case", "77f", "77c", "7", 77]
+// ["default", "77f", "77c", "7", 77]
+// ["else", "77f", "77c", "7", 77]
+// ["}", "77f", "77c", "7", 77]
 
                 return statement_list;
             }
@@ -2096,7 +2180,8 @@ function jslint_phase3_parse(state) {
             statement_list.push(a_statement);
             if (disrupt) {
 
-// cause: "while(0){break;0;}"
+// test_cause:
+// ["while(0){break;0;}", "77f", "77c", "7", 77]
 
                 warn("unreachable_a", a_statement);
             }
@@ -2110,7 +2195,8 @@ function jslint_phase3_parse(state) {
 
         if (functionage === token_global) {
 
-// cause: "while(0){}"
+// test_cause:
+// ["while(0){}", "77f", "77c", "7", 77]
 
             warn("unexpected_at_top_level_a", thing);
         }
@@ -2152,7 +2238,8 @@ function jslint_phase3_parse(state) {
         if (stmts.length === 0) {
             if (!option_dict.devel && special !== "ignore") {
 
-// cause: "function aa(){}"
+// test_cause:
+// ["function aa(){}", "77f", "77c", "7", 77]
 
                 warn("empty_block", the_block);
             }
@@ -2180,7 +2267,8 @@ function jslint_phase3_parse(state) {
             && the_thing.id !== "{"
         ) {
 
-// cause: "0=0"
+// test_cause:
+// ["0=0", "77f", "77c", "7", 77]
 
             warn("bad_assignment_a", the_thing);
             return false;
@@ -2313,7 +2401,8 @@ function jslint_phase3_parse(state) {
         const the_symbol = symbol(id, bp);
         the_symbol.led = function (left) {
 
-// cause: "0**0"
+// test_cause:
+// ["0**0", "77f", "77c", "7", 77]
 
             const the_token = token_now;
             the_token.arity = "binary";
@@ -2401,7 +2490,8 @@ function jslint_phase3_parse(state) {
             }
         } else if (!name.identifier) {
 
-// cause: "let aa={0:0}"
+// test_cause:
+// ["let aa={0:0}", "77f", "77c", "7", 77]
 
             return stop("expected_identifier_a", name);
         }
@@ -2419,7 +2509,8 @@ function jslint_phase3_parse(state) {
             if (state.mode_property) {
                 if (tenure[id] !== true) {
 
-// cause: "/*property aa*/\naa.bb"
+// test_cause:
+// ["/*property aa*/\naa.bb", "77f", "77c", "7", 77]
 
                     warn("unregistered_property_a", name);
                 }
@@ -2432,11 +2523,12 @@ function jslint_phase3_parse(state) {
                 ).test(id)
             ) {
 
-// cause: "aa.$"
-// cause: "aa._"
-// cause: "aa._aa"
-// cause: "aa.aaSync"
-// cause: "aa.aa_"
+// test_cause:
+// ["aa.$", "77f", "77c", "7", 77]
+// ["aa._", "77f", "77c", "7", 77]
+// ["aa._aa", "77f", "77c", "7", 77]
+// ["aa.aaSync", "77f", "77c", "7", 77]
+// ["aa.aa_", "77f", "77c", "7", 77]
 
                 warn("weird_property_a", name);
             }
@@ -2460,7 +2552,8 @@ function jslint_phase3_parse(state) {
             the_token.expression = [left, second, parse_expression(10)];
             if (token_nxt.id !== ")") {
 
-// cause: "0?0:0"
+// test_cause:
+// ["0?0:0", "77f", "77c", "7", 77]
 
                 warn("use_open", the_token);
             }
@@ -2503,7 +2596,8 @@ function jslint_phase3_parse(state) {
     constant("(string)", "string");
     constant("arguments", "object", function () {
 
-// cause: "arguments"
+// test_cause:
+// ["arguments", "77f", "77c", "7", 77]
 
         warn("unexpected_a", token_now);
         return token_now;
@@ -2511,12 +2605,14 @@ function jslint_phase3_parse(state) {
     constant("eval", "function", function () {
         if (!option_dict.eval) {
 
-// cause: "eval"
+// test_cause:
+// ["eval", "77f", "77c", "7", 77]
 
             warn("unexpected_a", token_now);
         } else if (token_nxt.id !== "(") {
 
-// cause: "/*jslint eval*/\neval"
+// test_cause:
+// ["/*jslint eval*/\neval", "77f", "77c", "7", 77]
 
             warn("expected_a_before_b", token_nxt, "(", artifact());
         }
@@ -2526,12 +2622,14 @@ function jslint_phase3_parse(state) {
     constant("Function", "function", function () {
         if (!option_dict.eval) {
 
-// cause: "Function"
+// test_cause:
+// ["Function", "77f", "77c", "7", 77]
 
             warn("unexpected_a", token_now);
         } else if (token_nxt.id !== "(") {
 
-// cause: "/*jslint eval*/\nFunction"
+// test_cause:
+// ["/*jslint eval*/\nFunction", "77f", "77c", "7", 77]
 
             warn("expected_a_before_b", token_nxt, "(", artifact());
         }
@@ -2539,7 +2637,8 @@ function jslint_phase3_parse(state) {
     });
     constant("ignore", "undefined", function () {
 
-// cause: "ignore"
+// test_cause:
+// ["ignore", "77f", "77c", "7", 77]
 
         warn("unexpected_a", token_now);
         return token_now;
@@ -2547,14 +2646,16 @@ function jslint_phase3_parse(state) {
     constant("Infinity", "number", Infinity);
     constant("isFinite", "function", function () {
 
-// cause: "isFinite"
+// test_cause:
+// ["isFinite", "77f", "77c", "7", 77]
 
         warn("expected_a_b", token_now, "Number.isFinite", "isFinite");
         return token_now;
     });
     constant("isNaN", "function", function () {
 
-// cause: "isNaN(0)"
+// test_cause:
+// ["isNaN(0)", "77f", "77c", "7", 77]
 
         warn("number_isNaN", token_now);
         return token_now;
@@ -2564,7 +2665,8 @@ function jslint_phase3_parse(state) {
     constant("this", "object", function () {
         if (!option_dict.this) {
 
-// cause: "this"
+// test_cause:
+// ["this", "77f", "77c", "7", 77]
 
             warn("unexpected_a", token_now);
         }
@@ -2617,8 +2719,9 @@ function jslint_phase3_parse(state) {
         let the_argument;
         if (left.id !== "function") {
 
-// cause: "(0?0:0)()"
-// cause: "0()"
+// test_cause:
+// ["(0?0:0)()", "77f", "77c", "7", 77]
+// ["0()", "77f", "77c", "7", 77]
 
             left_check(left, the_paren);
         }
@@ -2649,12 +2752,14 @@ function jslint_phase3_parse(state) {
         advance(")", the_paren);
         if (the_paren.expression.length === 2) {
 
-// cause: "aa(0)"
+// test_cause:
+// ["aa(0)", "77f", "77c", "7", 77]
 
             the_paren.free = true;
             if (the_argument.wrapped === true) {
 
-// cause: "aa((0))"
+// test_cause:
+// ["aa((0))", "77f", "77c", "7", 77]
 
                 warn("unexpected_a", the_paren);
             }
@@ -2663,8 +2768,9 @@ function jslint_phase3_parse(state) {
             }
         } else {
 
-// cause: "aa()"
-// cause: "aa(0,0)"
+// test_cause:
+// ["aa()", "77f", "77c", "7", 77]
+// ["aa(0,0)", "77f", "77c", "7", 77]
 
             the_paren.free = false;
         }
@@ -2695,13 +2801,15 @@ function jslint_phase3_parse(state) {
             )
         ) {
 
-// cause: "\"\".aa"
+// test_cause:
+// ["\"\".aa", "77f", "77c", "7", 77]
 
             left_check(left, the_token);
         }
         if (!name.identifier) {
 
-// cause: "aa.0"
+// test_cause:
+// ["aa.0", "77f", "77c", "7", 77]
 
             stop("expected_identifier_a");
         }
@@ -2733,7 +2841,8 @@ function jslint_phase3_parse(state) {
                 )
             )
 
-// cause: "(0+0)?.0"
+// test_cause:
+// ["(0+0)?.0", "77f", "77c", "7", 77]
 
             && (left.id !== "+" || name.id !== "slice")
             && (
@@ -2742,15 +2851,17 @@ function jslint_phase3_parse(state) {
             )
         ) {
 
-// cause: "\"aa\"?.0"
-// cause: "(/./)?.0"
-// cause: "aa=[]?.aa"
+// test_cause:
+// ["(/./)?.0", "77f", "77c", "7", 77]
+// ["\"aa\"?.0", "77f", "77c", "7", 77]
+// ["aa=[]?.aa", "77f", "77c", "7", 77]
 
             left_check(left, the_token);
         }
         if (!name.identifier) {
 
-// cause: "aa?.0"
+// test_cause:
+// ["aa?.0", "77f", "77c", "7", 77]
 
             stop("expected_identifier_a");
         }
@@ -2771,13 +2882,15 @@ function jslint_phase3_parse(state) {
             name = survey(the_subscript);
             if (rx_identifier.test(name)) {
 
-// cause: "aa[`aa`]"
+// test_cause:
+// ["aa[`aa`]", "77f", "77c", "7", 77]
 
                 warn("subscript_a", the_subscript, name);
             }
         }
 
-// cause: "0[0]"
+// test_cause:
+// ["0[0]", "77f", "77c", "7", 77]
 
         left_check(left, the_token);
         the_token.expression = [left, the_subscript];
@@ -2786,7 +2899,8 @@ function jslint_phase3_parse(state) {
     });
     infix("=>", 170, function (left) {
 
-// cause: "aa=>0"
+// test_cause:
+// ["aa=>0", "77f", "77c", "7", 77]
 
         return stop("wrap_parameter", left);
     });
@@ -2807,7 +2921,8 @@ function jslint_phase3_parse(state) {
                 }
                 advance("${");
 
-// cause: "let aa=`${}`;"
+// test_cause:
+// ["let aa=`${}`;", "77f", "77c", "7", 77]
 
                 the_tick.expression.push(parse_expression(0));
                 advance("}");
@@ -2820,7 +2935,8 @@ function jslint_phase3_parse(state) {
     infix("`", 160, function (left) {
         const the_tick = parse_tick();
 
-// cause: "0``"
+// test_cause:
+// ["0``", "77f", "77c", "7", 77]
 
         left_check(left, the_tick);
         the_tick.expression = [left].concat(the_tick.expression);
@@ -2863,7 +2979,8 @@ function jslint_phase3_parse(state) {
                 advance(",");
                 if (token_nxt.id === "]") {
 
-// cause: let aa=[0,]
+// test_cause:
+// ["let aa=[0,]", "77f", "77c", "7", 77]
 
                     warn("unexpected_a", token_now);
                     break;
@@ -2875,13 +2992,15 @@ function jslint_phase3_parse(state) {
     });
     prefix("/=", function () {
 
-// cause: "/="
+// test_cause:
+// ["/=", "77f", "77c", "7", 77]
 
         stop("expected_a_b", token_now, "/\\=", "/=");
     });
     prefix("=>", function () {
 
-// cause: "=>0"
+// test_cause:
+// ["=>0", "77f", "77c", "7", 77]
 
         return stop("expected_a_before_b", token_now, "()", "=>");
     });
@@ -2891,7 +3010,8 @@ function jslint_phase3_parse(state) {
         right = parse_expression(160);
         if (token_nxt.id !== "(") {
 
-// cause: "new aa"
+// test_cause:
+// ["new aa", "77f", "77c", "7", 77]
 
             warn("expected_a_before_b", token_nxt, "()", artifact());
         }
@@ -2902,8 +3022,9 @@ function jslint_phase3_parse(state) {
     prefix("void", function () {
         const the_void = token_now;
 
-// cause: "void"
-// cause: "void 0"
+// test_cause:
+// ["void 0", "77f", "77c", "7", 77]
+// ["void", "77f", "77c", "7", 77]
 
         warn("unexpected_a", the_void);
         the_void.expression = parse_expression(0);
@@ -2921,7 +3042,8 @@ function jslint_phase3_parse(state) {
                 if (token_nxt.id === "{") {
                     if (optional !== undefined) {
 
-// cause: "function aa(aa=0,{}){}"
+// test_cause:
+// ["function aa(aa=0,{}){}", "77f", "77c", "7", 77]
 
                         warn(
                             "required_a_optional_b",
@@ -2938,8 +3060,9 @@ function jslint_phase3_parse(state) {
                         let subparam = token_nxt;
                         if (!subparam.identifier) {
 
-// cause: "function aa(aa=0,{}){}"
-// cause: "function aa({0}){}"
+// test_cause:
+// ["function aa(aa=0,{}){}", "77f", "77c", "7", 77]
+// ["function aa({0}){}", "77f", "77c", "7", 77]
 
                             return stop("expected_identifier_a");
                         }
@@ -2953,7 +3076,8 @@ function jslint_phase3_parse(state) {
                             subparam = token_now;
                             if (!subparam.identifier) {
 
-// cause: "function aa({aa:0}){}"
+// test_cause:
+// ["function aa({aa:0}){}", "77f", "77c", "7", 77]
 
                                 return stop(
                                     "expected_identifier_a",
@@ -2962,7 +3086,8 @@ function jslint_phase3_parse(state) {
                             }
                         }
 
-// cause: "function aa({aa=aa},aa){}"
+// test_cause:
+// ["function aa({aa=aa},aa){}", "77f", "77c", "7", 77]
 
                         if (token_nxt.id === "=") {
                             advance("=");
@@ -2977,7 +3102,8 @@ function jslint_phase3_parse(state) {
                         }
                     }());
 
-// cause: "function aa({bb,aa}){}"
+// test_cause:
+// ["function aa({bb,aa}){}", "77f", "77c", "7", 77]
 
                     list.push(param);
                     warn_if_unordered("parameter", param.names);
@@ -2991,7 +3117,8 @@ function jslint_phase3_parse(state) {
                 } else if (token_nxt.id === "[") {
                     if (optional !== undefined) {
 
-// cause: "function aa(aa=0,[]){}"
+// test_cause:
+// ["function aa(aa=0,[]){}", "77f", "77c", "7", 77]
 
                         warn(
                             "required_a_optional_b",
@@ -3008,14 +3135,16 @@ function jslint_phase3_parse(state) {
                         const subparam = token_nxt;
                         if (!subparam.identifier) {
 
-// cause: "function aa(aa=0,[]){}"
+// test_cause:
+// ["function aa(aa=0,[]){}", "77f", "77c", "7", 77]
 
                             return stop("expected_identifier_a");
                         }
                         advance();
                         param.names.push(subparam);
 
-// cause: "function aa([aa=aa],aa){}"
+// test_cause:
+// ["function aa([aa=aa],aa){}", "77f", "77c", "7", 77]
 
                         if (token_nxt.id === "=") {
                             advance("=");
@@ -3041,7 +3170,8 @@ function jslint_phase3_parse(state) {
                         advance("...");
                         if (optional !== undefined) {
 
-// cause: "function aa(aa=0,...){}"
+// test_cause:
+// ["function aa(aa=0,...){}", "77f", "77c", "7", 77]
 
                             warn(
                                 "required_a_optional_b",
@@ -3053,7 +3183,8 @@ function jslint_phase3_parse(state) {
                     }
                     if (!token_nxt.identifier) {
 
-// cause: "function aa(0){}"
+// test_cause:
+// ["function aa(0){}", "77f", "77c", "7", 77]
 
                         return stop("expected_identifier_a");
                     }
@@ -3071,7 +3202,8 @@ function jslint_phase3_parse(state) {
                         } else {
                             if (optional !== undefined) {
 
-// cause: "function aa(aa=0,bb){}"
+// test_cause:
+// ["function aa(aa=0,bb){}", "77f", "77c", "7", 77]
 
                                 warn(
                                     "required_a_optional_b",
@@ -3105,8 +3237,9 @@ function jslint_phase3_parse(state) {
             if (the_function.arity === "statement") {
                 if (!token_nxt.identifier) {
 
-// cause: "function(){}"
-// cause: "function*aa(){}"
+// test_cause:
+// ["function(){}", "77f", "77c", "7", 77]
+// ["function*aa(){}", "77f", "77c", "7", 77]
 
                     return stop("expected_identifier_a");
                 }
@@ -3146,7 +3279,8 @@ function jslint_phase3_parse(state) {
 
         if (functionage.loop > 0) {
 
-// cause: "while(0){aa.map(function(){});}"
+// test_cause:
+// ["while(0){aa.map(function(){});}", "77f", "77c", "7", 77]
 
             warn("function_in_loop", the_function);
         }
@@ -3170,7 +3304,8 @@ function jslint_phase3_parse(state) {
         functionage = the_function;
         if (the_function.arity !== "statement" && typeof name === "object") {
 
-// cause: "let aa=function bb(){return;};"
+// test_cause:
+// ["let aa=function bb(){return;};", "77f", "77c", "7", 77]
 
             enroll(name, "function", true);
             name.dead = false;
@@ -3182,7 +3317,8 @@ function jslint_phase3_parse(state) {
 
         advance("(");
 
-// cause: "function(){}"
+// test_cause:
+// ["function(){}", "77f", "77c", "7", 77]
 
         token_now.free = false;
         token_now.arity = "function";
@@ -3203,7 +3339,8 @@ function jslint_phase3_parse(state) {
             && token_nxt.line === token_now.line
         ) {
 
-// cause: "function aa(){}0"
+// test_cause:
+// ["function aa(){}0", "77f", "77c", "7", 77]
 
             return stop("unexpected_a");
         }
@@ -3213,7 +3350,8 @@ function jslint_phase3_parse(state) {
             || token_nxt.id === "["
         ) {
 
-// cause: "function aa(){}\n[]"
+// test_cause:
+// ["function aa(){}\n[]", "77f", "77c", "7", 77]
 
             warn("unexpected_a");
         }
@@ -3236,7 +3374,8 @@ function jslint_phase3_parse(state) {
         parse_function();
         if (the_function.async === 1) {
 
-// cause: "async function aa(){}"
+// test_cause:
+// ["async function aa(){}", "77f", "77c", "7", 77]
 
             warn("missing_await_statement", the_function);
         }
@@ -3247,9 +3386,10 @@ function jslint_phase3_parse(state) {
         const the_await = token_now;
         if (functionage.async === 0) {
 
-// cause: "await"
-// cause: "function aa(){aa=await 0;}"
-// cause: "function aa(){await 0;}"
+// test_cause:
+// ["await", "77f", "77c", "7", 77]
+// ["function aa(){aa=await 0;}", "77f", "77c", "7", 77]
+// ["function aa(){await 0;}", "77f", "77c", "7", 77]
 
             warn("unexpected_a", the_await);
         } else {
@@ -3278,7 +3418,8 @@ function jslint_phase3_parse(state) {
         function_list.push(the_fart);
         if (functionage.loop > 0) {
 
-// cause: "while(0){aa.map(()=>0);}"
+// test_cause:
+// ["while(0){aa.map(()=>0);}", "77f", "77c", "7", 77]
 
             warn("function_in_loop", the_fart);
         }
@@ -3300,13 +3441,15 @@ function jslint_phase3_parse(state) {
         the_fart.signature = pl[1];
         the_fart.parameters.forEach(function (name) {
 
-// cause: "(aa)=>{}"
+// test_cause:
+// ["(aa)=>{}", "77f", "77c", "7", 77]
 
             enroll(name, "parameter", true);
         });
         if (token_nxt.id === "{") {
 
-// cause: "()=>{}"
+// test_cause:
+// ["()=>{}", "77f", "77c", "7", 77]
 
             warn("expected_a_b", the_fart, "function", "=>");
             the_fart.block = block("body");
@@ -3331,19 +3474,22 @@ function jslint_phase3_parse(state) {
             || (token_nxt.identifier && (cadet === "," || cadet === "="))
         ) {
 
-// cause: "()=>0"
+// test_cause:
+// ["()=>0", "77f", "77c", "7", 77]
 
             the_paren.free = false;
             return fart(parse_function_arg());
         }
 
-// cause: "(0)"
+// test_cause:
+// ["(0)", "77f", "77c", "7", 77]
 
         the_paren.free = true;
         the_value = parse_expression(0);
         if (the_value.wrapped === true) {
 
-// cause: "((0))"
+// test_cause:
+// ["((0))", "77f", "77c", "7", 77]
 
             warn("unexpected_a", the_paren);
         }
@@ -3353,18 +3499,21 @@ function jslint_phase3_parse(state) {
             if (the_value.arity !== "variable") {
                 if (the_value.id === "{" || the_value.id === "[") {
 
-// cause: "([])=>0"
-// cause: "({})=>0"
+// test_cause:
+// ["([])=>0", "77f", "77c", "7", 77]
+// ["({})=>0", "77f", "77c", "7", 77]
 
                     warn("expected_a_before_b", the_paren, "function", "(");
 
-// cause: "([])=>0"
-// cause: "({})=>0"
+// test_cause:
+// ["([])=>0", "77f", "77c", "7", 77]
+// ["({})=>0", "77f", "77c", "7", 77]
 
                     return stop("expected_a_b", token_nxt, "{", "=>");
                 }
 
-// cause: "(0)=>0"
+// test_cause:
+// ["(0)=>0", "77f", "77c", "7", 77]
 
                 return stop("expected_identifier_a", the_value);
             }
@@ -3397,7 +3546,8 @@ function jslint_phase3_parse(state) {
                 ) {
                     if (!option_dict.getset) {
 
-// cause: "aa={get aa(){}}"
+// test_cause:
+// ["aa={get aa(){}}", "77f", "77c", "7", 77]
 
                         warn("unexpected_a", name);
                     }
@@ -3408,7 +3558,8 @@ function jslint_phase3_parse(state) {
                     id = survey(name);
                     if (seen[full] === true || seen[id] === true) {
 
-// cause: "aa={get aa(){},get aa(){}}"
+// test_cause:
+// ["aa={get aa(){},get aa(){}}", "77f", "77c", "7", 77]
 
                         warn("duplicate_a", name);
                     }
@@ -3418,7 +3569,8 @@ function jslint_phase3_parse(state) {
                     id = survey(name);
                     if (typeof seen[id] === "boolean") {
 
-// cause: "aa={aa,aa}"
+// test_cause:
+// ["aa={aa,aa}", "77f", "77c", "7", 77]
 
                         warn("duplicate_a", name);
                     }
@@ -3428,7 +3580,8 @@ function jslint_phase3_parse(state) {
                     if (token_nxt.id === "}" || token_nxt.id === ",") {
                         if (typeof extra === "string") {
 
-// cause: "aa={get aa}"
+// test_cause:
+// ["aa={get aa}", "77f", "77c", "7", 77]
 
                             advance("(");
                         }
@@ -3442,11 +3595,13 @@ function jslint_phase3_parse(state) {
                             name: (
                                 typeof extra === "string"
 
-// cause: "aa={get aa(){}}"
+// test_cause:
+// ["aa={get aa(){}}", "77f", "77c", "7", 77]
 
                                 ? extra
 
-// cause: "aa={aa()}"
+// test_cause:
+// ["aa={aa()}", "77f", "77c", "7", 77]
 
                                 : id
                             ),
@@ -3455,7 +3610,8 @@ function jslint_phase3_parse(state) {
                     } else {
                         if (typeof extra === "string") {
 
-// cause: "aa={get aa.aa}"
+// test_cause:
+// ["aa={get aa.aa}", "77f", "77c", "7", 77]
 
                             advance("(");
                         }
@@ -3467,7 +3623,8 @@ function jslint_phase3_parse(state) {
                             && value.id !== "function"
                         ) {
 
-// cause: "aa={aa:aa}"
+// test_cause:
+// ["aa={aa:aa}", "77f", "77c", "7", 77]
 
                             warn("unexpected_a", the_colon, ": " + name.id);
                         }
@@ -3479,7 +3636,8 @@ function jslint_phase3_parse(state) {
                     the_brace.expression.push(value);
                 } else {
 
-// cause: aa={"aa":0}
+// test_cause:
+// ["aa={\"aa\":0}", "77f", "77c", "7", 77]
 
                     advance(":");
                     value = parse_expression(0);
@@ -3490,12 +3648,14 @@ function jslint_phase3_parse(state) {
                     break;
                 }
 
-// cause: aa={"aa":0,"bb":0}
+// test_cause:
+// ["aa={\"aa\":0,\"bb\":0}", "77f", "77c", "7", 77]
 
                 advance(",");
                 if (token_nxt.id === "}") {
 
-// cause: let aa={aa:0,}
+// test_cause:
+// ["let aa={aa:0,}", "77f", "77c", "7", 77]
 
                     warn("unexpected_a", token_now);
                     break;
@@ -3503,7 +3663,8 @@ function jslint_phase3_parse(state) {
             }
         }
 
-// cause: "aa={bb,aa}"
+// test_cause:
+// ["aa={bb,aa}", "77f", "77c", "7", 77]
 
         warn_if_unordered(
             "property",
@@ -3519,15 +3680,17 @@ function jslint_phase3_parse(state) {
 
     stmt(";", function () {
 
-// cause: ";"
+// test_cause:
+// [";", "77f", "77c", "7", 77]
 
         warn("unexpected_a", token_now);
         return token_now;
     });
     stmt("{", function () {
 
-// cause: ";{}"
-// cause: "class aa{}"
+// test_cause:
+// [";{}", "77f", "77c", "7", 77]
+// ["class aa{}", "77f", "77c", "7", 77]
 
         warn("naked_block", token_now);
         return block("naked");
@@ -3542,7 +3705,8 @@ function jslint_phase3_parse(state) {
             || functionage.finally > 0
         ) {
 
-// cause: "break"
+// test_cause:
+// ["break", "77f", "77c", "7", 77]
 
             warn("unexpected_a", the_break);
         }
@@ -3556,12 +3720,14 @@ function jslint_phase3_parse(state) {
             ) {
                 if (the_label !== undefined && the_label.dead) {
 
-// cause: "aa:{function aa(aa){break aa;}}"
+// test_cause:
+// ["aa:{function aa(aa){break aa;}}", "77f", "77c", "7", 77]
 
                     warn("out_of_scope_a");
                 } else {
 
-// cause: "aa:{break aa;}"
+// test_cause:
+// ["aa:{break aa;}", "77f", "77c", "7", 77]
 
                     warn("not_label_a");
                 }
@@ -3593,7 +3759,8 @@ function jslint_phase3_parse(state) {
                 mode_var = the_variable.id;
             } else if (the_variable.id !== mode_var) {
 
-// cause: "let aa;var aa"
+// test_cause:
+// ["let aa;var aa", "77f", "77c", "7", 77]
 
                 warn("expected_a_b", the_variable, mode_var, the_variable.id);
             }
@@ -3603,7 +3770,8 @@ function jslint_phase3_parse(state) {
 
         if (functionage.switch > 0) {
 
-// cause: "switch(0){case 0:var aa}"
+// test_cause:
+// ["switch(0){case 0:var aa}", "77f", "77c", "7", 77]
 
             warn("var_switch", the_variable);
         }
@@ -3616,7 +3784,8 @@ function jslint_phase3_parse(state) {
             break;
         case "import":
 
-// cause: "import aa from \"aa\";\nlet bb=0;"
+// test_cause:
+// ["import aa from \"aa\";\nlet bb=0;", "77f", "77c", "7", 77]
 
             break;
         case "let":
@@ -3624,9 +3793,10 @@ function jslint_phase3_parse(state) {
             break;
         case "var":
 
-// cause: "const aa=0;const bb=0;"
-// cause: "let aa=0;let bb=0;"
-// cause: "var aa=0;var bb=0;"
+// test_cause:
+// ["const aa=0;const bb=0;", "77f", "77c", "7", 77]
+// ["let aa=0;let bb=0;", "77f", "77c", "7", 77]
+// ["var aa=0;var bb=0;", "77f", "77c", "7", 77]
 
             variable_prv = functionage.last_statement;
             break;
@@ -3638,10 +3808,11 @@ function jslint_phase3_parse(state) {
                 || the_variable.id === "var"
             ) {
 
-// cause: "/*jslint beta*/\nconsole.log();let aa=0;"
-// cause: "console.log();var aa=0;"
-// cause: "try{aa();}catch(aa){var aa=0;}"
-// cause: "while(0){var aa;}"
+// test_cause:
+// ["/*jslint beta*/\nconsole.log();let aa=0;", "77f", "77c", "7", 77]
+// ["console.log();var aa=0;", "77f", "77c", "7", 77]
+// ["try{aa();}catch(aa){var aa=0;}", "77f", "77c", "7", 77]
+// ["while(0){var aa;}", "77f", "77c", "7", 77]
 
                 warn("var_on_top", token_now);
             }
@@ -3650,7 +3821,8 @@ function jslint_phase3_parse(state) {
             if (token_nxt.id === "{") {
                 if (the_variable.id === "var") {
 
-// cause: "var{aa}=0"
+// test_cause:
+// ["var{aa}=0", "77f", "77c", "7", 77]
 
                     warn("unexpected_a", the_variable);
                 }
@@ -3660,7 +3832,8 @@ function jslint_phase3_parse(state) {
                     name = token_nxt;
                     if (!name.identifier) {
 
-// cause: "let {0}"
+// test_cause:
+// ["let {0}", "77f", "77c", "7", 77]
 
                         return stop("expected_identifier_a");
                     }
@@ -3670,8 +3843,9 @@ function jslint_phase3_parse(state) {
                         advance(":");
                         if (!token_nxt.identifier) {
 
-// cause: "let {aa:0}"
-// cause: "let {aa:{aa}}"
+// test_cause:
+// ["let {aa:0}", "77f", "77c", "7", 77]
+// ["let {aa:{aa}}", "77f", "77c", "7", 77]
 
                             return stop("expected_identifier_a");
                         }
@@ -3688,7 +3862,8 @@ function jslint_phase3_parse(state) {
                     name.init = true;
                     if (token_nxt.id === "=") {
 
-// cause: "let {aa=0}"
+// test_cause:
+// ["let {aa=0}", "77f", "77c", "7", 77]
 
                         advance("=");
                         name.expression = parse_expression();
@@ -3700,7 +3875,8 @@ function jslint_phase3_parse(state) {
                     advance(",");
                 }
 
-// cause: "let{bb,aa}"
+// test_cause:
+// ["let{bb,aa}", "77f", "77c", "7", 77]
 
                 warn_if_unordered(the_variable.id, the_variable.names);
                 advance("}");
@@ -3709,7 +3885,8 @@ function jslint_phase3_parse(state) {
             } else if (token_nxt.id === "[") {
                 if (the_variable.id === "var") {
 
-// cause: "var[aa]=0"
+// test_cause:
+// ["var[aa]=0", "77f", "77c", "7", 77]
 
                     warn("unexpected_a", the_variable);
                 }
@@ -3723,7 +3900,8 @@ function jslint_phase3_parse(state) {
                     }
                     if (!token_nxt.identifier) {
 
-// cause: "let[]"
+// test_cause:
+// ["let[]", "77f", "77c", "7", 77]
 
                         return stop("expected_identifier_a");
                     }
@@ -3755,7 +3933,8 @@ function jslint_phase3_parse(state) {
                 advance();
                 if (name.id === "ignore") {
 
-// cause: "let ignore;function aa(ignore) {}"
+// test_cause:
+// ["let ignore;function aa(ignore) {}", "77f", "77c", "7", 77]
 
                     warn("unexpected_a", name);
                 }
@@ -3769,8 +3948,9 @@ function jslint_phase3_parse(state) {
                 the_variable.names.push(name);
             } else {
 
-// cause: "let 0"
-// cause: "var{aa:{aa}}"
+// test_cause:
+// ["let 0", "77f", "77c", "7", 77]
+// ["var{aa:{aa}}", "77f", "77c", "7", 77]
 
                 return stop("expected_identifier_a");
             }
@@ -3778,7 +3958,8 @@ function jslint_phase3_parse(state) {
                 break;
             }
 
-// cause: "let aa,bb;"
+// test_cause:
+// ["let aa,bb;", "77f", "77c", "7", 77]
 
             warn("expected_a_b", token_nxt, ";", ",");
             advance(",");
@@ -3797,9 +3978,10 @@ function jslint_phase3_parse(state) {
             )
         ) {
 
-// cause: "/*jslint beta*/\nconst bb=0;const aa=0;"
-// cause: "/*jslint beta*/\nlet bb;let aa;"
-// cause: "/*jslint beta*/\nvar bb;var aa;"
+// test_cause:
+// ["/*jslint beta*/\nconst bb=0;const aa=0;", "77f", "77c", "7", 77]
+// ["/*jslint beta*/\nlet bb;let aa;", "77f", "77c", "7", 77]
+// ["/*jslint beta*/\nvar bb;var aa;", "77f", "77c", "7", 77]
 
             warn(
                 "expected_a_b_ordered_before_c_d",
@@ -3819,8 +4001,9 @@ function jslint_phase3_parse(state) {
         const the_continue = token_now;
         if (functionage.loop < 1 || functionage.finally > 0) {
 
-// cause: "continue"
-// cause: "function aa(){while(0){try{}finally{continue}}}"
+// test_cause:
+// ["continue", "77f", "77c", "7", 77]
+// ["function aa(){while(0){try{}finally{continue}}}", "77f", "77c", "7", 77]
 
             warn("unexpected_a", the_continue);
         }
@@ -3834,7 +4017,8 @@ function jslint_phase3_parse(state) {
         const the_debug = token_now;
         if (!option_dict.devel) {
 
-// cause: "debugger"
+// test_cause:
+// ["debugger", "77f", "77c", "7", 77]
 
             warn("unexpected_a", the_debug);
         }
@@ -3849,7 +4033,8 @@ function jslint_phase3_parse(state) {
             || the_value.arity !== "binary"
         ) {
 
-// cause: "delete 0"
+// test_cause:
+// ["delete 0", "77f", "77c", "7", 77]
 
             stop("expected_a_b", the_value, ".", artifact(the_value));
         }
@@ -3867,7 +4052,8 @@ function jslint_phase3_parse(state) {
         semicolon();
         if (the_do.block.disrupt === true) {
 
-// cause: "function aa(){do{break;}while(0)}"
+// test_cause:
+// ["function aa(){do{break;}while(0)}", "77f", "77c", "7", 77]
 
             warn("weird_loop", the_do);
         }
@@ -3883,7 +4069,8 @@ function jslint_phase3_parse(state) {
         function export_id() {
             if (!token_nxt.identifier) {
 
-// cause: "export {}"
+// test_cause:
+// ["export {}", "77f", "77c", "7", 77]
 
                 stop("expected_identifier_a");
             }
@@ -3891,14 +4078,16 @@ function jslint_phase3_parse(state) {
             the_name = token_global.context[the_id];
             if (the_name === undefined) {
 
-// cause: "export {aa}"
+// test_cause:
+// ["export {aa}", "77f", "77c", "7", 77]
 
                 warn("unexpected_a");
             } else {
                 the_name.used += 1;
                 if (export_dict[the_id] !== undefined) {
 
-// cause: "let aa;export{aa,aa}"
+// test_cause:
+// ["let aa;export{aa,aa}", "77f", "77c", "7", 77]
 
                     warn("duplicate_a");
                 }
@@ -3912,7 +4101,8 @@ function jslint_phase3_parse(state) {
         if (token_nxt.id === "default") {
             if (export_dict.default !== undefined) {
 
-// cause: "export default 0;export default 0"
+// test_cause:
+// ["export default 0;export default 0", "77f", "77c", "7", 77]
 
                 warn("duplicate_a");
             }
@@ -3925,7 +4115,8 @@ function jslint_phase3_parse(state) {
                 || the_thing.expression[0].name.id !== "freeze"
             ) {
 
-// cause: "export default {}"
+// test_cause:
+// ["export default {}", "77f", "77c", "7", 77]
 
                 warn("freeze_exports", the_thing);
 
@@ -3933,7 +4124,8 @@ function jslint_phase3_parse(state) {
 
             } else {
 
-// cause: "export default Object.freeze({})"
+// test_cause:
+// ["export default Object.freeze({})", "77f", "77c", "7", 77]
 
                 semicolon();
             }
@@ -3942,7 +4134,8 @@ function jslint_phase3_parse(state) {
         } else {
             if (token_nxt.id === "function") {
 
-// cause: "export function aa(){}"
+// test_cause:
+// ["export function aa(){}", "77f", "77c", "7", 77]
 
                 warn("freeze_exports");
                 the_thing = parse_statement();
@@ -3950,7 +4143,8 @@ function jslint_phase3_parse(state) {
                 the_id = the_name.id;
                 the_name.used += 1;
 
-// cause: "let aa;export{aa};export function aa(){}"
+// test_cause:
+// ["let aa;export{aa};export function aa(){}", "77f", "77c", "7", 77]
 
                 if (export_dict[the_id] !== undefined) {
                     warn("duplicate_a", the_name);
@@ -3965,15 +4159,17 @@ function jslint_phase3_parse(state) {
                 || token_nxt.id === "const"
             ) {
 
-// cause: "export const"
-// cause: "export let"
-// cause: "export var"
+// test_cause:
+// ["export const", "77f", "77c", "7", 77]
+// ["export let", "77f", "77c", "7", 77]
+// ["export var", "77f", "77c", "7", 77]
 
                 warn("unexpected_a");
                 parse_statement();
             } else if (token_nxt.id === "{") {
 
-// cause: "export {}"
+// test_cause:
+// ["export {}", "77f", "77c", "7", 77]
 
                 advance("{");
                 (function loop() {
@@ -3987,7 +4183,8 @@ function jslint_phase3_parse(state) {
                 semicolon();
             } else {
 
-// cause: "export"
+// test_cause:
+// ["export", "77f", "77c", "7", 77]
 
                 stop("unexpected_a");
             }
@@ -4000,7 +4197,8 @@ function jslint_phase3_parse(state) {
         let first;
         if (!option_dict.for) {
 
-// cause: "for"
+// test_cause:
+// ["for", "77f", "77c", "7", 77]
 
             warn("unexpected_a", the_for);
         }
@@ -4008,12 +4206,14 @@ function jslint_phase3_parse(state) {
         functionage.loop += 1;
         advance("(");
 
-// cause: "for(){}"
+// test_cause:
+// ["for(){}", "77f", "77c", "7", 77]
 
         token_now.free = true;
         if (token_nxt.id === ";") {
 
-// cause: "for(;;){}"
+// test_cause:
+// ["for(;;){}", "77f", "77c", "7", 77]
 
             return stop("expected_a_b", the_for, "while (", "for (;");
         }
@@ -4023,7 +4223,8 @@ function jslint_phase3_parse(state) {
             || token_nxt.id === "const"
         ) {
 
-// cause: "for(const aa in aa){}"
+// test_cause:
+// ["for(const aa in aa){}", "77f", "77c", "7", 77]
 
             return stop("unexpected_a");
         }
@@ -4031,7 +4232,8 @@ function jslint_phase3_parse(state) {
         if (first.id === "in") {
             if (first.expression[0].arity !== "variable") {
 
-// cause: "for(0 in aa){}"
+// test_cause:
+// ["for(0 in aa){}", "77f", "77c", "7", 77]
 
                 warn("bad_assignment_a", first.expression[0]);
             }
@@ -4046,7 +4248,8 @@ function jslint_phase3_parse(state) {
             the_for.inc = parse_expression(0);
             if (the_for.inc.id === "++") {
 
-// cause: "for(aa;aa;aa++){}"
+// test_cause:
+// ["for(aa;aa;aa++){}", "77f", "77c", "7", 77]
 
                 warn("expected_a_b", the_for.inc, "+= 1", "++");
             }
@@ -4055,7 +4258,8 @@ function jslint_phase3_parse(state) {
         the_for.block = block();
         if (the_for.block.disrupt === true) {
 
-// cause: "/*jslint for*/\nfunction aa(bb,cc){for(0;0;0){break;}}"
+// test_cause:
+// ["/*jslint for*/\nfunction aa(bb,cc){for(0;0;0){break;}}", "77f", "77c", "7", 77] //jslint-quiet
 
             warn("weird_loop", the_for);
         }
@@ -4074,23 +4278,27 @@ function jslint_phase3_parse(state) {
             the_if.else = (
                 token_nxt.id === "if"
 
-// cause: "if(0){0}else if(0){0}"
+// test_cause:
+// ["if(0){0}else if(0){0}", "77f", "77c", "7", 77]
 
                 ? parse_statement()
 
-// cause: "if(0){0}else{0}"
+// test_cause:
+// ["if(0){0}else{0}", "77f", "77c", "7", 77]
 
                 : block()
             );
             if (the_if.block.disrupt === true) {
                 if (the_if.else.disrupt === true) {
 
-// cause: "if(0){break;}else{break;}"
+// test_cause:
+// ["if(0){break;}else{break;}", "77f", "77c", "7", 77]
 
                     the_if.disrupt = true;
                 } else {
 
-// cause: "if(0){break;}else{}"
+// test_cause:
+// ["if(0){break;}else{}", "77f", "77c", "7", 77]
 
                     warn("unexpected_a", the_else);
                 }
@@ -4104,7 +4312,8 @@ function jslint_phase3_parse(state) {
         let names;
         if (typeof state.mode_module === "object") {
 
-// cause: "/*global aa*/\nimport aa from \"aa\""
+// test_cause:
+// ["/*global aa*/\nimport aa from \"aa\"", "77f", "77c", "7", 77]
 
             warn(
                 "unexpected_directive_a",
@@ -4118,7 +4327,8 @@ function jslint_phase3_parse(state) {
             advance();
             if (name.id === "ignore") {
 
-// cause: "import ignore from \"aa\""
+// test_cause:
+// ["import ignore from \"aa\"", "77f", "77c", "7", 77]
 
                 warn("unexpected_a", name);
             }
@@ -4131,7 +4341,8 @@ function jslint_phase3_parse(state) {
                 while (true) {
                     if (!token_nxt.identifier) {
 
-// cause: "import {"
+// test_cause:
+// ["import {", "77f", "77c", "7", 77]
 
                         stop("expected_identifier_a");
                     }
@@ -4139,7 +4350,8 @@ function jslint_phase3_parse(state) {
                     advance();
                     if (name.id === "ignore") {
 
-// cause: "import {ignore} from \"aa\""
+// test_cause:
+// ["import {ignore} from \"aa\"", "77f", "77c", "7", 77]
 
                         warn("unexpected_a", name);
                     }
@@ -4162,7 +4374,8 @@ function jslint_phase3_parse(state) {
             /^[a-zA-Z0-9_$:.@\-\/]+$/
         ).test(token_now.value)) {
 
-// cause: "import aa from \"!aa\""
+// test_cause:
+// ["import aa from \"!aa\"", "77f", "77c", "7", 77]
 
             warn("bad_module_name_a", token_now);
         }
@@ -4176,7 +4389,8 @@ function jslint_phase3_parse(state) {
         not_top_level(the_return);
         if (functionage.finally > 0) {
 
-// cause: "function aa(){try{}finally{return;}}"
+// test_cause:
+// ["function aa(){try{}finally{return;}}", "77f", "77c", "7", 77]
 
             warn("unexpected_a", the_return);
         }
@@ -4199,14 +4413,16 @@ function jslint_phase3_parse(state) {
         not_top_level(the_switch);
         if (functionage.finally > 0) {
 
-// cause: "function aa(){try{}finally{switch(0){}}}"
+// test_cause:
+// ["function aa(){try{}finally{switch(0){}}}", "77f", "77c", "7", 77]
 
             warn("unexpected_a", the_switch);
         }
         functionage.switch += 1;
         advance("(");
 
-// cause: "switch(){}"
+// test_cause:
+// ["switch(){}", "77f", "77c", "7", 77]
 
         token_now.free = true;
         the_switch.expression = parse_expression(0);
@@ -4226,7 +4442,8 @@ function jslint_phase3_parse(state) {
                     return is_equal(thing, exp);
                 })) {
 
-// cause: "switch(0){case 0:break;case 0:break}"
+// test_cause:
+// ["switch(0){case 0:break;case 0:break}", "77f", "77c", "7", 77]
 
                     warn("unexpected_a", exp);
                 }
@@ -4238,17 +4455,19 @@ function jslint_phase3_parse(state) {
                 }
             }());
 
-// cause: switch(0){case "aa":case 0:break;}
-// cause: switch(0){case "bb":case "aa":break;}
-// cause: switch(0){case 1:case 0:break;}
-// cause: switch(0){case aa:case "aa":break;}
-// cause: switch(0){case bb:case aa:break;}
+// test_cause:
+// ["switch(0){case 1:case 0:break;}", "77f", "77c", "7", 77]
+// ["switch(0){case \"aa\":case 0:break;}", "77f", "77c", "7", 77]
+// ["switch(0){case \"bb\":case \"aa\":break;}", "77f", "77c", "7", 77]
+// ["switch(0){case aa:case \"aa\":break;}", "77f", "77c", "7", 77]
+// ["switch(0){case bb:case aa:break;}", "77f", "77c", "7", 77]
 
             warn_if_unordered_case_statement(the_case.expression);
             stmts = parse_statements();
             if (stmts.length < 1) {
 
-// cause: "switch(0){case 0:}"
+// test_cause:
+// ["switch(0){case 0:}", "77f", "77c", "7", 77]
 
                 warn("expected_statements_a");
                 return;
@@ -4268,11 +4487,12 @@ function jslint_phase3_parse(state) {
             }
         }());
 
-// cause: switch(0){case "aa":break;case 0:break;}
-// cause: switch(0){case "bb":break;case "aa":break;}
-// cause: switch(0){case 1:break;case 0:break;}
-// cause: switch(0){case aa:break;case "aa":break;}
-// cause: switch(0){case bb:break;case aa:break;}
+// test_cause:
+// ["switch(0){case 1:break;case 0:break;}", "77f", "77c", "7", 77]
+// ["switch(0){case \"aa\":break;case 0:break;}", "77f", "77c", "7", 77]
+// ["switch(0){case \"bb\":break;case \"aa\":break;}", "77f", "77c", "7", 77]
+// ["switch(0){case aa:break;case \"aa\":break;}", "77f", "77c", "7", 77]
+// ["switch(0){case bb:break;case aa:break;}", "77f", "77c", "7", 77]
 
         warn_if_unordered_case_statement(the_cases.map(function ({
             expression
@@ -4288,7 +4508,8 @@ function jslint_phase3_parse(state) {
             the_switch.else = parse_statements();
             if (the_switch.else.length < 1) {
 
-// cause: "switch(0){case 0:break;default:}"
+// test_cause:
+// ["switch(0){case 0:break;default:}", "77f", "77c", "7", 77]
 
                 warn("unexpected_a", the_default);
                 the_disrupt = false;
@@ -4301,7 +4522,8 @@ function jslint_phase3_parse(state) {
                     && the_last.label === undefined
                 ) {
 
-// cause: "switch(0){case 0:break;default:break;}"
+// test_cause:
+// ["switch(0){case 0:break;default:break;}", "77f", "77c", "7", 77]
 
                     warn("unexpected_a", the_last);
                     the_last.disrupt = false;
@@ -4323,7 +4545,8 @@ function jslint_phase3_parse(state) {
         semicolon();
         if (functionage.try > 0) {
 
-// cause: "try{throw 0}catch(){}"
+// test_cause:
+// ["try{throw 0}catch(){}", "77f", "77c", "7", 77]
 
             warn("unexpected_a", the_throw);
         }
@@ -4336,7 +4559,8 @@ function jslint_phase3_parse(state) {
         let the_disrupt;
         if (functionage.try > 0) {
 
-// cause: "try{try{}catch(){}}catch(){}"
+// test_cause:
+// ["try{try{}catch(){}}catch(){}", "77f", "77c", "7", 77]
 
             warn("unexpected_a", the_try);
         }
@@ -4359,7 +4583,8 @@ function jslint_phase3_parse(state) {
                 advance("(");
                 if (!token_nxt.identifier) {
 
-// cause: "try{}catch(){}"
+// test_cause:
+// ["try{}catch(){}", "77f", "77c", "7", 77]
 
                     return stop("expected_identifier_a");
                 }
@@ -4381,7 +4606,8 @@ function jslint_phase3_parse(state) {
             catchage = catch_stack.pop();
         } else {
 
-// cause: "try{}finally{break;}"
+// test_cause:
+// ["try{}finally{break;}", "77f", "77c", "7", 77]
 
             warn("expected_a_before_b", token_nxt, "catch", artifact());
 
@@ -4406,7 +4632,8 @@ function jslint_phase3_parse(state) {
         the_while.block = block();
         if (the_while.block.disrupt === true) {
 
-// cause: "function aa(){while(0){break;}}"
+// test_cause:
+// ["function aa(){while(0){break;}}", "77f", "77c", "7", 77]
 
             warn("weird_loop", the_while);
         }
@@ -4415,7 +4642,8 @@ function jslint_phase3_parse(state) {
     });
     stmt("with", function () {
 
-// cause: "with"
+// test_cause:
+// ["with", "77f", "77c", "7", 77]
 
         stop("unexpected_a", token_now);
     });
@@ -4433,7 +4661,8 @@ function jslint_phase3_parse(state) {
             case "(number)":
                 if (!rx_json_number.test(token_nxt.value)) {
 
-// cause: "[0x0]"
+// test_cause:
+// ["[0x0]", "77f", "77c", "7", 77]
 
                     warn("unexpected_a");
                 }
@@ -4442,7 +4671,8 @@ function jslint_phase3_parse(state) {
             case "(string)":
                 if (token_nxt.quote !== "\"") {
 
-// cause: "['']"
+// test_cause:
+// ["['']", "77f", "77c", "7", 77]
 
                     warn("unexpected_a", token_nxt, token_nxt.quote);
                 }
@@ -4455,7 +4685,8 @@ function jslint_phase3_parse(state) {
                 advance("(number)");
                 if (!rx_json_number.test(token_now.value)) {
 
-// cause: "[-0x0]"
+// test_cause:
+// ["[-0x0]", "77f", "77c", "7", 77]
 
                     warn("unexpected_a", token_now);
                 }
@@ -4463,7 +4694,8 @@ function jslint_phase3_parse(state) {
                 return negative;
             case "[":
 
-// cause: "[]"
+// test_cause:
+// ["[]", "77f", "77c", "7", 77]
 
                 return (function json_list() {
                     const bracket = token_nxt;
@@ -4475,7 +4707,8 @@ function jslint_phase3_parse(state) {
                             elements.push(parse_json());
                             if (token_nxt.id !== ",") {
 
-// cause: "[0,0]"
+// test_cause:
+// ["[0,0]", "77f", "77c", "7", 77]
 
                                 break;
                             }
@@ -4493,9 +4726,10 @@ function jslint_phase3_parse(state) {
                 return token_now;
             case "true":
 
-// cause: "[false]"
-// cause: "[null]"
-// cause: "[true]"
+// test_cause:
+// ["[false]", "77f", "77c", "7", 77]
+// ["[null]", "77f", "77c", "7", 77]
+// ["[true]", "77f", "77c", "7", 77]
 
                 advance();
                 return token_now;
@@ -4519,7 +4753,8 @@ function jslint_phase3_parse(state) {
                         while (true) {
                             if (token_nxt.quote !== "\"") {
 
-// cause: "{0:0}"
+// test_cause:
+// ["{0:0}", "77f", "77c", "7", 77]
 
                                 warn(
                                     "unexpected_a",
@@ -4531,12 +4766,14 @@ function jslint_phase3_parse(state) {
                             advance("(string)");
                             if (object[token_now.value] !== undefined) {
 
-// cause: "{\"aa\":0,\"aa\":0}"
+// test_cause:
+// ["{\"aa\":0,\"aa\":0}", "77f", "77c", "7", 77]
 
                                 warn("duplicate_a", token_now);
                             } else if (token_now.value === "__proto__") {
 
-// cause: "{\"__proto__\":0}"
+// test_cause:
+// ["{\"__proto__\":0}", "77f", "77c", "7", 77]
 
                                 warn("weird_property_a", token_now);
                             } else {
@@ -4557,7 +4794,8 @@ function jslint_phase3_parse(state) {
                 }());
             default:
 
-// cause: "[undefined]"
+// test_cause:
+// ["[undefined]", "77f", "77c", "7", 77]
 
                 stop("unexpected_a");
             }
@@ -4707,7 +4945,8 @@ function jslint_phase4_walk(state) {
 
         if (blockage !== token_global) {
 
-// cause: "if(0){import aa from \"aa\";}"
+// test_cause:
+// ["if(0){import aa from \"aa\";}", "77f", "77c", "7", 77]
 
             warn("misplaced_a", the_thing);
         }
@@ -4717,8 +4956,9 @@ function jslint_phase4_walk(state) {
         if (thing) {
             if (Array.isArray(thing)) {
 
-// cause: "(function(){}())"
-// cause: "0&&0"
+// test_cause:
+// ["(function(){}())", "77f", "77c", "7", 77]
+// ["0&&0", "77f", "77c", "7", 77]
 
                 thing.forEach(walk_expression);
             } else {
@@ -4726,25 +4966,29 @@ function jslint_phase4_walk(state) {
                 walk_expression(thing.expression);
                 if (thing.id === "function") {
 
-// cause: "aa=function(){}"
+// test_cause:
+// ["aa=function(){}", "77f", "77c", "7", 77]
 
                     walk_statement(thing.block);
                 }
                 if (thing.arity === "pre" || thing.arity === "post") {
 
-// cause: "aa=++aa"
-// cause: "aa=--aa"
+// test_cause:
+// ["aa=++aa", "77f", "77c", "7", 77]
+// ["aa=--aa", "77f", "77c", "7", 77]
 
                     warn("unexpected_a", thing);
                 } else if (
 
-// cause: "aa=0"
+// test_cause:
+// ["aa=0", "77f", "77c", "7", 77]
 
                     thing.arity === "statement"
                     || thing.arity === "assignment"
                 ) {
 
-// cause: "aa[aa=0]"
+// test_cause:
+// ["aa[aa=0]", "77f", "77c", "7", 77]
 
                     warn("unexpected_statement_a", thing);
                 }
@@ -4757,7 +5001,8 @@ function jslint_phase4_walk(state) {
         if (thing) {
             if (Array.isArray(thing)) {
 
-// cause: "+[]"
+// test_cause:
+// ["+[]", "77f", "77c", "7", 77]
 
                 thing.forEach(walk_statement);
             } else {
@@ -4766,7 +5011,8 @@ function jslint_phase4_walk(state) {
                 if (thing.arity === "binary") {
                     if (thing.id !== "(") {
 
-// cause: "0&&0"
+// test_cause:
+// ["0&&0", "77f", "77c", "7", 77]
 
                         warn("unexpected_expression_a", thing);
                     }
@@ -4776,12 +5022,13 @@ function jslint_phase4_walk(state) {
                     && thing.id !== "import"
                 ) {
 
-// cause: "!0"
-// cause: "+[]"
-// cause: "+new aa()"
-// cause: "0"
-// cause: "async function aa(){await 0;}"
-// cause: "typeof 0"
+// test_cause:
+// ["!0", "77f", "77c", "7", 77]
+// ["+[]", "77f", "77c", "7", 77]
+// ["+new aa()", "77f", "77c", "7", 77]
+// ["0", "77f", "77c", "7", 77]
+// ["async function aa(){await 0;}", "77f", "77c", "7", 77]
+// ["typeof 0", "77f", "77c", "7", 77]
 
                     warn("unexpected_expression_a", thing);
                 }
@@ -4822,10 +5069,11 @@ function jslint_phase4_walk(state) {
                 if (the_variable === undefined) {
                     if (global_dict[thing.id] === undefined) {
 
-// cause: "aa"
-// cause: "class aa{}"
-// cause: "let aa=0;try{aa();}catch(bb){bb();}bb();"
-// cause: "let aa=0;try{aa();}catch(ignore){bb();}"
+// test_cause:
+// ["aa", "77f", "77c", "7", 77]
+// ["class aa{}", "77f", "77c", "7", 77]
+// ["let aa=0;try{aa();}catch(bb){bb();}bb();", "77f", "77c", "7", 77]
+// ["let aa=0;try{aa();}catch(ignore){bb();}", "77f", "77c", "7", 77]
 
                         warn("undeclared_a", thing);
                         return;
@@ -4845,7 +5093,8 @@ function jslint_phase4_walk(state) {
                 functionage.context[thing.id] = the_variable;
             } else if (the_variable.role === "label") {
 
-// cause: "aa:while(0){aa;}"
+// test_cause:
+// ["aa:while(0){aa;}", "77f", "77c", "7", 77]
 
                 warn("label_a", thing);
             }
@@ -4858,7 +5107,8 @@ function jslint_phase4_walk(state) {
                 && the_variable.dead
             ) {
 
-// cause: "let aa;if(aa){let bb;}bb;"
+// test_cause:
+// ["let aa;if(aa){let bb;}bb;", "77f", "77c", "7", 77]
 
                 warn("out_of_scope_a", thing);
             }
@@ -4874,13 +5124,15 @@ function jslint_phase4_walk(state) {
 
     function preaction_function(thing) {
 
-// cause: "()=>0"
-// cause: "(function (){}())"
-// cause: "function aa(){}"
+// test_cause:
+// ["()=>0", "77f", "77c", "7", 77]
+// ["(function (){}())", "77f", "77c", "7", 77]
+// ["function aa(){}", "77f", "77c", "7", 77]
 
         if (thing.arity === "statement" && blockage.body !== true) {
 
-// cause: "if(0){function aa(){}\n}"
+// test_cause:
+// ["if(0){function aa(){}\n}", "77f", "77c", "7", 77]
 
             warn("unexpected_a", thing);
         }
@@ -4896,14 +5148,16 @@ function jslint_phase4_walk(state) {
         if (thing.extra === "get") {
             if (thing.parameters.length !== 0) {
 
-// cause: "/*jslint getset*/\naa={get aa(aa){}}"
+// test_cause:
+// ["/*jslint getset*/\naa={get aa(aa){}}", "77f", "77c", "7", 77]
 
                 warn("bad_get", thing);
             }
         } else if (thing.extra === "set") {
             if (thing.parameters.length !== 1) {
 
-// cause: "/*jslint getset*/\naa={set aa(){}}"
+// test_cause:
+// ["/*jslint getset*/\naa={set aa(){}}", "77f", "77c", "7", 77]
 
                 warn("bad_set", thing);
             }
@@ -4962,19 +5216,20 @@ function jslint_phase4_walk(state) {
             break;
         case "~":
 
-// cause: "0&0"
-// cause: "0&=0"
-// cause: "0<<0"
-// cause: "0<<=0"
-// cause: "0>>0"
-// cause: "0>>=0"
-// cause: "0>>>0"
-// cause: "0>>>=0"
-// cause: "0^0"
-// cause: "0^=0"
-// cause: "0|0"
-// cause: "0|=0"
-// cause: "~0"
+// test_cause:
+// ["0&0", "77f", "77c", "7", 77]
+// ["0&=0", "77f", "77c", "7", 77]
+// ["0<<0", "77f", "77c", "7", 77]
+// ["0<<=0", "77f", "77c", "7", 77]
+// ["0>>0", "77f", "77c", "7", 77]
+// ["0>>=0", "77f", "77c", "7", 77]
+// ["0>>>0", "77f", "77c", "7", 77]
+// ["0>>>=0", "77f", "77c", "7", 77]
+// ["0^0", "77f", "77c", "7", 77]
+// ["0^=0", "77f", "77c", "7", 77]
+// ["0|0", "77f", "77c", "7", 77]
+// ["0|=0", "77f", "77c", "7", 77]
+// ["~0", "77f", "77c", "7", 77]
 
             warn("unexpected_a", thing);
             break;
@@ -4992,7 +5247,8 @@ function jslint_phase4_walk(state) {
             )
         ) {
 
-// cause: "0<0<0"
+// test_cause:
+// ["0<0<0", "77f", "77c", "7", 77]
 
             warn("unexpected_a", thing);
         }
@@ -5049,7 +5305,8 @@ function jslint_phase4_walk(state) {
         functionage = function_stack.pop();
         if (thing.wrapped) {
 
-// cause: "aa=(function(){})"
+// test_cause:
+// ["aa=(function(){})", "77f", "77c", "7", 77]
 
             warn("unexpected_parens", thing);
         }
@@ -5072,14 +5329,16 @@ function jslint_phase4_walk(state) {
             right = thing.expression[1];
             if (left.id === "NaN" || right.id === "NaN") {
 
-// cause: "NaN===NaN"
+// test_cause:
+// ["NaN===NaN", "77f", "77c", "7", 77]
 
                 warn("number_isNaN", thing);
             } else if (left.id === "typeof") {
                 if (right.id !== "(string)") {
                     if (right.id !== "typeof") {
 
-// cause: "typeof 0===0"
+// test_cause:
+// ["typeof 0===0", "77f", "77c", "7", 77]
 
                         warn("expected_string_a", right);
                     }
@@ -5087,7 +5346,8 @@ function jslint_phase4_walk(state) {
                     value = right.value;
                     if (value === "null" || value === "undefined") {
 
-// cause: "typeof aa===\"undefined\""
+// test_cause:
+// ["typeof aa===\"undefined\"", "77f", "77c", "7", 77]
 
                         warn("unexpected_typeof_a", right, value);
                     } else if (
@@ -5099,7 +5359,8 @@ function jslint_phase4_walk(state) {
                         && value !== "symbol"
                     ) {
 
-// cause: "typeof 0===\"aa\""
+// test_cause:
+// ["typeof 0===\"aa\"", "77f", "77c", "7", 77]
 
                         warn("expected_type_string_a", right, value);
                     }
@@ -5109,13 +5370,15 @@ function jslint_phase4_walk(state) {
     });
     preaction("binary", "==", function (thing) {
 
-// cause: "0==0"
+// test_cause:
+// ["0==0", "77f", "77c", "7", 77]
 
         warn("expected_a_b", thing, "===", "==");
     });
     preaction("binary", "!=", function (thing) {
 
-// cause: "0!=0"
+// test_cause:
+// ["0!=0", "77f", "77c", "7", 77]
 
         warn("expected_a_b", thing, "!==", "!=");
     });
@@ -5124,7 +5387,8 @@ function jslint_phase4_walk(state) {
         thing.expression.forEach(function (thang) {
             if (thang.id === "&&" && !thang.wrapped) {
 
-// cause: "0&&0||0"
+// test_cause:
+// ["0&&0||0", "77f", "77c", "7", 77]
 
                 warn("and", thang);
             }
@@ -5157,13 +5421,15 @@ function jslint_phase4_walk(state) {
     });
     preaction("binary", "in", function (thing) {
 
-// cause: "aa in aa"
+// test_cause:
+// ["aa in aa", "77f", "77c", "7", 77]
 
         warn("infix_in", thing);
     });
     preaction("binary", "instanceof", function (thing) {
 
-// cause: "0 instanceof 0"
+// test_cause:
+// ["0 instanceof 0", "77f", "77c", "7", 77]
 
         warn("unexpected_a", thing);
     });
@@ -5180,7 +5446,8 @@ function jslint_phase4_walk(state) {
                 the_variable.init = true;
                 if (!the_variable.writable) {
 
-// cause: "const aa=0;for(aa in aa){}"
+// test_cause:
+// ["const aa=0;for(aa in aa){}", "77f", "77c", "7", 77]
 
                     warn("bad_assignment_a", thing.name);
                 }
@@ -5234,7 +5501,8 @@ function jslint_phase4_walk(state) {
         if (thing.id === "=") {
             if (thing.names !== undefined) {
 
-// cause: "if(0){aa=0}"
+// test_cause:
+// ["if(0){aa=0}", "77f", "77c", "7", 77]
 
                 noop();
 
@@ -5262,7 +5530,8 @@ function jslint_phase4_walk(state) {
                     && thing.expression[1].id === "undefined"
                 ) {
 
-// cause: "aa.aa=undefined"
+// test_cause:
+// ["aa.aa=undefined", "77f", "77c", "7", 77]
 
                     warn(
                         "expected_a_b",
@@ -5292,7 +5561,8 @@ function jslint_phase4_walk(state) {
                 )
             ) {
 
-// cause: "aa+=undefined"
+// test_cause:
+// ["aa+=undefined", "77f", "77c", "7", 77]
 
                 warn("unexpected_a", thing.expression[1]);
             }
@@ -5312,7 +5582,8 @@ function jslint_phase4_walk(state) {
                 )
             ) {
 
-// cause: "if(0===0){0}"
+// test_cause:
+// ["if(0===0){0}", "77f", "77c", "7", 77]
 
                 warn("weird_relation_a", thing);
             }
@@ -5321,12 +5592,14 @@ function jslint_phase4_walk(state) {
             if (!option_dict.convert) {
                 if (thing.expression[0].value === "") {
 
-// cause: "\"\"+0"
+// test_cause:
+// ["\"\"+0", "77f", "77c", "7", 77]
 
                     warn("expected_a_b", thing, "String(...)", "\"\" +");
                 } else if (thing.expression[1].value === "") {
 
-// cause: "0+\"\""
+// test_cause:
+// ["0+\"\"", "77f", "77c", "7", 77]
 
                     warn("expected_a_b", thing, "String(...)", "+ \"\"");
                 }
@@ -5334,20 +5607,23 @@ function jslint_phase4_walk(state) {
         } else if (thing.id === "[") {
             if (thing.expression[0].id === "window") {
 
-// cause: "aa=window[0]"
+// test_cause:
+// ["aa=window[0]", "77f", "77c", "7", 77]
 
                 warn("weird_expression_a", thing, "window[...]");
             }
             if (thing.expression[0].id === "self") {
 
-// cause: "aa=self[0]"
+// test_cause:
+// ["aa=self[0]", "77f", "77c", "7", 77]
 
                 warn("weird_expression_a", thing, "self[...]");
             }
         } else if (thing.id === "." || thing.id === "?.") {
             if (thing.expression.id === "RegExp") {
 
-// cause: "aa=RegExp.aa"
+// test_cause:
+// ["aa=RegExp.aa", "77f", "77c", "7", 77]
 
                 warn("weird_expression_a", thing);
             }
@@ -5360,7 +5636,8 @@ function jslint_phase4_walk(state) {
                 && !right.wrapped
             ) {
 
-// cause: "0- -0"
+// test_cause:
+// ["0- -0", "77f", "77c", "7", 77]
 
                 warn("wrap_unary", right);
             }
@@ -5380,14 +5657,15 @@ function jslint_phase4_walk(state) {
             || thing.expression[1].constant === true
         ) {
 
-// cause: "aa=(()=>0)&&(()=>0)"
-// cause: "aa=(``?``:``)&&(``?``:``)"
-// cause: "aa=/./&&/./"
-// cause: "aa=0&&0"
-// cause: "aa=[]&&[]"
-// cause: "aa=`${0}`&&`${0}`"
-// cause: "aa=function aa(){}&&function aa(){}"
-// cause: "aa={}&&{}"
+// test_cause:
+// ["aa=(()=>0)&&(()=>0)", "77f", "77c", "7", 77]
+// ["aa=(``?``:``)&&(``?``:``)", "77f", "77c", "7", 77]
+// ["aa=/./&&/./", "77f", "77c", "7", 77]
+// ["aa=0&&0", "77f", "77c", "7", 77]
+// ["aa=[]&&[]", "77f", "77c", "7", 77]
+// ["aa=`${0}`&&`${0}`", "77f", "77c", "7", 77]
+// ["aa=function aa(){}&&function aa(){}", "77f", "77c", "7", 77]
+// ["aa={}&&{}", "77f", "77c", "7", 77]
 
             warn("weird_condition_a", thing);
         }
@@ -5399,7 +5677,8 @@ function jslint_phase4_walk(state) {
             || thing.expression[0].constant === true
         ) {
 
-// cause: "aa=0||0"
+// test_cause:
+// ["aa=0||0", "77f", "77c", "7", 77]
 
             warn("weird_condition_a", thing);
         }
@@ -5420,7 +5699,8 @@ function jslint_phase4_walk(state) {
         if (left.id === "function") {
             if (!thing.wrapped) {
 
-// cause: "aa=function(){}()"
+// test_cause:
+// ["aa=function(){}()", "77f", "77c", "7", 77]
 
                 warn("wrap_immediate", thing);
             }
@@ -5434,17 +5714,19 @@ function jslint_phase4_walk(state) {
                     || left.id === "Symbol"
                 ) {
 
-// cause: "new Boolean()"
-// cause: "new Number()"
-// cause: "new String()"
-// cause: "new Symbol()"
-// cause: "new aa()"
+// test_cause:
+// ["new Boolean()", "77f", "77c", "7", 77]
+// ["new Number()", "77f", "77c", "7", 77]
+// ["new String()", "77f", "77c", "7", 77]
+// ["new Symbol()", "77f", "77c", "7", 77]
+// ["new aa()", "77f", "77c", "7", 77]
 
                     warn("unexpected_a", the_new);
                 } else if (left.id === "Function") {
                     if (!option_dict.eval) {
 
-// cause: "new Function()"
+// test_cause:
+// ["new Function()", "77f", "77c", "7", 77]
 
                         warn("unexpected_a", left, "new Function");
                     }
@@ -5452,13 +5734,15 @@ function jslint_phase4_walk(state) {
                     arg = thing.expression;
                     if (arg.length !== 2 || arg[1].id === "(string)") {
 
-// cause: "new Array()"
+// test_cause:
+// ["new Array()", "77f", "77c", "7", 77]
 
                         warn("expected_a_b", left, "[]", "new Array");
                     }
                 } else if (left.id === "Object") {
 
-// cause: "new Object()"
+// test_cause:
+// ["new Object()", "77f", "77c", "7", 77]
 
                     warn(
                         "expected_a_b",
@@ -5477,7 +5761,8 @@ function jslint_phase4_walk(state) {
                     && left.id !== "Symbol"
                 ) {
 
-// cause: "let Aa=Aa()"
+// test_cause:
+// ["let Aa=Aa()", "77f", "77c", "7", 77]
 
                     warn("expected_a_before_b", left, "new", artifact(left));
                 }
@@ -5486,7 +5771,8 @@ function jslint_phase4_walk(state) {
             cack = the_new !== undefined;
             if (left.expression.id === "Date" && left.name.id === "UTC") {
 
-// cause: "new Date.UTC()"
+// test_cause:
+// ["new Date.UTC()", "77f", "77c", "7", 77]
 
                 cack = !cack;
             }
@@ -5496,12 +5782,14 @@ function jslint_phase4_walk(state) {
             ).test(left.name.id) !== cack) {
                 if (the_new !== undefined) {
 
-// cause: "new Date.UTC()"
+// test_cause:
+// ["new Date.UTC()", "77f", "77c", "7", 77]
 
                     warn("unexpected_a", the_new);
                 } else {
 
-// cause: "let Aa=Aa.Aa()"
+// test_cause:
+// ["let Aa=Aa.Aa()", "77f", "77c", "7", 77]
 
                     warn(
                         "expected_a_before_b",
@@ -5522,7 +5810,8 @@ function jslint_phase4_walk(state) {
                             && new_date.expression.id === "Date"
                         ) {
 
-// cause: "new Date().getTime()"
+// test_cause:
+// ["new Date().getTime()", "77f", "77c", "7", 77]
 
                             warn(
                                 "expected_a_b",
@@ -5539,13 +5828,15 @@ function jslint_phase4_walk(state) {
     postaction("binary", "[", function (thing) {
         if (thing.expression[0].id === "RegExp") {
 
-// cause: "aa=RegExp[0]"
+// test_cause:
+// ["aa=RegExp[0]", "77f", "77c", "7", 77]
 
             warn("weird_expression_a", thing);
         }
         if (is_weird(thing.expression[1])) {
 
-// cause: "aa[[0]]"
+// test_cause:
+// ["aa[[0]]", "77f", "77c", "7", 77]
 
             warn("weird_expression_a", thing.expression[1]);
         }
@@ -5600,12 +5891,14 @@ function jslint_phase4_walk(state) {
             warn("unexpected_a", thing);
         } else if (is_equal(thing.expression[0], thing.expression[1])) {
 
-// cause: "aa?aa:0"
+// test_cause:
+// ["aa?aa:0", "77f", "77c", "7", 77]
 
             warn("expected_a_b", thing, "||", "?");
         } else if (is_equal(thing.expression[0], thing.expression[2])) {
 
-// cause: "aa?0:aa"
+// test_cause:
+// ["aa?0:aa", "77f", "77c", "7", 77]
 
             warn("expected_a_b", thing, "&&", "?");
         } else if (
@@ -5613,7 +5906,8 @@ function jslint_phase4_walk(state) {
             && thing.expression[2].id === "false"
         ) {
 
-// cause: "aa?true:false"
+// test_cause:
+// ["aa?true:false", "77f", "77c", "7", 77]
 
             warn("expected_a_b", thing, "!!", "?");
         } else if (
@@ -5621,7 +5915,8 @@ function jslint_phase4_walk(state) {
             && thing.expression[2].id === "true"
         ) {
 
-// cause: "aa?false:true"
+// test_cause:
+// ["aa?false:true", "77f", "77c", "7", 77]
 
             warn("expected_a_b", thing, "!", "?");
         } else if (
@@ -5632,7 +5927,8 @@ function jslint_phase4_walk(state) {
             )
         ) {
 
-// cause: "(aa&&!aa?0:1)"
+// test_cause:
+// ["(aa&&!aa?0:1)", "77f", "77c", "7", 77]
 
             warn("wrap_condition", thing.expression[0]);
         }
@@ -5651,7 +5947,8 @@ function jslint_phase4_walk(state) {
         } else if (thing.id === "!!") {
             if (!option_dict.convert) {
 
-// cause: "!!0"
+// test_cause:
+// ["!!0", "77f", "77c", "7", 77]
 
                 warn("expected_a_b", thing, "Boolean(...)", "!!");
             }
@@ -5671,7 +5968,8 @@ function jslint_phase4_walk(state) {
         const right = thing.expression;
         if (!option_dict.convert) {
 
-// cause: "aa=+0"
+// test_cause:
+// ["aa=+0", "77f", "77c", "7", 77]
 
             warn("expected_a_b", thing, "Number(...)", "+");
         }
@@ -5707,23 +6005,25 @@ function jslint_phase5_whitage(state) {
 
 // free = false
 
-// cause: "()=>0"
-// cause: "aa()"
-// cause: "aa(0,0)"
-// cause: "function(){}"
+// test_cause:
+// ["()=>0", "77f", "77c", "7", 77]
+// ["aa()", "77f", "77c", "7", 77]
+// ["aa(0,0)", "77f", "77c", "7", 77]
+// ["function(){}", "77f", "77c", "7", 77]
 
     let free = false;
 
 // free = true
 
-// cause: "(0)"
-// cause: "(aa)"
-// cause: "aa(0)"
-// cause: "do{}while()"
-// cause: "for(){}"
-// cause: "if(){}"
-// cause: "switch(){}"
-// cause: "while(){}"
+// test_cause:
+// ["(0)", "77f", "77c", "7", 77]
+// ["(aa)", "77f", "77c", "7", 77]
+// ["aa(0)", "77f", "77c", "7", 77]
+// ["do{}while()", "77f", "77c", "7", 77]
+// ["for(){}", "77f", "77c", "7", 77]
+// ["if(){}", "77f", "77c", "7", 77]
+// ["switch(){}", "77f", "77c", "7", 77]
+// ["while(){}", "77f", "77c", "7", 77]
 
     let left = token_global;
     let margin = 0;
@@ -5778,7 +6078,8 @@ function jslint_phase5_whitage(state) {
             const name = the_function.context[id];
             if (id !== "ignore" && name.parent === the_function) {
 
-// cause: "let aa=function bb(){return;};"
+// test_cause:
+// ["let aa=function bb(){return;};", "77f", "77c", "7", 77]
 
                 if (
                     name.used === 0
@@ -5795,20 +6096,23 @@ function jslint_phase5_whitage(state) {
                     )
                 ) {
 
-// cause: "/*jslint node*/\nlet aa;"
-// cause: "function aa(aa){return;}"
-// cause: "let aa=0;try{aa();}catch(bb){aa();}"
+// test_cause:
+// ["/*jslint node*/\nlet aa;", "77f", "77c", "7", 77]
+// ["function aa(aa){return;}", "77f", "77c", "7", 77]
+// ["let aa=0;try{aa();}catch(bb){aa();}", "77f", "77c", "7", 77]
 
                     warn("unused_a", name);
                 } else if (!name.init) {
 
-// cause: "/*jslint node*/\nlet aa;aa();"
+// test_cause:
+// ["/*jslint node*/\nlet aa;aa();", "77f", "77c", "7", 77]
 
                     warn("uninitialized_a", name);
                 }
             }
 
-// cause: "function aa(ignore){return;}"
+// test_cause:
+// ["function aa(ignore){return;}", "77f", "77c", "7", 77]
 
         });
     }
@@ -5823,7 +6127,8 @@ function jslint_phase5_whitage(state) {
 
             if (left.thru !== right.from && nr_comments_skipped === 0) {
 
-// cause: "let aa = aa( );"
+// test_cause:
+// ["let aa = aa( );", "77f", "77c", "7", 77]
 
                 warn(
                     "unexpected_space_a_b",
@@ -5863,11 +6168,13 @@ function jslint_phase5_whitage(state) {
             assert_or_throw(free, `Expected free.`);
             if (right.from < margin) {
 
-// cause:
+// test_cause:
+// ["
 // let aa = aa(
 //     aa
 // ()
 // );
+// ", "77f", "77c", "7", 77]
 
                 expected_at(margin);
             }
@@ -5973,10 +6280,11 @@ function jslint_phase5_whitage(state) {
             case "[":
             case "{":
 
-// cause: "let aa=("
-// cause: "let aa=["
-// cause: "let aa=`${"
-// cause: "let aa={"
+// test_cause:
+// ["let aa=(", "77f", "77c", "7", 77]
+// ["let aa=[", "77f", "77c", "7", 77]
+// ["let aa=`${", "77f", "77c", "7", 77]
+// ["let aa={", "77f", "77c", "7", 77]
 
                 noop();
 
@@ -5995,28 +6303,32 @@ function jslint_phase5_whitage(state) {
 // If left and right are opener and closer, then the placement of right depends
 // on the openness. Illegal pairs (like '{]') have already been detected.
 
-// cause: "let aa=[];"
-// cause: "let aa=aa();"
-// cause: "let aa={};"
+// test_cause:
+// ["let aa=[];", "77f", "77c", "7", 77]
+// ["let aa=aa();", "77f", "77c", "7", 77]
+// ["let aa={};", "77f", "77c", "7", 77]
 
                     if (left.line === right.line) {
 
-// cause: "let aa = aa( );"
+// test_cause:
+// ["let aa = aa( );", "77f", "77c", "7", 77]
 
                         no_space();
                     } else {
 
-// cause: "let aa = aa(\n );"
+// test_cause:
+// ["let aa = aa(\n );", "77f", "77c", "7", 77]
 
                         at_margin(0);
                     }
                     break;
                 default:
 
-// cause: "let aa=(0"
-// cause: "let aa=[0"
-// cause: "let aa=`${0"
-// cause: "let aa={0"
+// test_cause:
+// ["let aa=(0", "77f", "77c", "7", 77]
+// ["let aa=[0", "77f", "77c", "7", 77]
+// ["let aa=`${0", "77f", "77c", "7", 77]
+// ["let aa={0", "77f", "77c", "7", 77]
 
                     opening = left.open || (left.line !== right.line);
                     push();
@@ -6036,10 +6348,11 @@ function jslint_phase5_whitage(state) {
                     }
                     if (opening) {
 
-// cause: "function aa(){\nreturn;\n}"
-// cause: "let aa=(\n0\n)"
-// cause: "let aa=[\n0\n]"
-// cause: "let aa=`${\n0\n}`"
+// test_cause:
+// ["function aa(){\nreturn;\n}", "77f", "77c", "7", 77]
+// ["let aa=(\n0\n)", "77f", "77c", "7", 77]
+// ["let aa=[\n0\n]", "77f", "77c", "7", 77]
+// ["let aa=`${\n0\n}`", "77f", "77c", "7", 77]
 
                         free = closer === ")" && left.free;
                         open = true;
@@ -6047,7 +6360,8 @@ function jslint_phase5_whitage(state) {
                         if (right.role === "label") {
                             if (right.from !== 0) {
 
-// cause:
+// test_cause:
+// ["
 // function aa() {
 //  bb:
 //     while (aa) {
@@ -6056,6 +6370,7 @@ function jslint_phase5_whitage(state) {
 //         }
 //     }
 // }
+// ", "77f", "77c", "7", 77]
 
                                 expected_at(0);
                             }
@@ -6067,11 +6382,13 @@ function jslint_phase5_whitage(state) {
                     } else {
                         if (right.statement || right.role === "label") {
 
-// cause:
+// test_cause:
+// ["
 // function aa() {bb:
 //     while (aa) {aa();
 //     }
 // }
+// ", "77f", "77c", "7", 77]
 
                             warn(
                                 "expected_line_break_a_b",
@@ -6081,15 +6398,17 @@ function jslint_phase5_whitage(state) {
                             );
                         }
 
-// cause: "${0}"
-// cause: "(0)"
-// cause: "[0]"
-// cause: "{0}"
+// test_cause:
+// ["${0}", "77f", "77c", "7", 77]
+// ["(0)", "77f", "77c", "7", 77]
+// ["[0]", "77f", "77c", "7", 77]
+// ["{0}", "77f", "77c", "7", 77]
 
                         free = false;
                         open = false;
 
-// cause: "let aa = ( 0 );"
+// test_cause:
+// ["let aa = ( 0 );", "77f", "77c", "7", 77]
 
                         no_space_only();
                     }
@@ -6099,18 +6418,21 @@ function jslint_phase5_whitage(state) {
                 if (right.statement === true) {
                     if (left.id === "else") {
 
-// cause:
+// test_cause:
+// ["
 // let aa = 0;
 // if (aa) {
 //     aa();
 // } else  if (aa) {
 //     aa();
 // }
+// ", "77f", "77c", "7", 77]
 
                         one_space_only();
                     } else {
 
-// cause: " let aa = 0;"
+// test_cause:
+// [" let aa = 0;", "77f", "77c", "7", 77]
 
                         at_margin(0);
                         open = false;
@@ -6138,7 +6460,8 @@ function jslint_phase5_whitage(state) {
                     } else if (right.role === "label") {
                         if (right.from !== 0) {
 
-// cause:
+// test_cause:
+// ["
 // function aa() {
 //     aa();cc:
 //     while (aa) {
@@ -6147,6 +6470,7 @@ function jslint_phase5_whitage(state) {
 //         }
 //     }
 // }
+// ", "77f", "77c", "7", 77]
 
                             expected_at(0);
                         }
@@ -6156,17 +6480,20 @@ function jslint_phase5_whitage(state) {
                             && left.line === right.line
                         )) {
 
-// cause: "let {aa,bb} = 0;"
+// test_cause:
+// ["let {aa,bb} = 0;", "77f", "77c", "7", 77]
 
                             one_space();
                         } else {
 
-// cause:
+// test_cause:
+// ["
 // function aa() {
 //     aa(
 //         0,0
 //     );
 // }
+// ", "77f", "77c", "7", 77]
 
                             at_margin(0);
                         }
@@ -6176,17 +6503,20 @@ function jslint_phase5_whitage(state) {
                     } else if (right.arity === "ternary") {
                         if (open) {
 
-// cause:
+// test_cause:
+// ["
 // let aa = (
 //     aa
 //     ? 0
 // : 1
 // );
+// ", "77f", "77c", "7", 77]
 
                             at_margin(0);
                         } else {
 
-// cause: "let aa = (aa ? 0 : 1);"
+// test_cause:
+// ["let aa = (aa ? 0 : 1);", "77f", "77c", "7", 77]
 
                             warn("use_open", right);
                         }
@@ -6196,11 +6526,13 @@ function jslint_phase5_whitage(state) {
                         && free
                     ) {
 
-// cause:
+// test_cause:
+// ["
 // let aa = aa(
 //     aa
 // ()
 // );
+// ", "77f", "77c", "7", 77]
 
                         no_space();
                     } else if (
@@ -6220,17 +6552,20 @@ function jslint_phase5_whitage(state) {
                         )
                     ) {
 
-// cause: "let aa = 0 ;"
+// test_cause:
+// ["let aa = 0 ;", "77f", "77c", "7", 77]
 
                         no_space_only();
                     } else if (right.id === "." || right.id === "?.") {
 
-// cause: "let aa = aa ?.aa;"
+// test_cause:
+// ["let aa = aa ?.aa;", "77f", "77c", "7", 77]
 
                         no_space_only();
                     } else if (left.id === ";") {
 
-// cause:
+// test_cause:
+// ["
 // /*jslint for*/
 // function aa() {
 //     for (
@@ -6241,6 +6576,7 @@ function jslint_phase5_whitage(state) {
 //         aa();
 //     }
 // }
+// ", "77f", "77c", "7", 77]
 
                         if (open) {
                             at_margin(0);
@@ -6260,12 +6596,14 @@ function jslint_phase5_whitage(state) {
                         || (left.id === ")" && right.id === "{")
                     ) {
 
-// cause:
+// test_cause:
+// ["
 // function aa() {
 //     do {
 //         aa();
 //     } while(aa());
 // }
+// ", "77f", "77c", "7", 77]
 
                         one_space_only();
                     } else if (
@@ -6299,12 +6637,14 @@ function jslint_phase5_whitage(state) {
                         || (left.arity === "statement" && right.id !== ";")
                     ) {
 
-// cause: "let aa=0;"
-// cause:
+// test_cause:
+// ["let aa=0;", "77f", "77c", "7", 77]
+// ["
 // let aa={
 //     aa:
 // 0
 // };
+// ", "77f", "77c", "7", 77]
 
                         one_space();
                     } else if (left.arity === "unary" && left.id !== "`") {
@@ -6607,7 +6947,8 @@ function jslint(
         let aa_value;
         let bb_value;
 
-// cause: "0&&0"
+// test_cause:
+// ["0&&0", "77f", "77c", "7", 77]
 
         noop();
 
@@ -6623,7 +6964,8 @@ function jslint(
                 && aa.length === bb.length
                 && aa.every(function (value, index) {
 
-// cause: "`${0}`&&`${0}`"
+// test_cause:
+// ["`${0}`&&`${0}`", "77f", "77c", "7", 77]
 
                     return is_equal(value, bb[index]);
                 })
@@ -6657,7 +6999,8 @@ function jslint(
         }
         if (aa.arity === bb.arity && aa.id === bb.id) {
 
-// cause: "aa.bb&&aa.bb"
+// test_cause:
+// ["aa.bb&&aa.bb", "77f", "77c", "7", 77]
 
             if (aa.id === ".") {
                 return (
@@ -6666,14 +7009,16 @@ function jslint(
                 );
             }
 
-// cause: "+0&&+0"
+// test_cause:
+// ["+0&&+0", "77f", "77c", "7", 77]
 
             if (aa.arity === "unary") {
                 return is_equal(aa.expression, bb.expression);
             }
             if (aa.arity === "binary") {
 
-// cause: "aa[0]&&aa[0]"
+// test_cause:
+// ["aa[0]&&aa[0]", "77f", "77c", "7", 77]
 
                 return (
                     aa.id !== "("
@@ -6683,7 +7028,8 @@ function jslint(
             }
             if (aa.arity === "ternary") {
 
-// cause: "aa=(``?``:``)&&(``?``:``)"
+// test_cause:
+// ["aa=(``?``:``)&&(``?``:``)", "77f", "77c", "7", 77]
 
                 return (
                     is_equal(aa.expression[0], bb.expression[0])
@@ -6702,12 +7048,14 @@ function jslint(
                 `Expected !(aa.arity === "function" || aa.arity === "regexp").`
             );
 
-// cause: "undefined&&undefined"
+// test_cause:
+// ["undefined&&undefined", "77f", "77c", "7", 77]
 
             return true;
         }
 
-// cause: "null&&undefined"
+// test_cause:
+// ["null&&undefined", "77f", "77c", "7", 77]
 
         return false;
     }
@@ -7030,7 +7378,8 @@ function jslint(
         }
         if (warning.directive_quiet) {
 
-// cause: "0 //jslint-quiet"
+// test_cause:
+// ["0 //jslint-quiet", "77f", "77c", "7", 77]
 
             return warning;
         }
@@ -7185,7 +7534,8 @@ function jslint(
             directive_list.forEach(function (comment) {
                 if (comment.directive === "global") {
 
-// cause: "/*global aa*/"
+// test_cause:
+// ["/*global aa*/", "77f", "77c", "7", 77]
 
                     warn("missing_browser", comment);
                 }

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -177,9 +177,6 @@ function noop() {
     return;
 }
 
-// Coverage-hack.
-noop(jslint_charset_ascii);
-
 function populate(array, object = empty(), value = true) {
 
 // Augment an object by taking property names from an array of strings.
@@ -283,8 +280,8 @@ function jslint_phase2_lex(state) {
         if (match !== undefined && char !== match) {
 
 // test_cause:
-// ["aa=/[", "char_after", "expected_a", "]", 77]
-// ["aa=/aa{/", "char_after", "expected_a_b", "/", 77]
+// ["aa=/[", "char_after", "expected_a", "]", 5]
+// ["aa=/aa{/", "char_after", "expected_a_b", "/", 8]
 
             return (
                 char === ""
@@ -320,7 +317,7 @@ function jslint_phase2_lex(state) {
         if (!quiet && length === 0) {
 
 // test_cause:
-// ["0x", "read_digits", "expected_digits_after_a", "0x", 77]
+// ["0x", "read_digits", "expected_digits_after_a", "0x", 2]
 
             warn_at("expected_digits_after_a", line, column, snippet);
         }
@@ -347,7 +344,7 @@ function jslint_phase2_lex(state) {
         ) {
 
 // test_cause:
-// ["/////////////////////////////////////////////////////////////////////////////////", "read_line", "too_long", "", 77] //jslint-quiet
+// ["/////////////////////////////////////////////////////////////////////////////////", "read_line", "too_long", "", 1] //jslint-quiet
 
             warn_at("too_long", line);
         }
@@ -370,7 +367,7 @@ function jslint_phase2_lex(state) {
         if (line_source === "/*jslint-disable*/") {
 
 // test_cause:
-// ["/*jslint-disable*/", "read_line", "jslint_disable", "", 77]
+// ["/*jslint-disable*/", "read_line", "jslint_disable", "", 0]
 
             test_cause("jslint_disable");
             line_disable = line;
@@ -378,7 +375,7 @@ function jslint_phase2_lex(state) {
             if (line_disable === undefined) {
 
 // test_cause:
-// ["/*jslint-enable*/", "read_line", "unopened_enable", "", 77]
+// ["/*jslint-enable*/", "read_line", "unopened_enable", "", 1]
 
                 stop_at("unopened_enable", line);
             }
@@ -386,7 +383,7 @@ function jslint_phase2_lex(state) {
         } else if (line_source.endsWith(" //jslint-quiet")) {
 
 // test_cause:
-// ["0 //jslint-quiet", "read_line", "jslint_quiet", "", 77]
+// ["0 //jslint-quiet", "read_line", "jslint_quiet", "", 0]
 
             test_cause("jslint_quiet");
             line_list[line].directive_quiet = true;
@@ -394,7 +391,7 @@ function jslint_phase2_lex(state) {
         if (line_disable !== undefined) {
 
 // test_cause:
-// ["/*jslint-disable*/\n0", "read_line", "line_disable", "", 77]
+// ["/*jslint-disable*/\n0", "read_line", "line_disable", "", 0]
 
             test_cause("line_disable");
             line_source = "";
@@ -403,7 +400,7 @@ function jslint_phase2_lex(state) {
             if (!option_dict.white) {
 
 // test_cause:
-// ["\t", "read_line", "use_spaces", "", 77]
+// ["\t", "read_line", "use_spaces", "", 1]
 
                 warn_at("use_spaces", line, line_source.indexOf("\t") + 1);
             }
@@ -415,7 +412,7 @@ function jslint_phase2_lex(state) {
         if (!option_dict.white && line_source.endsWith(" ")) {
 
 // test_cause:
-// [" ", "read_line", "unexpected_trailing_space", "", 77]
+// [" ", "read_line", "unexpected_trailing_space", "", 1]
 
             warn_at("unexpected_trailing_space", line, line_source.length - 1);
         }
@@ -461,7 +458,7 @@ function jslint_phase2_lex(state) {
         ) {
 
 // test_cause:
-// ["/**//**/", "token_create", "expected_space_a_b", "(comment)", 77]
+// ["/**//**/", "token_create", "expected_space_a_b", "(comment)", 5]
 
             warn(
                 "expected_space_a_b",
@@ -473,7 +470,7 @@ function jslint_phase2_lex(state) {
         if (token_prv.id === "." && id === "(number)") {
 
 // test_cause:
-// [".0", "token_create", "expected_a_before_b", ".", 77]
+// [".0", "token_create", "expected_a_before_b", ".", 1]
 
             warn("expected_a_before_b", token_prv, "0", ".");
         }
@@ -505,7 +502,7 @@ function jslint_phase2_lex(state) {
         case "":
 
 // test_cause:
-// ["\"\\", "char_after_escape", "unclosed_string", "", 77]
+// ["\"\\", "char_after_escape", "unclosed_string", "", 2]
 
             return stop_at("unclosed_string", line, column);
         case "/":
@@ -525,9 +522,7 @@ function jslint_phase2_lex(state) {
         case "t":
 
 // test_cause:
-// ["
-// "\/\\\`\b\f\n\r\t"
-// ", "char_after_escape", "char_after", "", 77]
+// ["\"\\/\\\\\\`\\b\\f\\n\\r\\t\"", "char_after_escape", "char_after", "", 0]
 
             test_cause("char_after");
             return char_after();
@@ -536,21 +531,21 @@ function jslint_phase2_lex(state) {
                 if (state.mode_json) {
 
 // test_cause:
-// ["[\"\\u{12345}\"]", "char_after_escape", "unexpected_a", "{", 77]
+// ["[\"\\u{12345}\"]", "char_after_escape", "unexpected_a", "{", 5]
 
                     warn_at("unexpected_a", line, column, char);
                 }
                 if (read_digits(rx_hexs) > 5) {
 
 // test_cause:
-// ["\"\\u{123456}\"", "char_after_escape", "too_many_digits", "", 77]
+// ["\"\\u{123456}\"", "char_after_escape", "too_many_digits", "", 11]
 
                     warn_at("too_many_digits", line, column);
                 }
                 if (char !== "}") {
 
 // test_cause:
-// ["\"\\u{12345\"", "char_after_escape", "expected_a_before_b", "\"", 77]
+// ["\"\\u{12345\"", "char_after_escape", "expected_a_before_b", "\"", 10]
 
                     stop_at("expected_a_before_b", line, column, "}", char);
                 }
@@ -560,7 +555,7 @@ function jslint_phase2_lex(state) {
             if (read_digits(rx_hexs, true) < 4) {
 
 // test_cause:
-// ["\"\\u0\"", "char_after_escape", "expected_four_digits", "", 77]
+// ["\"\\u0\"", "char_after_escape", "expected_four_digits", "", 5]
 
                 warn_at("expected_four_digits", line, column);
             }
@@ -571,7 +566,7 @@ function jslint_phase2_lex(state) {
             }
 
 // test_cause:
-// ["\"\\0\"", "char_after_escape", "unexpected_a_before_b", "0", 77]
+// ["\"\\0\"", "char_after_escape", "unexpected_a_before_b", "0", 3]
 
             warn_at("unexpected_a_before_b", line, column, "\\", char);
         }
@@ -599,7 +594,7 @@ function jslint_phase2_lex(state) {
             if (mode_mega) {
 
 // test_cause:
-// ["`${//}`", "lex_comment", "unexpected_comment", "`", 77]
+// ["`${//}`", "lex_comment", "unexpected_comment", "`", 4]
 
                 warn("unexpected_comment", the_comment, "`");
             }
@@ -611,7 +606,7 @@ function jslint_phase2_lex(state) {
             if (line_source[0] === "/") {
 
 // test_cause:
-// ["/*/", "lex_comment", "unexpected_a", "/", 77]
+// ["/*/", "lex_comment", "unexpected_a", "/", 2]
 
                 warn_at("unexpected_a", line, column + ii, "/");
             }
@@ -630,7 +625,7 @@ function jslint_phase2_lex(state) {
                     if (jj >= 0) {
 
 // test_cause:
-// ["/*/*", "lex_comment", "nested_comment", "", 77]
+// ["/*/*", "lex_comment", "nested_comment", "", 2]
 
                         warn_at("nested_comment", line, column + jj);
                     }
@@ -640,7 +635,7 @@ function jslint_phase2_lex(state) {
                 if (line_source === undefined) {
 
 // test_cause:
-// ["/*", "lex_comment", "unclosed_comment", "", 77]
+// ["/*", "lex_comment", "unclosed_comment", "", 1]
 
                     return stop_at("unclosed_comment", line, column);
                 }
@@ -652,7 +647,7 @@ function jslint_phase2_lex(state) {
             if (jj >= 0) {
 
 // test_cause:
-// ["/*/**/", "lex_comment", "nested_comment", "", 77]
+// ["/*/**/", "lex_comment", "nested_comment", "", 2]
 
                 warn_at("nested_comment", line, column + jj);
             }
@@ -674,7 +669,7 @@ function jslint_phase2_lex(state) {
         ) {
 
 // test_cause:
-// ["//todo", "lex_comment", "todo_comment", "(comment)", 77] //jslint-quiet
+// ["//todo", "lex_comment", "todo_comment", "(comment)", 1] //jslint-quiet
 
             warn("todo_comment", the_comment);
         }
@@ -692,7 +687,7 @@ function jslint_phase2_lex(state) {
         if (!mode_directive) {
 
 // test_cause:
-// ["0\n/*global aa*/", "lex_comment", "misplaced_directive_a", "global", 77]
+// ["0\n/*global aa*/", "lex_comment", "misplaced_directive_a", "global", 1]
 
             warn_at("misplaced_directive_a", line, from, match[1]);
             return the_comment;
@@ -716,7 +711,7 @@ function jslint_phase2_lex(state) {
                 if (body) {
 
 // test_cause:
-// ["/*jslint !*/", "lex_comment", "bad_directive_a", "!", 77]
+// ["/*jslint !*/", "lex_comment", "bad_directive_a", "!", 1]
 
                     return stop("bad_directive_a", the_comment, body);
                 }
@@ -753,7 +748,7 @@ function jslint_phase2_lex(state) {
                 } else {
 
 // test_cause:
-// ["/*jslint undefined*/", "lex_comment", "bad_option_a", "undefined", 77]
+// ["/*jslint undefined*/", "lex_comment", "bad_option_a", "undefined", 1]
 
                     warn("bad_option_a", the_comment, name);
                 }
@@ -764,7 +759,7 @@ function jslint_phase2_lex(state) {
                 if (value) {
 
 // test_cause:
-// ["/*global aa:false*/", "lex_comment", "bad_option_a", "aa:false", 77]
+// ["/*global aa:false*/", "lex_comment", "bad_option_a", "aa:false", 1]
 
                     warn("bad_option_a", the_comment, name + ":" + value);
                 }
@@ -784,7 +779,7 @@ function jslint_phase2_lex(state) {
         if (mode_mega) {
 
 // test_cause:
-// ["`${`", "lex_megastring", "expected_a_b", "`", 77]
+// ["`${`", "lex_megastring", "expected_a_b", "`", 4]
 
             return stop_at("expected_a_b", line, column, "}", "`");
         }
@@ -837,7 +832,7 @@ function jslint_phase2_lex(state) {
                     if (id === "{") {
 
 // test_cause:
-// ["`${{", "lex_megastring", "expected_a_b", "{", 77]
+// ["`${{", "lex_megastring", "expected_a_b", "{", 4]
 
                         return stop_at("expected_a_b", line, column, "}", "{");
                     }
@@ -873,7 +868,7 @@ function jslint_phase2_lex(state) {
                 if (read_line() === undefined) {
 
 // test_cause:
-// ["`", "lex_megastring", "unclosed_mega", "", 77]
+// ["`", "lex_megastring", "unclosed_mega", "", 1]
 
                     return stop_at("unclosed_mega", line_mega, from_mega);
                 }
@@ -923,7 +918,7 @@ function jslint_phase2_lex(state) {
         ) {
 
 // test_cause:
-// ["0a", "lex_number", "unexpected_a_after_b", "0", 77]
+// ["0a", "lex_number", "unexpected_a_after_b", "0", 2]
 
             return stop_at(
                 "unexpected_a_after_b",
@@ -968,14 +963,14 @@ function jslint_phase2_lex(state) {
                 case "]":
 
 // test_cause:
-// ["aa=/[", "lex_regexp_bracketed", "closer", "", 77]
-// ["aa=/[]/", "lex_regexp_bracketed", "closer", "", 77]
+// ["aa=/[", "lex_regexp_bracketed", "closer", "", 0]
+// ["aa=/[]/", "lex_regexp_bracketed", "closer", "", 0]
 
                     test_cause("closer");
                     if (mode_regexp_range) {
 
 // test_cause:
-// ["aa=/[0-]/", "lex_regexp_bracketed", "unexpected_a", "-", 77]
+// ["aa=/[0-]/", "lex_regexp_bracketed", "unexpected_a", "-", 7]
 
                         warn_at("unexpected_a", line, column - 1, "-");
                     }
@@ -983,7 +978,7 @@ function jslint_phase2_lex(state) {
                 case " ":
 
 // test_cause:
-// ["aa=/[ ]/", "lex_regexp_bracketed", "expected_a_b", " ", 77]
+// ["aa=/[ ]/", "lex_regexp_bracketed", "expected_a_b", " ", 6]
 
                     warn_at("expected_a_b", line, column, "\\u0020", " ");
                     break;
@@ -993,11 +988,11 @@ function jslint_phase2_lex(state) {
                 case "^":
 
 // test_cause:
-// ["aa=/[-]/", "lex_regexp_bracketed", "expected_a_before_b", "-", 77]
-// ["aa=/[.^]/", "lex_regexp_bracketed", "expected_a_before_b", "^", 77]
-// ["aa=/[/", "lex_regexp_bracketed", "expected_a_before_b", "/", 77]
-// ["aa=/[\\\\/]/", "lex_regexp_bracketed", "expected_a_before_b", "/", 77]
-// ["aa=/[\\\\[]/", "lex_regexp_bracketed", "expected_a_before_b", "[", 77]
+// ["aa=/[-]/", "lex_regexp_bracketed", "expected_a_before_b", "-", 6]
+// ["aa=/[.^]/", "lex_regexp_bracketed", "expected_a_before_b", "^", 7]
+// ["aa=/[/", "lex_regexp_bracketed", "expected_a_before_b", "/", 6]
+// ["aa=/[\\\\/]/", "lex_regexp_bracketed", "expected_a_before_b", "/", 8]
+// ["aa=/[\\\\[]/", "lex_regexp_bracketed", "expected_a_before_b", "[", 8]
 
                     warn_at("expected_a_before_b", line, column, "\\", char);
                     break;
@@ -1009,7 +1004,7 @@ function jslint_phase2_lex(state) {
                     if (mode_mega) {
 
 // test_cause:
-// ["`${/[`]/}`", "lex_regexp_bracketed", "unexpected_a", "`", 77]
+// ["`${/[`]/}`", "lex_regexp_bracketed", "unexpected_a", "`", 6]
 
                         warn_at("unexpected_a", line, column, "`");
                     }
@@ -1043,9 +1038,9 @@ function jslint_phase2_lex(state) {
             case "]":
 
 // test_cause:
-// ["/ /", "lex_regexp_group", "expected_regexp_factor_a", "", 77]
-// ["aa=/)", "lex_regexp_group", "expected_regexp_factor_a", ")", 77]
-// ["aa=/]", "lex_regexp_group", "expected_regexp_factor_a", "]", 77]
+// ["/ /", "lex_regexp_group", "expected_regexp_factor_a", "", 3]
+// ["aa=/)", "lex_regexp_group", "expected_regexp_factor_a", ")", 5]
+// ["aa=/]", "lex_regexp_group", "expected_regexp_factor_a", "]", 5]
 
                 warn_at("expected_regexp_factor_a", line, column, char);
                 break;
@@ -1060,7 +1055,7 @@ function jslint_phase2_lex(state) {
                 case " ":
 
 // test_cause:
-// ["aa=/ /", "lex_regexp_group", "expected_a_b", " ", 77]
+// ["aa=/ /", "lex_regexp_group", "expected_a_b", " ", 5]
 
                     warn_at("expected_a_b", line, column, "\\s", " ");
                     char_after();
@@ -1087,8 +1082,8 @@ function jslint_phase2_lex(state) {
                     } else if (char === ":") {
 
 // test_cause:
-// ["aa=/(:)/", "lex_regexp_group", "expected_a_before_b", ":", 77]
-// ["aa=/?/", "lex_regexp_group", "expected_a_before_b", "?", 77]
+// ["aa=/(:)/", "lex_regexp_group", "expected_a_before_b", ":", 6]
+// ["aa=/?/", "lex_regexp_group", "expected_a_before_b", "?", 5]
 
                         warn_at("expected_a_before_b", line, column, "?", ":");
                     }
@@ -1106,11 +1101,11 @@ function jslint_phase2_lex(state) {
                 case "}":
 
 // test_cause:
-// ["aa=/+/", "lex_regexp_group", "expected_a_before_b", "+", 77]
-// ["aa=/.**/", "lex_regexp_group", "expected_a_before_b", "*", 77]
-// ["aa=/?/", "lex_regexp_group", "expected_a_before_b", "?", 77]
-// ["aa=/{/", "lex_regexp_group", "expected_a_before_b", "{", 77]
-// ["aa=/}/", "lex_regexp_group", "expected_a_before_b", "}", 77]
+// ["aa=/+/", "lex_regexp_group", "expected_a_before_b", "+", 5]
+// ["aa=/.**/", "lex_regexp_group", "expected_a_before_b", "*", 7]
+// ["aa=/?/", "lex_regexp_group", "expected_a_before_b", "?", 5]
+// ["aa=/{/", "lex_regexp_group", "expected_a_before_b", "{", 5]
+// ["aa=/}/", "lex_regexp_group", "expected_a_before_b", "}", 5]
 
                     warn_at("expected_a_before_b", line, column, "\\", char);
                     char_after();
@@ -1121,7 +1116,7 @@ function jslint_phase2_lex(state) {
                 case "\\":
 
 // test_cause:
-// ["aa=/\\/", "lex_regexp_group", "escape", "", 77]
+// ["aa=/\\/", "lex_regexp_group", "escape", "", 0]
 
                     test_cause("escape");
                     char_after_escape("BbDdSsWw^${}[]():=!.|*+?");
@@ -1136,7 +1131,7 @@ function jslint_phase2_lex(state) {
                     if (mode_mega) {
 
 // test_cause:
-// ["`${/`/}`", "lex_regexp_group", "unexpected_a", "`", 77]
+// ["`${/`/}`", "lex_regexp_group", "unexpected_a", "`", 5]
 
                         warn_at("unexpected_a", line, column, "`");
                     }
@@ -1155,8 +1150,8 @@ function jslint_phase2_lex(state) {
                     if (char_after(char) === "?") {
 
 // test_cause:
-// ["aa=/.*?/", "lex_regexp_group", "?", "", 77]
-// ["aa=/.+?/", "lex_regexp_group", "?", "", 77]
+// ["aa=/.*?/", "lex_regexp_group", "?", "", 0]
+// ["aa=/.+?/", "lex_regexp_group", "?", "", 0]
 
                         test_cause("?");
                         char_after("?");
@@ -1166,7 +1161,7 @@ function jslint_phase2_lex(state) {
                     if (char_after("?") === "?") {
 
 // test_cause:
-// ["aa=/.??/", "lex_regexp_group", "unexpected_a", "?", 77]
+// ["aa=/.??/", "lex_regexp_group", "unexpected_a", "?", 7]
 
                         warn_at("unexpected_a", line, column, char);
                         char_after("?");
@@ -1176,14 +1171,14 @@ function jslint_phase2_lex(state) {
                     if (read_digits(rx_digits, true) === 0) {
 
 // test_cause:
-// ["aa=/aa{/", "lex_regexp_group", "expected_a_before_b", ",", 77]
+// ["aa=/aa{/", "lex_regexp_group", "expected_a_before_b", ",", 8]
 
                         warn_at("expected_a_before_b", line, column, "0", ",");
                     }
                     if (char === ",") {
 
 // test_cause:
-// ["aa=/.{,/", "lex_regexp_group", "comma", "", 77]
+// ["aa=/.{,/", "lex_regexp_group", "comma", "", 0]
 
                         test_cause("comma");
                         read_digits(rx_digits, true);
@@ -1191,7 +1186,7 @@ function jslint_phase2_lex(state) {
                     if (char_after("}") === "?") {
 
 // test_cause:
-// ["aa=/.{0}?/", "lex_regexp_group", "unexpected_a", "?", 77]
+// ["aa=/.{0}?/", "lex_regexp_group", "unexpected_a", "?", 9]
 
                         warn_at("unexpected_a", line, column, char);
                         char_after("?");
@@ -1210,7 +1205,7 @@ function jslint_phase2_lex(state) {
         if (char === "=") {
 
 // test_cause:
-// ["aa=/=/", "lex_regexp", "expected_a_before_b", "=", 77]
+// ["aa=/=/", "lex_regexp", "expected_a_before_b", "=", 5]
 
             warn_at("expected_a_before_b", line, column, "\\", "=");
         }
@@ -1255,15 +1250,15 @@ function jslint_phase2_lex(state) {
             case "y":
 
 // test_cause:
-// ["aa=/./gimuy", "lex_regexp", "flag", "", 77]
+// ["aa=/./gimuy", "lex_regexp", "flag", "", 0]
 
                 test_cause("flag");
                 break;
             default:
 
 // test_cause:
-// ["aa=/./gg", "lex_regexp", "unexpected_a", "g", 77]
-// ["aa=/./z", "lex_regexp", "unexpected_a", "z", 77]
+// ["aa=/./gg", "lex_regexp", "unexpected_a", "g", 8]
+// ["aa=/./z", "lex_regexp", "unexpected_a", "z", 7]
 
                 warn_at("unexpected_a", line, column, char);
             }
@@ -1274,7 +1269,7 @@ function jslint_phase2_lex(state) {
         if (char === "/" || char === "*") {
 
 // test_cause:
-// ["aa=/.//", "lex_regexp", "unexpected_a", "/", 77]
+// ["aa=/.//", "lex_regexp", "unexpected_a", "/", 3]
 
             return stop_at("unexpected_a", line, from, char);
         }
@@ -1284,7 +1279,7 @@ function jslint_phase2_lex(state) {
         if (mode_regexp_multiline && !flag.m) {
 
 // test_cause:
-// ["aa=/$^/", "lex_regexp", "missing_m", "", 77]
+// ["aa=/$^/", "lex_regexp", "missing_m", "", 7]
 
             warn_at("missing_m", line, column);
         }
@@ -1319,14 +1314,14 @@ function jslint_phase2_lex(state) {
             the_token = lex_regexp();
 
 // test_cause:
-// ["case /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 77]
-// ["delete /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 77]
-// ["in /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 77]
-// ["instanceof /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 77]
-// ["new /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 77]
-// ["typeof /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 77]
-// ["void /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 77]
-// ["yield /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 77]
+// ["case /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 6]
+// ["delete /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 8]
+// ["in /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 4]
+// ["instanceof /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 12]
+// ["new /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 5]
+// ["typeof /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 8]
+// ["void /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 6]
+// ["yield /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 7]
 
             return stop("unexpected_a", the_token);
         case "return":
@@ -1351,21 +1346,21 @@ function jslint_phase2_lex(state) {
             the_token = lex_regexp();
 
 // test_cause:
-// ["!/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
-// ["%/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
-// ["&/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
-// ["+/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
-// ["-/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
-// ["0 * /./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
-// ["0 / /./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
-// [";/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
-// ["</./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
-// [">/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
-// ["^/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
-// ["{/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
-// ["|/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
-// ["}/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
-// ["~/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
+// ["!/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 2]
+// ["%/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 2]
+// ["&/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 2]
+// ["+/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 2]
+// ["-/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 2]
+// ["0 * /./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 5]
+// ["0 / /./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 5]
+// [";/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 2]
+// ["</./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 2]
+// [">/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 2]
+// ["^/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 2]
+// ["{/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 2]
+// ["|/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 2]
+// ["}/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 2]
+// ["~/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 2]
 
             warn("wrap_regexp", the_token);
             return the_token;
@@ -1377,12 +1372,12 @@ function jslint_phase2_lex(state) {
         case "[":
 
 // test_cause:
-// ["(/./", "lex_slash_or_regexp", "recurse", "", 77]
-// [",/./", "lex_slash_or_regexp", "recurse", "", 77]
-// [":/./", "lex_slash_or_regexp", "recurse", "", 77]
-// ["=/./", "lex_slash_or_regexp", "recurse", "", 77]
-// ["?/./", "lex_slash_or_regexp", "recurse", "", 77]
-// ["aa[/./", "lex_slash_or_regexp", "recurse", "", 77]
+// ["(/./", "lex_slash_or_regexp", "recurse", "", 0]
+// [",/./", "lex_slash_or_regexp", "recurse", "", 0]
+// [":/./", "lex_slash_or_regexp", "recurse", "", 0]
+// ["=/./", "lex_slash_or_regexp", "recurse", "", 0]
+// ["?/./", "lex_slash_or_regexp", "recurse", "", 0]
+// ["aa[/./", "lex_slash_or_regexp", "recurse", "", 0]
 
             test_cause("recurse");
             return lex_regexp();
@@ -1404,7 +1399,7 @@ function jslint_phase2_lex(state) {
         if (!option_dict.single && quote === "'") {
 
 // test_cause:
-// ["''", "lex_string", "use_double", "", 77]
+// ["''", "lex_string", "use_double", "", 1]
 
             warn_at("use_double", line, column);
         }
@@ -1418,7 +1413,7 @@ function jslint_phase2_lex(state) {
             case "":
 
 // test_cause:
-// ["\"", "lex_string", "unclosed_string", "", 77]
+// ["\"", "lex_string", "unclosed_string", "", 1]
 
                 return stop_at("unclosed_string", line, column);
             case "\\":
@@ -1428,7 +1423,7 @@ function jslint_phase2_lex(state) {
                 if (mode_mega) {
 
 // test_cause:
-// ["`${\"`\"}`", "lex_string", "unexpected_a", "`", 77]
+// ["`${\"`\"}`", "lex_string", "unexpected_a", "`", 5]
 
                     warn_at("unexpected_a", line, column, "`");
                 }
@@ -1465,13 +1460,13 @@ function jslint_phase2_lex(state) {
                         mode_mega
 
 // test_cause:
-// ["`${//}`", "lex_token", "unclosed_mega", "", 77]
+// ["`${//}`", "lex_token", "unclosed_mega", "", 1]
 
                         ? stop_at("unclosed_mega", line_mega, from_mega)
                         : line_disable !== undefined
 
 // test_cause:
-// ["/*jslint-disable*/", "lex_token", "unclosed_disable", "", 77]
+// ["/*jslint-disable*/", "lex_token", "unclosed_disable", "", 1]
 
                         ? stop_at("unclosed_disable", line_disable)
                         : token_create("(end)")
@@ -1490,7 +1485,7 @@ function jslint_phase2_lex(state) {
             if (!match) {
 
 // test_cause:
-// ["#", "lex_token", "unexpected_char_a", "#", 77]
+// ["#", "lex_token", "unexpected_char_a", "#", 1]
 
                 return stop_at(
                     "unexpected_char_a",
@@ -1702,12 +1697,12 @@ function jslint_phase3_parse(state) {
                 match === undefined
 
 // test_cause:
-// ["()", "advance", "expected_a_b", "(end)", 77]
+// ["()", "advance", "expected_a_b", "(end)", 1]
 
                 ? stop("expected_a_b", token_nxt, id, artifact())
 
 // test_cause:
-// ["{\"aa\":0", "advance", "expected_a_b_from_c_d", "{", 77]
+// ["{\"aa\":0", "advance", "expected_a_b_from_c_d", "{", 1]
 
                 : stop(
                     "expected_a_b_from_c_d",
@@ -1736,7 +1731,7 @@ function jslint_phase3_parse(state) {
             if (state.mode_json) {
 
 // test_cause:
-// ["[//]", "advance", "unexpected_a", "(comment)", 77]
+// ["[//]", "advance", "unexpected_a", "(comment)", 2]
 
                 warn("unexpected_a");
             }
@@ -1774,7 +1769,7 @@ function jslint_phase3_parse(state) {
         if (syntax_dict[id] !== undefined && id !== "ignore") {
 
 // test_cause:
-// ["let undefined", "enroll", "reserved_a", "undefined", 77]
+// ["let undefined", "enroll", "reserved_a", "undefined", 5]
 
             warn("reserved_a", name);
         } else {
@@ -1785,7 +1780,7 @@ function jslint_phase3_parse(state) {
             if (earlier) {
 
 // test_cause:
-// ["let aa;let aa", "enroll", "redefinition_a_b", "1", 77]
+// ["let aa;let aa", "enroll", "redefinition_a_b", "1", 12]
 
                 warn("redefinition_a_b", name, name.id, earlier.line);
 
@@ -1803,7 +1798,7 @@ function jslint_phase3_parse(state) {
                         if (earlier.role === "variable") {
 
 // test_cause:
-// ["let ignore;function aa(ignore){}", "enroll", "unexpected_a", "ignore", 77]
+// ["let ignore;function aa(ignore){}", "enroll", "unexpected_a", "ignore", 24]
 
                             warn("unexpected_a", name);
                         }
@@ -1819,8 +1814,8 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // function aa(){try{aa();}catch(aa){aa();}}
-// ", "enroll", "redefinition_a_b", "1", 77]
-// ["function aa(){var aa;}", "enroll", "redefinition_a_b", "1", 77]
+// ", "enroll", "redefinition_a_b", "1", 31]
+// ["function aa(){var aa;}", "enroll", "redefinition_a_b", "1", 19]
 
                             warn(
                                 "redefinition_a_b",
@@ -1883,14 +1878,14 @@ function jslint_phase3_parse(state) {
         if (the_symbol !== undefined && the_symbol.nud !== undefined) {
 
 // test_cause:
-// ["0", "parse_expression", "symbol", "", 77]
+// ["0", "parse_expression", "symbol", "", 0]
 
             test_cause("symbol");
             left = the_symbol.nud();
         } else if (token_now.identifier) {
 
 // test_cause:
-// ["aa", "parse_expression", "identifier", "", 77]
+// ["aa", "parse_expression", "identifier", "", 0]
 
             test_cause("identifier");
             left = token_now;
@@ -1898,9 +1893,9 @@ function jslint_phase3_parse(state) {
         } else {
 
 // test_cause:
-// ["!", "parse_expression", "unexpected_a", "(end)", 77]
-// ["/./", "parse_expression", "unexpected_a", "/", 77]
-// ["let aa=`${}`;", "parse_expression", "unexpected_a", "}", 77]
+// ["!", "parse_expression", "unexpected_a", "(end)", 1]
+// ["/./", "parse_expression", "unexpected_a", "/", 1]
+// ["let aa=`${}`;", "parse_expression", "unexpected_a", "}", 11]
 
             return stop("unexpected_a", token_now);
         }
@@ -1930,9 +1925,9 @@ function jslint_phase3_parse(state) {
         let the_value;
 
 // test_cause:
-// ["do{}while()", "condition", "", "", 77]
-// ["if(){}", "condition", "", "", 77]
-// ["while(){}", "condition", "", "", 77]
+// ["do{}while()", "condition", "", "", 0]
+// ["if(){}", "condition", "", "", 0]
+// ["while(){}", "condition", "", "", 0]
 
         test_cause("");
         the_paren.free = true;
@@ -1942,7 +1937,7 @@ function jslint_phase3_parse(state) {
         if (the_value.wrapped === true) {
 
 // test_cause:
-// ["while((0)){}", "condition", "unexpected_a", "(", 77]
+// ["while((0)){}", "condition", "unexpected_a", "(", 6]
 
             warn("unexpected_a", the_paren);
         }
@@ -1998,22 +1993,22 @@ function jslint_phase3_parse(state) {
         case "~":
 
 // test_cause:
-// ["if(0%0){}", "condition", "unexpected_a", "%", 77]
-// ["if(0&0){}", "condition", "unexpected_a", "&", 77]
-// ["if(0){}", "condition", "unexpected_a", "0", 77]
-// ["if(0*0){}", "condition", "unexpected_a", "*", 77]
-// ["if(0+0){}", "condition", "unexpected_a", "+", 77]
-// ["if(0-0){}", "condition", "unexpected_a", "-", 77]
-// ["if(0/0){}", "condition", "unexpected_a", "/", 77]
-// ["if(0<<0){}", "condition", "unexpected_a", "<<", 77]
-// ["if(0>>0){}", "condition", "unexpected_a", ">>", 77]
-// ["if(0>>>0){}", "condition", "unexpected_a", ">>>", 77]
-// ["if(0?0:0){}", "condition", "unexpected_a", "?", 77]
-// ["if(0^0){}", "condition", "unexpected_a", "^", 77]
-// ["if(0|0){}", "condition", "unexpected_a", "|", 77]
-// ["if(\"aa\"){}", "condition", "unexpected_a", "aa", 77]
-// ["if(typeof 0){}", "condition", "unexpected_a", "typeof", 77]
-// ["if(~0){}", "condition", "unexpected_a", "~", 77]
+// ["if(0%0){}", "condition", "unexpected_a", "%", 5]
+// ["if(0&0){}", "condition", "unexpected_a", "&", 5]
+// ["if(0){}", "condition", "unexpected_a", "0", 4]
+// ["if(0*0){}", "condition", "unexpected_a", "*", 5]
+// ["if(0+0){}", "condition", "unexpected_a", "+", 5]
+// ["if(0-0){}", "condition", "unexpected_a", "-", 5]
+// ["if(0/0){}", "condition", "unexpected_a", "/", 5]
+// ["if(0<<0){}", "condition", "unexpected_a", "<<", 5]
+// ["if(0>>0){}", "condition", "unexpected_a", ">>", 5]
+// ["if(0>>>0){}", "condition", "unexpected_a", ">>>", 5]
+// ["if(0?0:0){}", "condition", "unexpected_a", "?", 5]
+// ["if(0^0){}", "condition", "unexpected_a", "^", 5]
+// ["if(0|0){}", "condition", "unexpected_a", "|", 5]
+// ["if(\"aa\"){}", "condition", "unexpected_a", "aa", 4]
+// ["if(typeof 0){}", "condition", "unexpected_a", "typeof", 4]
+// ["if(~0){}", "condition", "unexpected_a", "~", 4]
 
             warn("unexpected_a", the_value);
             break;
@@ -2030,7 +2025,7 @@ function jslint_phase3_parse(state) {
         } else {
 
 // test_cause:
-// ["0", "semicolon", "expected_a_b", "(end)", 77]
+// ["0", "semicolon", "expected_a_b", "(end)", 1]
 
             warn_at(
                 "expected_a_b",
@@ -2059,7 +2054,7 @@ function jslint_phase3_parse(state) {
             if (the_label.id === "ignore") {
 
 // test_cause:
-// ["ignore:", "parse_statement", "unexpected_a", "ignore", 77]
+// ["ignore:", "parse_statement", "unexpected_a", "ignore", 1]
 
                 warn("unexpected_a", the_label);
             }
@@ -2082,7 +2077,7 @@ function jslint_phase3_parse(state) {
             advance();
 
 // test_cause:
-// ["aa:", "parse_statement", "unexpected_label_a", "aa", 77]
+// ["aa:", "parse_statement", "unexpected_label_a", "aa", 1]
 
             warn("unexpected_label_a", the_label);
         }
@@ -2114,7 +2109,7 @@ function jslint_phase3_parse(state) {
             if (the_statement.wrapped && the_statement.id !== "(") {
 
 // test_cause:
-// ["(0)", "parse_statement", "unexpected_a", "(", 77]
+// ["(0)", "parse_statement", "unexpected_a", "(", 1]
 
                 warn("unexpected_a", first);
             }
@@ -2146,11 +2141,11 @@ function jslint_phase3_parse(state) {
             case "}":
 
 // test_cause:
-// [";", "parse_statements", "closer", "", 77]
-// ["case", "parse_statements", "closer", "", 77]
-// ["default", "parse_statements", "closer", "", 77]
-// ["else", "parse_statements", "closer", "", 77]
-// ["}", "parse_statements", "closer", "", 77]
+// [";", "parse_statements", "closer", "", 0]
+// ["case", "parse_statements", "closer", "", 0]
+// ["default", "parse_statements", "closer", "", 0]
+// ["else", "parse_statements", "closer", "", 0]
+// ["}", "parse_statements", "closer", "", 0]
 
                 test_cause("closer");
                 return statement_list;
@@ -2160,7 +2155,7 @@ function jslint_phase3_parse(state) {
             if (disrupt) {
 
 // test_cause:
-// ["while(0){break;0;}", "parse_statements", "unreachable_a", "0", 77]
+// ["while(0){break;0;}", "parse_statements", "unreachable_a", "0", 16]
 
                 warn("unreachable_a", a_statement);
             }
@@ -2177,7 +2172,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // while(0){}
-// ", "check_not_top_level", "unexpected_at_top_level_a", "while", 77]
+// ", "check_not_top_level", "unexpected_at_top_level_a", "while", 1]
 
             warn("unexpected_at_top_level_a", thing);
         }
@@ -2220,7 +2215,7 @@ function jslint_phase3_parse(state) {
             if (!option_dict.devel && special !== "ignore") {
 
 // test_cause:
-// ["function aa(){}", "block", "empty_block", "{", 77]
+// ["function aa(){}", "block", "empty_block", "{", 14]
 
                 warn("empty_block", the_block);
             }
@@ -2249,7 +2244,7 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["0=0", "check_mutation", "bad_assignment_a", "0", 77]
+// ["0=0", "check_mutation", "bad_assignment_a", "0", 1]
 
             warn("bad_assignment_a", the_thing);
             return false;
@@ -2384,7 +2379,7 @@ function jslint_phase3_parse(state) {
             const the_token = token_now;
 
 // test_cause:
-// ["0**0", "parse_infixr_led", "led", "", 77]
+// ["0**0", "parse_infixr_led", "led", "", 0]
 
             test_cause("led");
             the_token.arity = "binary";
@@ -2470,7 +2465,7 @@ function jslint_phase3_parse(state) {
         } else if (!name.identifier) {
 
 // test_cause:
-// ["let aa={0:0}", "survey", "expected_identifier_a", "0", 77]
+// ["let aa={0:0}", "survey", "expected_identifier_a", "0", 9]
 
             return stop("expected_identifier_a", name);
         }
@@ -2489,7 +2484,7 @@ function jslint_phase3_parse(state) {
                 if (tenure[id] !== true) {
 
 // test_cause:
-// ["/*property aa*/\naa.bb", "survey", "unregistered_property_a", "bb", 77]
+// ["/*property aa*/\naa.bb", "survey", "unregistered_property_a", "bb", 4]
 
                     warn("unregistered_property_a", name);
                 }
@@ -2503,11 +2498,11 @@ function jslint_phase3_parse(state) {
             ) {
 
 // test_cause:
-// ["aa.$", "survey", "weird_property_a", "$", 77]
-// ["aa._", "survey", "weird_property_a", "_", 77]
-// ["aa._aa", "survey", "weird_property_a", "_aa", 77]
-// ["aa.aaSync", "survey", "weird_property_a", "aaSync", 77]
-// ["aa.aa_", "survey", "weird_property_a", "aa_", 77]
+// ["aa.$", "survey", "weird_property_a", "$", 4]
+// ["aa._", "survey", "weird_property_a", "_", 4]
+// ["aa._aa", "survey", "weird_property_a", "_aa", 4]
+// ["aa.aaSync", "survey", "weird_property_a", "aaSync", 4]
+// ["aa.aa_", "survey", "weird_property_a", "aa_", 4]
 
                 warn("weird_property_a", name);
             }
@@ -2532,7 +2527,7 @@ function jslint_phase3_parse(state) {
             if (token_nxt.id !== ")") {
 
 // test_cause:
-// ["0?0:0", "parse_ternary_led", "use_open", "?", 77]
+// ["0?0:0", "parse_ternary_led", "use_open", "?", 2]
 
                 warn("use_open", the_token);
             }
@@ -2576,7 +2571,7 @@ function jslint_phase3_parse(state) {
     constant("arguments", "object", function const_arguments() {
 
 // test_cause:
-// ["arguments", "const_arguments", "unexpected_a", "arguments", 77]
+// ["arguments", "const_arguments", "unexpected_a", "arguments", 1]
 
         warn("unexpected_a", token_now);
         return token_now;
@@ -2585,13 +2580,13 @@ function jslint_phase3_parse(state) {
         if (!option_dict.eval) {
 
 // test_cause:
-// ["eval", "const_eval", "unexpected_a", "eval", 77]
+// ["eval", "const_eval", "unexpected_a", "eval", 1]
 
             warn("unexpected_a", token_now);
         } else if (token_nxt.id !== "(") {
 
 // test_cause:
-// ["/*jslint eval*/\neval", "const_eval", "expected_a_before_b", "(end)", 77]
+// ["/*jslint eval*/\neval", "const_eval", "expected_a_before_b", "(end)", 1]
 
             warn("expected_a_before_b", token_nxt, "(", artifact());
         }
@@ -2602,7 +2597,7 @@ function jslint_phase3_parse(state) {
         if (!option_dict.eval) {
 
 // test_cause:
-// ["Function", "const_Function", "unexpected_a", "Function", 77]
+// ["Function", "const_Function", "unexpected_a", "Function", 1]
 
             warn("unexpected_a", token_now);
         } else if (token_nxt.id !== "(") {
@@ -2611,7 +2606,7 @@ function jslint_phase3_parse(state) {
 // ["
 // /*jslint eval*/
 // Function
-// ", "const_Function", "expected_a_before_b", "(end)", 77]
+// ", "const_Function", "expected_a_before_b", "(end)", 1]
 
             warn("expected_a_before_b", token_nxt, "(", artifact());
         }
@@ -2620,7 +2615,7 @@ function jslint_phase3_parse(state) {
     constant("ignore", "undefined", function const_ignore() {
 
 // test_cause:
-// ["ignore", "const_ignore", "unexpected_a", "ignore", 77]
+// ["ignore", "const_ignore", "unexpected_a", "ignore", 1]
 
         warn("unexpected_a", token_now);
         return token_now;
@@ -2629,7 +2624,7 @@ function jslint_phase3_parse(state) {
     constant("isFinite", "function", function const_isInfinite() {
 
 // test_cause:
-// ["isFinite", "const_isInfinite", "expected_a_b", "isFinite", 77]
+// ["isFinite", "const_isInfinite", "expected_a_b", "isFinite", 1]
 
         warn("expected_a_b", token_now, "Number.isFinite", "isFinite");
         return token_now;
@@ -2637,7 +2632,7 @@ function jslint_phase3_parse(state) {
     constant("isNaN", "function", function const_isNaN() {
 
 // test_cause:
-// ["isNaN(0)", "const_isNaN", "number_isNaN", "isNaN", 77]
+// ["isNaN(0)", "const_isNaN", "number_isNaN", "isNaN", 1]
 
         warn("number_isNaN", token_now);
         return token_now;
@@ -2648,7 +2643,7 @@ function jslint_phase3_parse(state) {
         if (!option_dict.this) {
 
 // test_cause:
-// ["this", "const_this", "unexpected_a", "this", 77]
+// ["this", "const_this", "unexpected_a", "this", 1]
 
             warn("unexpected_a", token_now);
         }
@@ -2702,8 +2697,8 @@ function jslint_phase3_parse(state) {
         if (left.id !== "function") {
 
 // test_cause:
-// ["(0?0:0)()", "check_left", "unexpected_a", "(", 77]
-// ["0()", "check_left", "unexpected_a", "(", 77]
+// ["(0?0:0)()", "check_left", "unexpected_a", "(", 8]
+// ["0()", "check_left", "unexpected_a", "(", 2]
 
             check_left(left, the_paren);
         }
@@ -2735,14 +2730,14 @@ function jslint_phase3_parse(state) {
         if (the_paren.expression.length === 2) {
 
 // test_cause:
-// ["aa(0)", "infix_lparen", "free", "", 77]
+// ["aa(0)", "infix_lparen", "free", "", 0]
 
             test_cause("free");
             the_paren.free = true;
             if (the_argument.wrapped === true) {
 
 // test_cause:
-// ["aa((0))", "infix_lparen", "unexpected_a", "(", 77]
+// ["aa((0))", "infix_lparen", "unexpected_a", "(", 3]
 
                 warn("unexpected_a", the_paren);
             }
@@ -2752,8 +2747,8 @@ function jslint_phase3_parse(state) {
         } else {
 
 // test_cause:
-// ["aa()", "infix_lparen", "not_free", "", 77]
-// ["aa(0,0)", "infix_lparen", "not_free", "", 77]
+// ["aa()", "infix_lparen", "not_free", "", 0]
+// ["aa(0,0)", "infix_lparen", "not_free", "", 0]
 
             test_cause("not_free");
             the_paren.free = false;
@@ -2786,14 +2781,14 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["\"\".aa", "check_left", "unexpected_a", ".", 77]
+// ["\"\".aa", "check_left", "unexpected_a", ".", 3]
 
             check_left(left, the_token);
         }
         if (!name.identifier) {
 
 // test_cause:
-// ["aa.0", "infix_dot", "expected_identifier_a", "0", 77]
+// ["aa.0", "infix_dot", "expected_identifier_a", "0", 4]
 
             stop("expected_identifier_a");
         }
@@ -2826,7 +2821,7 @@ function jslint_phase3_parse(state) {
             )
 
 // test_cause:
-// ["(0+0)?.0", "infix_option_chain", "check_left", "", 77]
+// ["(0+0)?.0", "infix_option_chain", "check_left", "", 0]
 
             && (left.id !== "+" || name.id !== "slice")
             && (
@@ -2837,16 +2832,16 @@ function jslint_phase3_parse(state) {
             test_cause("check_left");
 
 // test_cause:
-// ["(/./)?.0", "check_left", "unexpected_a", "?.", 77]
-// ["\"aa\"?.0", "check_left", "unexpected_a", "?.", 77]
-// ["aa=[]?.aa", "check_left", "unexpected_a", "?.", 77]
+// ["(/./)?.0", "check_left", "unexpected_a", "?.", 6]
+// ["\"aa\"?.0", "check_left", "unexpected_a", "?.", 5]
+// ["aa=[]?.aa", "check_left", "unexpected_a", "?.", 6]
 
             check_left(left, the_token);
         }
         if (!name.identifier) {
 
 // test_cause:
-// ["aa?.0", "infix_option_chain", "expected_identifier_a", "0", 77]
+// ["aa?.0", "infix_option_chain", "expected_identifier_a", "0", 5]
 
             stop("expected_identifier_a");
         }
@@ -2868,14 +2863,14 @@ function jslint_phase3_parse(state) {
             if (rx_identifier.test(name)) {
 
 // test_cause:
-// ["aa[`aa`]", "infix_lbracket", "subscript_a", "aa", 77]
+// ["aa[`aa`]", "infix_lbracket", "subscript_a", "aa", 4]
 
                 warn("subscript_a", the_subscript, name);
             }
         }
 
 // test_cause:
-// ["0[0]", "check_left", "unexpected_a", "[", 77]
+// ["0[0]", "check_left", "unexpected_a", "[", 2]
 
         check_left(left, the_token);
         the_token.expression = [left, the_subscript];
@@ -2885,7 +2880,7 @@ function jslint_phase3_parse(state) {
     infix("=>", 170, function infix_fart_unwrapped(left) {
 
 // test_cause:
-// ["aa=>0", "infix_fart_unwrapped", "wrap_parameter", "aa", 77]
+// ["aa=>0", "infix_fart_unwrapped", "wrap_parameter", "aa", 1]
 
         return stop("wrap_parameter", left);
     });
@@ -2907,7 +2902,7 @@ function jslint_phase3_parse(state) {
                 advance("${");
 
 // test_cause:
-// ["let aa=`${}`;", "parse_tick", "${", "", 77]
+// ["let aa=`${}`;", "parse_tick", "${", "", 0]
 
                 test_cause("${");
                 the_tick.expression.push(parse_expression(0));
@@ -2922,7 +2917,7 @@ function jslint_phase3_parse(state) {
         const the_tick = parse_tick();
 
 // test_cause:
-// ["0``", "check_left", "unexpected_a", "`", 77]
+// ["0``", "check_left", "unexpected_a", "`", 2]
 
         check_left(left, the_tick);
         the_tick.expression = [left].concat(the_tick.expression);
@@ -2966,7 +2961,7 @@ function jslint_phase3_parse(state) {
                 if (token_nxt.id === "]") {
 
 // test_cause:
-// ["let aa=[0,]", "prefix_lbracket", "unexpected_a", ",", 77]
+// ["let aa=[0,]", "prefix_lbracket", "unexpected_a", ",", 10]
 
                     warn("unexpected_a", token_now);
                     break;
@@ -2979,14 +2974,14 @@ function jslint_phase3_parse(state) {
     prefix("/=", function prefix_assign_divide() {
 
 // test_cause:
-// ["/=", "prefix_assign_divide", "expected_a_b", "/=", 77]
+// ["/=", "prefix_assign_divide", "expected_a_b", "/=", 1]
 
         stop("expected_a_b", token_now, "/\\=", "/=");
     });
     prefix("=>", function prefix_fart() {
 
 // test_cause:
-// ["=>0", "prefix_fart", "expected_a_before_b", "=>", 77]
+// ["=>0", "prefix_fart", "expected_a_before_b", "=>", 1]
 
         return stop("expected_a_before_b", token_now, "()", "=>");
     });
@@ -2997,7 +2992,7 @@ function jslint_phase3_parse(state) {
         if (token_nxt.id !== "(") {
 
 // test_cause:
-// ["new aa", "prefix_new", "expected_a_before_b", "(end)", 77]
+// ["new aa", "prefix_new", "expected_a_before_b", "(end)", 1]
 
             warn("expected_a_before_b", token_nxt, "()", artifact());
         }
@@ -3009,8 +3004,8 @@ function jslint_phase3_parse(state) {
         const the_void = token_now;
 
 // test_cause:
-// ["void 0", "prefix_void", "unexpected_a", "void", 77]
-// ["void", "prefix_void", "unexpected_a", "void", 77]
+// ["void 0", "prefix_void", "unexpected_a", "void", 1]
+// ["void", "prefix_void", "unexpected_a", "void", 1]
 
         warn("unexpected_a", the_void);
         the_void.expression = parse_expression(0);
@@ -3030,7 +3025,7 @@ function jslint_phase3_parse(state) {
                     if (optional !== undefined) {
 
 // test_cause:
-// ["function aa(aa=0,{}){}", "parameter", "required_a_optional_b", "aa", 77]
+// ["function aa(aa=0,{}){}", "parameter", "required_a_optional_b", "aa", 18]
 
                         warn(
                             "required_a_optional_b",
@@ -3048,8 +3043,8 @@ function jslint_phase3_parse(state) {
                         if (!subparam.identifier) {
 
 // test_cause:
-// ["function aa(aa=0,{}){}", "parameter", "expected_identifier_a", "}", 77]
-// ["function aa({0}){}", "parameter", "expected_identifier_a", "0", 77]
+// ["function aa(aa=0,{}){}", "parameter", "expected_identifier_a", "}", 19]
+// ["function aa({0}){}", "parameter", "expected_identifier_a", "0", 14]
 
                             return stop("expected_identifier_a");
                         }
@@ -3064,7 +3059,7 @@ function jslint_phase3_parse(state) {
                             if (!subparam.identifier) {
 
 // test_cause:
-// ["function aa({aa:0}){}", "parameter", "expected_identifier_a", "}", 77]
+// ["function aa({aa:0}){}", "parameter", "expected_identifier_a", "}", 18]
 
                                 return stop(
                                     "expected_identifier_a",
@@ -3074,7 +3069,7 @@ function jslint_phase3_parse(state) {
                         }
 
 // test_cause:
-// ["function aa({aa=aa},aa){}", "parameter", "equal", "", 77]
+// ["function aa({aa=aa},aa){}", "parameter", "equal", "", 0]
 
                         test_cause("equal");
                         if (token_nxt.id === "=") {
@@ -3095,7 +3090,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // function aa({bb,aa}){}
-// ", "check_ordered", "expected_a_b_before_c_d", "aa", 77]
+// ", "check_ordered", "expected_a_b_before_c_d", "aa", 17]
 
                     check_ordered("parameter", param.names);
                     advance("}");
@@ -3109,7 +3104,7 @@ function jslint_phase3_parse(state) {
                     if (optional !== undefined) {
 
 // test_cause:
-// ["function aa(aa=0,[]){}", "parameter", "required_a_optional_b", "aa", 77]
+// ["function aa(aa=0,[]){}", "parameter", "required_a_optional_b", "aa", 18]
 
                         warn(
                             "required_a_optional_b",
@@ -3127,7 +3122,7 @@ function jslint_phase3_parse(state) {
                         if (!subparam.identifier) {
 
 // test_cause:
-// ["function aa(aa=0,[]){}", "parameter", "expected_identifier_a", "]", 77]
+// ["function aa(aa=0,[]){}", "parameter", "expected_identifier_a", "]", 19]
 
                             return stop("expected_identifier_a");
                         }
@@ -3135,7 +3130,7 @@ function jslint_phase3_parse(state) {
                         param.names.push(subparam);
 
 // test_cause:
-// ["function aa([aa=aa],aa){}", "parameter", "id", "", 77]
+// ["function aa([aa=aa],aa){}", "parameter", "id", "", 0]
 
                         test_cause("id");
                         if (token_nxt.id === "=") {
@@ -3164,7 +3159,7 @@ function jslint_phase3_parse(state) {
                         if (optional !== undefined) {
 
 // test_cause:
-// ["function aa(aa=0,...){}", "parameter", "required_a_optional_b", "aa", 77]
+// ["function aa(aa=0,...){}", "parameter", "required_a_optional_b", "aa", 21]
 
                             warn(
                                 "required_a_optional_b",
@@ -3177,7 +3172,7 @@ function jslint_phase3_parse(state) {
                     if (!token_nxt.identifier) {
 
 // test_cause:
-// ["function aa(0){}", "parameter", "expected_identifier_a", "0", 77]
+// ["function aa(0){}", "parameter", "expected_identifier_a", "0", 13]
 
                         return stop("expected_identifier_a");
                     }
@@ -3196,7 +3191,7 @@ function jslint_phase3_parse(state) {
                             if (optional !== undefined) {
 
 // test_cause:
-// ["function aa(aa=0,bb){}", "parameter", "required_a_optional_b", "aa", 77]
+// ["function aa(aa=0,bb){}", "parameter", "required_a_optional_b", "aa", 18]
 
                                 warn(
                                     "required_a_optional_b",
@@ -3231,8 +3226,8 @@ function jslint_phase3_parse(state) {
                 if (!token_nxt.identifier) {
 
 // test_cause:
-// ["function(){}", "parse_function", "expected_identifier_a", "(", 77]
-// ["function*aa(){}", "parse_function", "expected_identifier_a", "*", 77]
+// ["function(){}", "parse_function", "expected_identifier_a", "(", 9]
+// ["function*aa(){}", "parse_function", "expected_identifier_a", "*", 9]
 
                     return stop("expected_identifier_a");
                 }
@@ -3275,7 +3270,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // while(0){aa.map(function(){});}
-// ", "parse_function", "function_in_loop", "function", 77]
+// ", "parse_function", "function_in_loop", "function", 17]
 
             warn("function_in_loop", the_function);
         }
@@ -3294,7 +3289,7 @@ function jslint_phase3_parse(state) {
         if (the_function.arity !== "statement" && typeof name === "object") {
 
 // test_cause:
-// ["let aa=function bb(){return;};", "parse_function", "expression", "", 77]
+// ["let aa=function bb(){return;};", "parse_function", "expression", "", 0]
 
             test_cause("expression");
             enroll(name, "function", true);
@@ -3315,7 +3310,7 @@ function jslint_phase3_parse(state) {
         advance("(");
 
 // test_cause:
-// ["function aa(){}", "parse_function", "opener", "", 77]
+// ["function aa(){}", "parse_function", "opener", "", 0]
 
         test_cause("opener");
         token_now.free = false;
@@ -3338,7 +3333,7 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["function aa(){}0", "parse_function", "unexpected_a", "0", 77]
+// ["function aa(){}0", "parse_function", "unexpected_a", "0", 16]
 
             return stop("unexpected_a");
         }
@@ -3349,9 +3344,9 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["function aa(){}\n.aa", "parse_function", "unexpected_a", ".", 77]
-// ["function aa(){}\n?.aa", "parse_function", "unexpected_a", "?.", 77]
-// ["function aa(){}\n[]", "parse_function", "unexpected_a", "[", 77]
+// ["function aa(){}\n.aa", "parse_function", "unexpected_a", ".", 1]
+// ["function aa(){}\n?.aa", "parse_function", "unexpected_a", "?.", 1]
+// ["function aa(){}\n[]", "parse_function", "unexpected_a", "[", 1]
 
             warn("unexpected_a");
         }
@@ -3377,7 +3372,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // async function aa(){}
-// ", "parse_async", "missing_await_statement", "function", 77]
+// ", "parse_async", "missing_await_statement", "function", 7]
 
             warn("missing_await_statement", the_function);
         }
@@ -3389,9 +3384,9 @@ function jslint_phase3_parse(state) {
         if (functionage.async === 0) {
 
 // test_cause:
-// ["await", "parse_await", "unexpected_a", "await", 77]
-// ["function aa(){aa=await 0;}", "parse_await", "unexpected_a", "await", 77]
-// ["function aa(){await 0;}", "parse_await", "unexpected_a", "await", 77]
+// ["await", "parse_await", "unexpected_a", "await", 1]
+// ["function aa(){aa=await 0;}", "parse_await", "unexpected_a", "await", 18]
+// ["function aa(){await 0;}", "parse_await", "unexpected_a", "await", 15]
 
             warn("unexpected_a", the_await);
         } else {
@@ -3421,7 +3416,7 @@ function jslint_phase3_parse(state) {
         if (functionage.loop > 0) {
 
 // test_cause:
-// ["while(0){aa.map(()=>0);}", "parse_fart", "function_in_loop", "=>", 77]
+// ["while(0){aa.map(()=>0);}", "parse_fart", "function_in_loop", "=>", 19]
 
             warn("function_in_loop", the_fart);
         }
@@ -3444,7 +3439,7 @@ function jslint_phase3_parse(state) {
         the_fart.parameters.forEach(function (name) {
 
 // test_cause:
-// ["(aa)=>{}", "parse_fart", "parameter", "", 77]
+// ["(aa)=>{}", "parse_fart", "parameter", "", 0]
 
             test_cause("parameter");
             enroll(name, "parameter", true);
@@ -3452,7 +3447,7 @@ function jslint_phase3_parse(state) {
         if (token_nxt.id === "{") {
 
 // test_cause:
-// ["()=>{}", "parse_fart", "expected_a_b", "=>", 77]
+// ["()=>{}", "parse_fart", "expected_a_b", "=>", 3]
 
             warn("expected_a_b", the_fart, "function", "=>");
             the_fart.block = block("body");
@@ -3478,7 +3473,7 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["()=>0", "prefix_lparen", "fart", "", 77]
+// ["()=>0", "prefix_lparen", "fart", "", 0]
 
             test_cause("fart");
             the_paren.free = false;
@@ -3486,7 +3481,7 @@ function jslint_phase3_parse(state) {
         }
 
 // test_cause:
-// ["(0)", "prefix_lparen", "expr", "", 77]
+// ["(0)", "prefix_lparen", "expr", "", 0]
 
         test_cause("expr");
         the_paren.free = true;
@@ -3494,7 +3489,7 @@ function jslint_phase3_parse(state) {
         if (the_value.wrapped === true) {
 
 // test_cause:
-// ["((0))", "prefix_lparen", "unexpected_a", "(", 77]
+// ["((0))", "prefix_lparen", "unexpected_a", "(", 1]
 
             warn("unexpected_a", the_paren);
         }
@@ -3505,20 +3500,20 @@ function jslint_phase3_parse(state) {
                 if (the_value.id === "{" || the_value.id === "[") {
 
 // test_cause:
-// ["([])=>0", "prefix_lparen", "expected_a_before_b", "(", 77]
-// ["({})=>0", "prefix_lparen", "expected_a_before_b", "(", 77]
+// ["([])=>0", "prefix_lparen", "expected_a_before_b", "(", 1]
+// ["({})=>0", "prefix_lparen", "expected_a_before_b", "(", 1]
 
                     warn("expected_a_before_b", the_paren, "function", "(");
 
 // test_cause:
-// ["([])=>0", "prefix_lparen", "expected_a_b", "=>", 77]
-// ["({})=>0", "prefix_lparen", "expected_a_b", "=>", 77]
+// ["([])=>0", "prefix_lparen", "expected_a_b", "=>", 5]
+// ["({})=>0", "prefix_lparen", "expected_a_b", "=>", 5]
 
                     return stop("expected_a_b", token_nxt, "{", "=>");
                 }
 
 // test_cause:
-// ["(0)=>0", "prefix_lparen", "expected_identifier_a", "0", 77]
+// ["(0)=>0", "prefix_lparen", "expected_identifier_a", "0", 2]
 
                 return stop("expected_identifier_a", the_value);
             }
@@ -3552,7 +3547,7 @@ function jslint_phase3_parse(state) {
                     if (!option_dict.getset) {
 
 // test_cause:
-// ["aa={get aa(){}}", "prefix_lbrace", "unexpected_a", "get", 77]
+// ["aa={get aa(){}}", "prefix_lbrace", "unexpected_a", "get", 5]
 
                         warn("unexpected_a", name);
                     }
@@ -3564,7 +3559,7 @@ function jslint_phase3_parse(state) {
                     if (seen[full] === true || seen[id] === true) {
 
 // test_cause:
-// ["aa={get aa(){},get aa(){}}", "prefix_lbrace", "duplicate_a", "aa", 77]
+// ["aa={get aa(){},get aa(){}}", "prefix_lbrace", "duplicate_a", "aa", 20]
 
                         warn("duplicate_a", name);
                     }
@@ -3575,7 +3570,7 @@ function jslint_phase3_parse(state) {
                     if (typeof seen[id] === "boolean") {
 
 // test_cause:
-// ["aa={aa,aa}", "prefix_lbrace", "duplicate_a", "aa", 77]
+// ["aa={aa,aa}", "prefix_lbrace", "duplicate_a", "aa", 8]
 
                         warn("duplicate_a", name);
                     }
@@ -3586,7 +3581,7 @@ function jslint_phase3_parse(state) {
                         if (typeof extra === "string") {
 
 // test_cause:
-// ["aa={get aa}", "prefix_lbrace", "closer", "", 77]
+// ["aa={get aa}", "prefix_lbrace", "closer", "", 0]
 
                             test_cause("closer");
                             advance("(");
@@ -3595,8 +3590,8 @@ function jslint_phase3_parse(state) {
                     } else if (token_nxt.id === "(") {
 
 // test_cause:
-// ["aa={aa()}", "prefix_lbrace", "paren", "", 77]
-// ["aa={get aa(){}}", "prefix_lbrace", "paren", "", 77]
+// ["aa={aa()}", "prefix_lbrace", "paren", "", 0]
+// ["aa={get aa(){}}", "prefix_lbrace", "paren", "", 0]
 
                         test_cause("paren");
                         value = parse_function({
@@ -3615,7 +3610,7 @@ function jslint_phase3_parse(state) {
                         if (typeof extra === "string") {
 
 // test_cause:
-// ["aa={get aa.aa}", "prefix_lbrace", "paren", "", 77]
+// ["aa={get aa.aa}", "prefix_lbrace", "paren", "", 0]
 
                             test_cause("paren");
                             advance("(");
@@ -3629,7 +3624,7 @@ function jslint_phase3_parse(state) {
                         ) {
 
 // test_cause:
-// ["aa={aa:aa}", "prefix_lbrace", "unexpected_a", ": aa", 77]
+// ["aa={aa:aa}", "prefix_lbrace", "unexpected_a", ": aa", 7]
 
                             warn("unexpected_a", the_colon, ": " + name.id);
                         }
@@ -3642,7 +3637,7 @@ function jslint_phase3_parse(state) {
                 } else {
 
 // test_cause:
-// ["aa={\"aa\":0}", "prefix_lbrace", "colon", "", 77]
+// ["aa={\"aa\":0}", "prefix_lbrace", "colon", "", 0]
 
                     test_cause("colon");
                     advance(":");
@@ -3655,14 +3650,14 @@ function jslint_phase3_parse(state) {
                 }
 
 // test_cause:
-// ["aa={\"aa\":0,\"bb\":0}", "prefix_lbrace", "comma", "", 77]
+// ["aa={\"aa\":0,\"bb\":0}", "prefix_lbrace", "comma", "", 0]
 
                 test_cause("comma");
                 advance(",");
                 if (token_nxt.id === "}") {
 
 // test_cause:
-// ["let aa={aa:0,}", "prefix_lbrace", "unexpected_a", ",", 77]
+// ["let aa={aa:0,}", "prefix_lbrace", "unexpected_a", ",", 13]
 
                     warn("unexpected_a", token_now);
                     break;
@@ -3671,7 +3666,7 @@ function jslint_phase3_parse(state) {
         }
 
 // test_cause:
-// ["aa={bb,aa}", "check_ordered", "expected_a_b_before_c_d", "aa", 77]
+// ["aa={bb,aa}", "check_ordered", "expected_a_b_before_c_d", "aa", 8]
 
         check_ordered(
             "property",
@@ -3688,7 +3683,7 @@ function jslint_phase3_parse(state) {
     stmt(";", function stmt_semicolon() {
 
 // test_cause:
-// [";", "stmt_semicolon", "unexpected_a", ";", 77]
+// [";", "stmt_semicolon", "unexpected_a", ";", 1]
 
         warn("unexpected_a", token_now);
         return token_now;
@@ -3696,8 +3691,8 @@ function jslint_phase3_parse(state) {
     stmt("{", function stmt_lbrace() {
 
 // test_cause:
-// [";{}", "stmt_lbrace", "naked_block", "{", 77]
-// ["class aa{}", "stmt_lbrace", "naked_block", "{", 77]
+// [";{}", "stmt_lbrace", "naked_block", "{", 2]
+// ["class aa{}", "stmt_lbrace", "naked_block", "{", 9]
 
         warn("naked_block", token_now);
         return block("naked");
@@ -3713,7 +3708,7 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["break", "stmt_break", "unexpected_a", "break", 77]
+// ["break", "stmt_break", "unexpected_a", "break", 1]
 
             warn("unexpected_a", the_break);
         }
@@ -3728,13 +3723,13 @@ function jslint_phase3_parse(state) {
                 if (the_label !== undefined && the_label.dead) {
 
 // test_cause:
-// ["aa:{function aa(aa){break aa;}}", "stmt_break", "out_of_scope_a", "aa", 77]
+// ["aa:{function aa(aa){break aa;}}", "stmt_break", "out_of_scope_a", "aa", 27]
 
                     warn("out_of_scope_a");
                 } else {
 
 // test_cause:
-// ["aa:{break aa;}", "stmt_break", "not_label_a", "aa", 77]
+// ["aa:{break aa;}", "stmt_break", "not_label_a", "aa", 11]
 
                     warn("not_label_a");
                 }
@@ -3767,7 +3762,7 @@ function jslint_phase3_parse(state) {
             } else if (the_variable.id !== mode_var) {
 
 // test_cause:
-// ["let aa;var aa", "parse_var", "expected_a_b", "var", 77]
+// ["let aa;var aa", "parse_var", "expected_a_b", "var", 8]
 
                 warn("expected_a_b", the_variable, mode_var, the_variable.id);
             }
@@ -3778,7 +3773,7 @@ function jslint_phase3_parse(state) {
         if (functionage.switch > 0) {
 
 // test_cause:
-// ["switch(0){case 0:var aa}", "parse_var", "var_switch", "var", 77]
+// ["switch(0){case 0:var aa}", "parse_var", "var_switch", "var", 18]
 
             warn("var_switch", the_variable);
         }
@@ -3791,9 +3786,9 @@ function jslint_phase3_parse(state) {
         case "var":
 
 // test_cause:
-// ["const aa=0;const bb=0;", "parse_var", "declare", "", 77]
-// ["let aa=0;let bb=0;", "parse_var", "declare", "", 77]
-// ["var aa=0;var bb=0;", "parse_var", "declare", "", 77]
+// ["const aa=0;const bb=0;", "parse_var", "declare", "", 0]
+// ["let aa=0;let bb=0;", "parse_var", "declare", "", 0]
+// ["var aa=0;var bb=0;", "parse_var", "declare", "", 0]
 
             test_cause("declare");
             variable_prv = functionage.last_statement;
@@ -3801,7 +3796,7 @@ function jslint_phase3_parse(state) {
         case "import":
 
 // test_cause:
-// ["import aa from \"aa\";\nlet bb=0;", "parse_var", "import", "", 77]
+// ["import aa from \"aa\";\nlet bb=0;", "parse_var", "import", "", 0]
 
             test_cause("import");
             break;
@@ -3817,10 +3812,10 @@ function jslint_phase3_parse(state) {
 // ["
 // /*jslint beta*/
 // console.log();let aa=0;
-// ", "parse_var", "var_on_top", "let", 77]
-// ["console.log();var aa=0;", "parse_var", "var_on_top", "var", 77]
-// ["try{aa();}catch(aa){var aa=0;}", "parse_var", "var_on_top", "var", 77]
-// ["while(0){var aa;}", "parse_var", "var_on_top", "var", 77]
+// ", "parse_var", "var_on_top", "let", 15]
+// ["console.log();var aa=0;", "parse_var", "var_on_top", "var", 15]
+// ["try{aa();}catch(aa){var aa=0;}", "parse_var", "var_on_top", "var", 21]
+// ["while(0){var aa;}", "parse_var", "var_on_top", "var", 10]
 
                 warn("var_on_top", token_now);
             }
@@ -3830,7 +3825,7 @@ function jslint_phase3_parse(state) {
                 if (the_variable.id === "var") {
 
 // test_cause:
-// ["var{aa}=0", "parse_var", "unexpected_a", "var", 77]
+// ["var{aa}=0", "parse_var", "unexpected_a", "var", 1]
 
                     warn("unexpected_a", the_variable);
                 }
@@ -3841,7 +3836,7 @@ function jslint_phase3_parse(state) {
                     if (!name.identifier) {
 
 // test_cause:
-// ["let {0}", "parse_var", "expected_identifier_a", "0", 77]
+// ["let {0}", "parse_var", "expected_identifier_a", "0", 6]
 
                         return stop("expected_identifier_a");
                     }
@@ -3852,8 +3847,8 @@ function jslint_phase3_parse(state) {
                         if (!token_nxt.identifier) {
 
 // test_cause:
-// ["let {aa:0}", "parse_var", "expected_identifier_a", "0", 77]
-// ["let {aa:{aa}}", "parse_var", "expected_identifier_a", "{", 77]
+// ["let {aa:0}", "parse_var", "expected_identifier_a", "0", 9]
+// ["let {aa:{aa}}", "parse_var", "expected_identifier_a", "{", 9]
 
                             return stop("expected_identifier_a");
                         }
@@ -3871,7 +3866,7 @@ function jslint_phase3_parse(state) {
                     if (token_nxt.id === "=") {
 
 // test_cause:
-// ["let {aa=0}", "parse_var", "assign", "", 77]
+// ["let {aa=0}", "parse_var", "assign", "", 0]
 
                         test_cause("assign");
                         advance("=");
@@ -3885,7 +3880,7 @@ function jslint_phase3_parse(state) {
                 }
 
 // test_cause:
-// ["let{bb,aa}", "check_ordered", "expected_a_b_before_c_d", "aa", 77]
+// ["let{bb,aa}", "check_ordered", "expected_a_b_before_c_d", "aa", 8]
 
                 check_ordered(the_variable.id, the_variable.names);
                 advance("}");
@@ -3895,7 +3890,7 @@ function jslint_phase3_parse(state) {
                 if (the_variable.id === "var") {
 
 // test_cause:
-// ["var[aa]=0", "parse_var", "unexpected_a", "var", 77]
+// ["var[aa]=0", "parse_var", "unexpected_a", "var", 1]
 
                     warn("unexpected_a", the_variable);
                 }
@@ -3910,7 +3905,7 @@ function jslint_phase3_parse(state) {
                     if (!token_nxt.identifier) {
 
 // test_cause:
-// ["let[]", "parse_var", "expected_identifier_a", "]", 77]
+// ["let[]", "parse_var", "expected_identifier_a", "]", 5]
 
                         return stop("expected_identifier_a");
                     }
@@ -3945,7 +3940,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // let ignore;function aa(ignore) {}
-// ", "parse_var", "unexpected_a", "ignore", 77]
+// ", "parse_var", "unexpected_a", "ignore", 5]
 
                     warn("unexpected_a", name);
                 }
@@ -3960,8 +3955,8 @@ function jslint_phase3_parse(state) {
             } else {
 
 // test_cause:
-// ["let 0", "parse_var", "expected_identifier_a", "0", 77]
-// ["var{aa:{aa}}", "parse_var", "expected_identifier_a", "{", 77]
+// ["let 0", "parse_var", "expected_identifier_a", "0", 5]
+// ["var{aa:{aa}}", "parse_var", "expected_identifier_a", "{", 8]
 
                 return stop("expected_identifier_a");
             }
@@ -3970,7 +3965,7 @@ function jslint_phase3_parse(state) {
             }
 
 // test_cause:
-// ["let aa,bb;", "parse_var", "expected_a_b", ",", 77]
+// ["let aa,bb;", "parse_var", "expected_a_b", ",", 7]
 
             warn("expected_a_b", token_nxt, ";", ",");
             advance(",");
@@ -3993,15 +3988,15 @@ function jslint_phase3_parse(state) {
 // ["
 // /*jslint beta*/
 // const bb=0;const aa=0;
-// ", "parse_var", "expected_a_b_before_c_d", "aa", 77]
+// ", "parse_var", "expected_a_b_before_c_d", "aa", 12]
 // ["
 // /*jslint beta*/
 // let bb;let aa;
-// ", "parse_var", "expected_a_b_before_c_d", "aa", 77]
+// ", "parse_var", "expected_a_b_before_c_d", "aa", 8]
 // ["
 // /*jslint beta*/
 // var bb;var aa;
-// ", "parse_var", "expected_a_b_before_c_d", "aa", 77]
+// ", "parse_var", "expected_a_b_before_c_d", "aa", 8]
 
             warn(
                 "expected_a_b_before_c_d",
@@ -4022,10 +4017,10 @@ function jslint_phase3_parse(state) {
         if (functionage.loop < 1 || functionage.finally > 0) {
 
 // test_cause:
-// ["continue", "parse_continue", "unexpected_a", "continue", 77]
+// ["continue", "parse_continue", "unexpected_a", "continue", 1]
 // ["
 // function aa(){while(0){try{}finally{continue}}}
-// ", "parse_continue", "unexpected_a", "continue", 77]
+// ", "parse_continue", "unexpected_a", "continue", 37]
 
             warn("unexpected_a", the_continue);
         }
@@ -4040,7 +4035,7 @@ function jslint_phase3_parse(state) {
         if (!option_dict.devel) {
 
 // test_cause:
-// ["debugger", "stmt_debugger", "unexpected_a", "debugger", 77]
+// ["debugger", "stmt_debugger", "unexpected_a", "debugger", 1]
 
             warn("unexpected_a", the_debug);
         }
@@ -4056,7 +4051,7 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["delete 0", "stmt_delete", "expected_a_b", "0", 77]
+// ["delete 0", "stmt_delete", "expected_a_b", "0", 8]
 
             stop("expected_a_b", the_value, ".", artifact(the_value));
         }
@@ -4075,7 +4070,7 @@ function jslint_phase3_parse(state) {
         if (the_do.block.disrupt === true) {
 
 // test_cause:
-// ["function aa(){do{break;}while(0)}", "stmt_do", "weird_loop", "do", 77]
+// ["function aa(){do{break;}while(0)}", "stmt_do", "weird_loop", "do", 15]
 
             warn("weird_loop", the_do);
         }
@@ -4095,7 +4090,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // export default 0;export default 0
-// ", "stmt_export", "duplicate_a", "default", 77]
+// ", "stmt_export", "duplicate_a", "default", 25]
 
                 warn("duplicate_a");
             }
@@ -4109,7 +4104,7 @@ function jslint_phase3_parse(state) {
             ) {
 
 // test_cause:
-// ["export default {}", "stmt_export", "freeze_exports", "{", 77]
+// ["export default {}", "stmt_export", "freeze_exports", "{", 16]
 
                 warn("freeze_exports", the_thing);
 
@@ -4120,7 +4115,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // export default Object.freeze({})
-// ", "semicolon", "expected_a_b", "(end)", 77]
+// ", "semicolon", "expected_a_b", "(end)", 32]
 
                 semicolon();
             }
@@ -4130,7 +4125,7 @@ function jslint_phase3_parse(state) {
             if (token_nxt.id === "function") {
 
 // test_cause:
-// ["export function aa(){}", "stmt_export", "freeze_exports", "function", 77]
+// ["export function aa(){}", "stmt_export", "freeze_exports", "function", 8]
 
                 warn("freeze_exports");
                 the_thing = parse_statement();
@@ -4142,7 +4137,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // let aa;export{aa};export function aa(){}
-// ", "stmt_export", "duplicate_a", "aa", 77]
+// ", "stmt_export", "duplicate_a", "aa", 35]
 
                     warn("duplicate_a", the_name);
                 }
@@ -4157,16 +4152,16 @@ function jslint_phase3_parse(state) {
             ) {
 
 // test_cause:
-// ["export const", "stmt_export", "unexpected_a", "const", 77]
-// ["export let", "stmt_export", "unexpected_a", "let", 77]
-// ["export var", "stmt_export", "unexpected_a", "var", 77]
+// ["export const", "stmt_export", "unexpected_a", "const", 8]
+// ["export let", "stmt_export", "unexpected_a", "let", 8]
+// ["export var", "stmt_export", "unexpected_a", "var", 8]
 
                 warn("unexpected_a");
                 parse_statement();
             } else if (token_nxt.id === "{") {
 
 // test_cause:
-// ["export {}", "stmt_export", "advance{", "", 77]
+// ["export {}", "stmt_export", "advance{", "", 0]
 
                 test_cause("advance{");
                 advance("{");
@@ -4174,7 +4169,7 @@ function jslint_phase3_parse(state) {
                     if (!token_nxt.identifier) {
 
 // test_cause:
-// ["export {}", "stmt_export", "expected_identifier_a", "}", 77]
+// ["export {}", "stmt_export", "expected_identifier_a", "}", 9]
 
                         stop("expected_identifier_a");
                     }
@@ -4183,7 +4178,7 @@ function jslint_phase3_parse(state) {
                     if (the_name === undefined) {
 
 // test_cause:
-// ["export {aa}", "stmt_export", "unexpected_a", "aa", 77]
+// ["export {aa}", "stmt_export", "unexpected_a", "aa", 9]
 
                         warn("unexpected_a");
                     } else {
@@ -4191,7 +4186,7 @@ function jslint_phase3_parse(state) {
                         if (export_dict[the_id] !== undefined) {
 
 // test_cause:
-// ["let aa;export{aa,aa}", "stmt_export", "duplicate_a", "aa", 77]
+// ["let aa;export{aa,aa}", "stmt_export", "duplicate_a", "aa", 18]
 
                             warn("duplicate_a");
                         }
@@ -4210,7 +4205,7 @@ function jslint_phase3_parse(state) {
             } else {
 
 // test_cause:
-// ["export", "stmt_export", "unexpected_a", "(end)", 77]
+// ["export", "stmt_export", "unexpected_a", "(end)", 1]
 
                 stop("unexpected_a");
             }
@@ -4224,7 +4219,7 @@ function jslint_phase3_parse(state) {
         if (!option_dict.for) {
 
 // test_cause:
-// ["for", "stmt_for", "unexpected_a", "for", 77]
+// ["for", "stmt_for", "unexpected_a", "for", 1]
 
             warn("unexpected_a", the_for);
         }
@@ -4235,7 +4230,7 @@ function jslint_phase3_parse(state) {
         if (token_nxt.id === ";") {
 
 // test_cause:
-// ["for(;;){}", "stmt_for", "expected_a_b", "for (;", 77]
+// ["for(;;){}", "stmt_for", "expected_a_b", "for (;", 1]
 
             return stop("expected_a_b", the_for, "while (", "for (;");
         }
@@ -4246,7 +4241,7 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["for(const aa in aa){}", "stmt_for", "unexpected_a", "const", 77]
+// ["for(const aa in aa){}", "stmt_for", "unexpected_a", "const", 5]
 
             return stop("unexpected_a");
         }
@@ -4255,7 +4250,7 @@ function jslint_phase3_parse(state) {
             if (first.expression[0].arity !== "variable") {
 
 // test_cause:
-// ["for(0 in aa){}", "stmt_for", "bad_assignment_a", "0", 77]
+// ["for(0 in aa){}", "stmt_for", "bad_assignment_a", "0", 5]
 
                 warn("bad_assignment_a", first.expression[0]);
             }
@@ -4271,7 +4266,7 @@ function jslint_phase3_parse(state) {
             if (the_for.inc.id === "++") {
 
 // test_cause:
-// ["for(aa;aa;aa++){}", "stmt_for", "expected_a_b", "++", 77]
+// ["for(aa;aa;aa++){}", "stmt_for", "expected_a_b", "++", 13]
 
                 warn("expected_a_b", the_for.inc, "+= 1", "++");
             }
@@ -4284,7 +4279,7 @@ function jslint_phase3_parse(state) {
 // ["
 // /*jslint for*/
 // function aa(bb,cc){for(0;0;0){break;}}
-// ", "stmt_for", "weird_loop", "for", 77]
+// ", "stmt_for", "weird_loop", "for", 20]
 
             warn("weird_loop", the_for);
         }
@@ -4307,22 +4302,22 @@ function jslint_phase3_parse(state) {
             );
 
 // test_cause:
-// ["if(0){0}else if(0){0}", "stmt_if", "else", "", 77]
-// ["if(0){0}else{0}", "stmt_if", "else", "", 77]
+// ["if(0){0}else if(0){0}", "stmt_if", "else", "", 0]
+// ["if(0){0}else{0}", "stmt_if", "else", "", 0]
 
             test_cause("else");
             if (the_if.block.disrupt === true) {
                 if (the_if.else.disrupt === true) {
 
 // test_cause:
-// ["if(0){break;}else{break;}", "stmt_if", "disrupt", "", 77]
+// ["if(0){break;}else{break;}", "stmt_if", "disrupt", "", 0]
 
                     test_cause("disrupt");
                     the_if.disrupt = true;
                 } else {
 
 // test_cause:
-// ["if(0){break;}else{}", "stmt_if", "unexpected_a", "else", 77]
+// ["if(0){break;}else{}", "stmt_if", "unexpected_a", "else", 14]
 
                     warn("unexpected_a", the_else);
                 }
@@ -4340,7 +4335,7 @@ function jslint_phase3_parse(state) {
 // ["
 // /*global aa*/
 // import aa from "aa"
-// ", "stmt_import", "unexpected_directive_a", "global", 77]
+// ", "stmt_import", "unexpected_directive_a", "global", 1]
 
             warn(
                 "unexpected_directive_a",
@@ -4355,7 +4350,7 @@ function jslint_phase3_parse(state) {
             if (name.id === "ignore") {
 
 // test_cause:
-// ["import ignore from \"aa\"", "stmt_import", "unexpected_a", "ignore", 77]
+// ["import ignore from \"aa\"", "stmt_import", "unexpected_a", "ignore", 8]
 
                 warn("unexpected_a", name);
             }
@@ -4369,7 +4364,7 @@ function jslint_phase3_parse(state) {
                     if (!token_nxt.identifier) {
 
 // test_cause:
-// ["import {", "stmt_import", "expected_identifier_a", "(end)", 77]
+// ["import {", "stmt_import", "expected_identifier_a", "(end)", 1]
 
                         stop("expected_identifier_a");
                     }
@@ -4378,7 +4373,7 @@ function jslint_phase3_parse(state) {
                     if (name.id === "ignore") {
 
 // test_cause:
-// ["import {ignore} from \"aa\"", "stmt_import", "unexpected_a", "ignore", 77]
+// ["import {ignore} from \"aa\"", "stmt_import", "unexpected_a", "ignore", 9]
 
                         warn("unexpected_a", name);
                     }
@@ -4402,7 +4397,7 @@ function jslint_phase3_parse(state) {
         ).test(token_now.value)) {
 
 // test_cause:
-// ["import aa from \"!aa\"", "stmt_import", "bad_module_name_a", "!aa", 77]
+// ["import aa from \"!aa\"", "stmt_import", "bad_module_name_a", "!aa", 16]
 
             warn("bad_module_name_a", token_now);
         }
@@ -4419,7 +4414,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // function aa(){try{}finally{return;}}
-// ", "stmt_return", "unexpected_a", "return", 77]
+// ", "stmt_return", "unexpected_a", "return", 28]
 
             warn("unexpected_a", the_return);
         }
@@ -4450,7 +4445,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // function aa(){try{}finally{switch(0){}}}
-// ", "stmt_switch", "unexpected_a", "switch", 77]
+// ", "stmt_switch", "unexpected_a", "switch", 28]
 
             warn("unexpected_a", the_switch);
         }
@@ -4480,7 +4475,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // switch(0){case 0:break;case 0:break}
-// ", "stmt_switch", "unexpected_a", "0", 77]
+// ", "stmt_switch", "unexpected_a", "0", 29]
 
                     warn("unexpected_a", exp);
                 }
@@ -4495,26 +4490,26 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // switch(0){case 1:case 0:break;}
-// ", "check_ordered_case", "expected_a_b_before_c_d", "case-number", 77]
+// ", "check_ordered_case", "expected_a_b_before_c_d", "case-number", 23]
 // ["
 // switch(0){case "aa":case 0:break;}
-// ", "check_ordered_case", "expected_a_b_before_c_d", "case-number", 77]
+// ", "check_ordered_case", "expected_a_b_before_c_d", "case-number", 26]
 // ["
 // switch(0){case "bb":case "aa":break;}
-// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 77]
+// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 26]
 // ["
 // switch(0){case aa:case "aa":break;}
-// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 77]
+// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 24]
 // ["
 // switch(0){case bb:case aa:break;}
-// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 77]
+// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 24]
 
             check_ordered_case(the_case.expression);
             stmts = parse_statements();
             if (stmts.length < 1) {
 
 // test_cause:
-// ["switch(0){case 0:}", "stmt_switch", "expected_statements_a", "}", 77]
+// ["switch(0){case 0:}", "stmt_switch", "expected_statements_a", "}", 18]
 
                 warn("expected_statements_a");
                 return;
@@ -4537,19 +4532,19 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // switch(0){case 1:break;case 0:break;}
-// ", "check_ordered_case", "expected_a_b_before_c_d", "case-number", 77]
+// ", "check_ordered_case", "expected_a_b_before_c_d", "case-number", 29]
 // ["
 // switch(0){case "aa":break;case 0:break;}
-// ", "check_ordered_case", "expected_a_b_before_c_d", "case-number", 77]
+// ", "check_ordered_case", "expected_a_b_before_c_d", "case-number", 32]
 // ["
 // switch(0){case "bb":break;case "aa":break;}
-// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 77]
+// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 32]
 // ["
 // switch(0){case aa:break;case "aa":break;}
-// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 77]
+// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 30]
 // ["
 // switch(0){case bb:break;case aa:break;}
-// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 77]
+// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 30]
 
         check_ordered_case(the_cases.map(function ({
             expression
@@ -4568,7 +4563,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // switch(0){case 0:break;default:}
-// ", "stmt_switch", "unexpected_a", "default", 77]
+// ", "stmt_switch", "unexpected_a", "default", 24]
 
                 warn("unexpected_a", the_default);
                 the_disrupt = false;
@@ -4584,7 +4579,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // switch(0){case 0:break;default:break;}
-// ", "stmt_switch", "unexpected_a", "break", 77]
+// ", "stmt_switch", "unexpected_a", "break", 32]
 
                     warn("unexpected_a", the_last);
                     the_last.disrupt = false;
@@ -4607,7 +4602,7 @@ function jslint_phase3_parse(state) {
         if (functionage.try > 0) {
 
 // test_cause:
-// ["try{throw 0}catch(){}", "stmt_throw", "unexpected_a", "throw", 77]
+// ["try{throw 0}catch(){}", "stmt_throw", "unexpected_a", "throw", 5]
 
             warn("unexpected_a", the_throw);
         }
@@ -4621,7 +4616,7 @@ function jslint_phase3_parse(state) {
         if (functionage.try > 0) {
 
 // test_cause:
-// ["try{try{}catch(){}}catch(){}", "stmt_try", "unexpected_a", "try", 77]
+// ["try{try{}catch(){}}catch(){}", "stmt_try", "unexpected_a", "try", 5]
 
             warn("unexpected_a", the_try);
         }
@@ -4645,7 +4640,7 @@ function jslint_phase3_parse(state) {
                 if (!token_nxt.identifier) {
 
 // test_cause:
-// ["try{}catch(){}", "stmt_try", "expected_identifier_a", ")", 77]
+// ["try{}catch(){}", "stmt_try", "expected_identifier_a", ")", 12]
 
                     return stop("expected_identifier_a");
                 }
@@ -4668,7 +4663,7 @@ function jslint_phase3_parse(state) {
         } else {
 
 // test_cause:
-// ["try{}finally{break;}", "stmt_try", "expected_a_before_b", "finally", 77]
+// ["try{}finally{break;}", "stmt_try", "expected_a_before_b", "finally", 6]
 
             warn("expected_a_before_b", token_nxt, "catch", artifact());
 
@@ -4694,7 +4689,7 @@ function jslint_phase3_parse(state) {
         if (the_while.block.disrupt === true) {
 
 // test_cause:
-// ["function aa(){while(0){break;}}", "stmt_while", "weird_loop", "while", 77]
+// ["function aa(){while(0){break;}}", "stmt_while", "weird_loop", "while", 15]
 
             warn("weird_loop", the_while);
         }
@@ -4704,7 +4699,7 @@ function jslint_phase3_parse(state) {
     stmt("with", function stmt_with() {
 
 // test_cause:
-// ["with", "stmt_with", "unexpected_a", "with", 77]
+// ["with", "stmt_with", "unexpected_a", "with", 1]
 
         stop("unexpected_a", token_now);
     });
@@ -4725,7 +4720,7 @@ function jslint_phase3_parse(state) {
             if (!rx_json_number.test(token_nxt.value)) {
 
 // test_cause:
-// ["[0x0]", "parse_json", "unexpected_a", "0x0", 77]
+// ["[0x0]", "parse_json", "unexpected_a", "0x0", 2]
 
                 warn("unexpected_a");
             }
@@ -4735,7 +4730,7 @@ function jslint_phase3_parse(state) {
             if (token_nxt.quote !== "\"") {
 
 // test_cause:
-// ["['']", "parse_json", "unexpected_a", "'", 77]
+// ["['']", "parse_json", "unexpected_a", "'", 2]
 
                 warn("unexpected_a", token_nxt, token_nxt.quote);
             }
@@ -4749,7 +4744,7 @@ function jslint_phase3_parse(state) {
             if (!rx_json_number.test(token_now.value)) {
 
 // test_cause:
-// ["[-0x0]", "parse_json", "unexpected_a", "0x0", 77]
+// ["[-0x0]", "parse_json", "unexpected_a", "0x0", 3]
 
                 warn("unexpected_a", token_now);
             }
@@ -4758,7 +4753,7 @@ function jslint_phase3_parse(state) {
         case "[":
 
 // test_cause:
-// ["[]", "parse_json", "bracket", "", 77]
+// ["[]", "parse_json", "bracket", "", 0]
 
             test_cause("bracket");
             container = token_nxt;
@@ -4773,7 +4768,7 @@ function jslint_phase3_parse(state) {
                     if (token_nxt.id !== ",") {
 
 // test_cause:
-// ["[0,0]", "parse_json", "comma", "", 77]
+// ["[0,0]", "parse_json", "comma", "", 0]
 
                         test_cause("comma");
                         break;
@@ -4788,9 +4783,9 @@ function jslint_phase3_parse(state) {
         case "true":
 
 // test_cause:
-// ["[false]", "parse_json", "advance", "", 77]
-// ["[null]", "parse_json", "advance", "", 77]
-// ["[true]", "parse_json", "advance", "", 77]
+// ["[false]", "parse_json", "advance", "", 0]
+// ["[null]", "parse_json", "advance", "", 0]
+// ["[true]", "parse_json", "advance", "", 0]
 
             test_cause("advance");
             advance();
@@ -4798,7 +4793,7 @@ function jslint_phase3_parse(state) {
         case "{":
 
 // test_cause:
-// ["{}", "parse_json", "brace", "", 77]
+// ["{}", "parse_json", "brace", "", 0]
 
             test_cause("brace");
             container = token_nxt;
@@ -4817,7 +4812,7 @@ function jslint_phase3_parse(state) {
                     if (token_nxt.quote !== "\"") {
 
 // test_cause:
-// ["{0:0}", "parse_json", "unexpected_a", "0", 77]
+// ["{0:0}", "parse_json", "unexpected_a", "0", 2]
 
                         warn(
                             "unexpected_a",
@@ -4830,13 +4825,13 @@ function jslint_phase3_parse(state) {
                     if (is_dup[token_now.value] !== undefined) {
 
 // test_cause:
-// ["{\"aa\":0,\"aa\":0}", "parse_json", "duplicate_a", "aa", 77]
+// ["{\"aa\":0,\"aa\":0}", "parse_json", "duplicate_a", "aa", 9]
 
                         warn("duplicate_a", token_now);
                     } else if (token_now.value === "__proto__") {
 
 // test_cause:
-// ["{\"__proto__\":0}", "parse_json", "weird_property_a", "__proto__", 77]
+// ["{\"__proto__\":0}", "parse_json", "weird_property_a", "__proto__", 2]
 
                         warn("weird_property_a", token_now);
                     } else {
@@ -4862,7 +4857,7 @@ function jslint_phase3_parse(state) {
         default:
 
 // test_cause:
-// ["[undefined]", "parse_json", "unexpected_a", "undefined", 77]
+// ["[undefined]", "parse_json", "unexpected_a", "undefined", 2]
 
             stop("unexpected_a");
         }
@@ -5010,7 +5005,7 @@ function jslint_phase4_walk(state) {
         };
     }
 
-    function check_top_level(the_thing) {
+    function post_export_import(the_thing) {
 
 // Some features must be at the most outermost level.
 
@@ -5019,7 +5014,7 @@ function jslint_phase4_walk(state) {
 // test_cause:
 // ["
 // if(0){import aa from "aa";}
-// ", "check_top_level", "misplaced_a", "import", 77]
+// ", "post_export_import", "misplaced_a", "import", 7]
 
             warn("misplaced_a", the_thing);
         }
@@ -5030,8 +5025,8 @@ function jslint_phase4_walk(state) {
             if (Array.isArray(thing)) {
 
 // test_cause:
-// ["(function(){}())", "walk_expression", "isArray", "", 77]
-// ["0&&0", "walk_expression", "isArray", "", 77]
+// ["(function(){}())", "walk_expression", "isArray", "", 0]
+// ["0&&0", "walk_expression", "isArray", "", 0]
 
                 test_cause("isArray");
                 thing.forEach(walk_expression);
@@ -5041,7 +5036,7 @@ function jslint_phase4_walk(state) {
                 if (thing.id === "function") {
 
 // test_cause:
-// ["aa=function(){}", "walk_expression", "function", "", 77]
+// ["aa=function(){}", "walk_expression", "function", "", 0]
 
                     test_cause("function");
                     walk_statement(thing.block);
@@ -5049,8 +5044,8 @@ function jslint_phase4_walk(state) {
                 if (thing.arity === "pre" || thing.arity === "post") {
 
 // test_cause:
-// ["aa=++aa", "walk_expression", "unexpected_a", "++", 77]
-// ["aa=--aa", "walk_expression", "unexpected_a", "--", 77]
+// ["aa=++aa", "walk_expression", "unexpected_a", "++", 4]
+// ["aa=--aa", "walk_expression", "unexpected_a", "--", 4]
 
                     warn("unexpected_a", thing);
                 } else if (
@@ -5059,13 +5054,13 @@ function jslint_phase4_walk(state) {
                 ) {
 
 // test_cause:
-// ["aa[aa=0]", "walk_expression", "unexpected_statement_a", "=", 77]
+// ["aa[aa=0]", "walk_expression", "unexpected_statement_a", "=", 6]
 
                     warn("unexpected_statement_a", thing);
                 }
 
 // test_cause:
-// ["aa=0", "walk_expression", "default", "", 77]
+// ["aa=0", "walk_expression", "default", "", 0]
 
                 test_cause("default");
                 postamble(thing);
@@ -5078,7 +5073,7 @@ function jslint_phase4_walk(state) {
             if (Array.isArray(thing)) {
 
 // test_cause:
-// ["+[]", "walk_statement", "isArray", "", 77]
+// ["+[]", "walk_statement", "isArray", "", 0]
 
                 test_cause("isArray");
                 thing.forEach(walk_statement);
@@ -5089,7 +5084,7 @@ function jslint_phase4_walk(state) {
                     if (thing.id !== "(") {
 
 // test_cause:
-// ["0&&0", "walk_statement", "unexpected_expression_a", "&&", 77]
+// ["0&&0", "walk_statement", "unexpected_expression_a", "&&", 2]
 
                         warn("unexpected_expression_a", thing);
                     }
@@ -5100,14 +5095,14 @@ function jslint_phase4_walk(state) {
                 ) {
 
 // test_cause:
-// ["!0", "walk_statement", "unexpected_expression_a", "!", 77]
-// ["+[]", "walk_statement", "unexpected_expression_a", "+", 77]
-// ["+new aa()", "walk_statement", "unexpected_expression_a", "+", 77]
-// ["0", "walk_statement", "unexpected_expression_a", "0", 77]
+// ["!0", "walk_statement", "unexpected_expression_a", "!", 1]
+// ["+[]", "walk_statement", "unexpected_expression_a", "+", 1]
+// ["+new aa()", "walk_statement", "unexpected_expression_a", "+", 1]
+// ["0", "walk_statement", "unexpected_expression_a", "0", 1]
 // ["
 // async function aa(){await 0;}
-// ", "walk_statement", "unexpected_expression_a", "0", 77]
-// ["typeof 0", "walk_statement", "unexpected_expression_a", "typeof", 77]
+// ", "walk_statement", "unexpected_expression_a", "0", 27]
+// ["typeof 0", "walk_statement", "unexpected_expression_a", "typeof", 1]
 
                     warn("unexpected_expression_a", thing);
                 }
@@ -5149,14 +5144,14 @@ function jslint_phase4_walk(state) {
                     if (global_dict[thing.id] === undefined) {
 
 // test_cause:
-// ["aa", "lookup", "undeclared_a", "aa", 77]
-// ["class aa{}", "lookup", "undeclared_a", "aa", 77]
+// ["aa", "lookup", "undeclared_a", "aa", 1]
+// ["class aa{}", "lookup", "undeclared_a", "aa", 7]
 // ["
 // let aa=0;try{aa();}catch(bb){bb();}bb();
-// ", "lookup", "undeclared_a", "bb", 77]
+// ", "lookup", "undeclared_a", "bb", 36]
 // ["
 // let aa=0;try{aa();}catch(ignore){bb();}
-// ", "lookup", "undeclared_a", "bb", 77]
+// ", "lookup", "undeclared_a", "bb", 34]
 
                         warn("undeclared_a", thing);
                         return;
@@ -5177,7 +5172,7 @@ function jslint_phase4_walk(state) {
             } else if (the_variable.role === "label") {
 
 // test_cause:
-// ["aa:while(0){aa;}", "lookup", "label_a", "aa", 77]
+// ["aa:while(0){aa;}", "lookup", "label_a", "aa", 13]
 
                 warn("label_a", thing);
             }
@@ -5191,7 +5186,7 @@ function jslint_phase4_walk(state) {
             ) {
 
 // test_cause:
-// ["let aa;if(aa){let bb;}bb;", "lookup", "out_of_scope_a", "bb", 77]
+// ["let aa;if(aa){let bb;}bb;", "lookup", "out_of_scope_a", "bb", 23]
 
                 warn("out_of_scope_a", thing);
             }
@@ -5208,15 +5203,15 @@ function jslint_phase4_walk(state) {
     function pre_function(thing) {
 
 // test_cause:
-// ["()=>0", "pre_function", "", "", 77]
-// ["(function (){}())", "pre_function", "", "", 77]
-// ["function aa(){}", "pre_function", "", "", 77]
+// ["()=>0", "pre_function", "", "", 0]
+// ["(function (){}())", "pre_function", "", "", 0]
+// ["function aa(){}", "pre_function", "", "", 0]
 
         test_cause("");
         if (thing.arity === "statement" && blockage.body !== true) {
 
 // test_cause:
-// ["if(0){function aa(){}\n}", "pre_function", "unexpected_a", "function", 77]
+// ["if(0){function aa(){}\n}", "pre_function", "unexpected_a", "function", 7]
 
             warn("unexpected_a", thing);
         }
@@ -5236,7 +5231,7 @@ function jslint_phase4_walk(state) {
 // ["
 // /*jslint getset*/
 // aa={get aa(aa){}}
-// ", "pre_function", "bad_get", "function", 77]
+// ", "pre_function", "bad_get", "function", 9]
 
                 warn("bad_get", thing);
             }
@@ -5247,7 +5242,7 @@ function jslint_phase4_walk(state) {
 // ["
 // /*jslint getset*/
 // aa={set aa(){}}
-// ", "pre_function", "bad_set", "function", 77]
+// ", "pre_function", "bad_set", "function", 9]
 
                 warn("bad_set", thing);
             }
@@ -5283,19 +5278,19 @@ function jslint_phase4_walk(state) {
         case "~":
 
 // test_cause:
-// ["0&0", "pre_bitwise", "unexpected_a", "&", 77]
-// ["0&=0", "pre_bitwise", "unexpected_a", "&=", 77]
-// ["0<<0", "pre_bitwise", "unexpected_a", "<<", 77]
-// ["0<<=0", "pre_bitwise", "unexpected_a", "<<=", 77]
-// ["0>>0", "pre_bitwise", "unexpected_a", ">>", 77]
-// ["0>>=0", "pre_bitwise", "unexpected_a", ">>=", 77]
-// ["0>>>0", "pre_bitwise", "unexpected_a", ">>>", 77]
-// ["0>>>=0", "pre_bitwise", "unexpected_a", ">>>=", 77]
-// ["0^0", "pre_bitwise", "unexpected_a", "^", 77]
-// ["0^=0", "pre_bitwise", "unexpected_a", "^=", 77]
-// ["0|0", "pre_bitwise", "unexpected_a", "|", 77]
-// ["0|=0", "pre_bitwise", "unexpected_a", "|=", 77]
-// ["~0", "pre_bitwise", "unexpected_a", "~", 77]
+// ["0&0", "pre_bitwise", "unexpected_a", "&", 2]
+// ["0&=0", "pre_bitwise", "unexpected_a", "&=", 2]
+// ["0<<0", "pre_bitwise", "unexpected_a", "<<", 2]
+// ["0<<=0", "pre_bitwise", "unexpected_a", "<<=", 2]
+// ["0>>0", "pre_bitwise", "unexpected_a", ">>", 2]
+// ["0>>=0", "pre_bitwise", "unexpected_a", ">>=", 2]
+// ["0>>>0", "pre_bitwise", "unexpected_a", ">>>", 2]
+// ["0>>>=0", "pre_bitwise", "unexpected_a", ">>>=", 2]
+// ["0^0", "pre_bitwise", "unexpected_a", "^", 2]
+// ["0^=0", "pre_bitwise", "unexpected_a", "^=", 2]
+// ["0|0", "pre_bitwise", "unexpected_a", "|", 2]
+// ["0|=0", "pre_bitwise", "unexpected_a", "|=", 2]
+// ["~0", "pre_bitwise", "unexpected_a", "~", 1]
 
             warn("unexpected_a", thing);
             break;
@@ -5314,7 +5309,7 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["0<0<0", "pre_bitwise", "unexpected_a", "<", 77]
+// ["0<0<0", "pre_bitwise", "unexpected_a", "<", 4]
 
             warn("unexpected_a", thing);
         }
@@ -5372,7 +5367,7 @@ function jslint_phase4_walk(state) {
         if (thing.wrapped) {
 
 // test_cause:
-// ["aa=(function(){})", "post_function", "unexpected_parens", "function", 77]
+// ["aa=(function(){})", "post_function", "unexpected_parens", "function", 5]
 
             warn("unexpected_parens", thing);
         }
@@ -5396,7 +5391,7 @@ function jslint_phase4_walk(state) {
             if (left.id === "NaN" || right.id === "NaN") {
 
 // test_cause:
-// ["NaN===NaN", "pre_bin", "number_isNaN", "===", 77]
+// ["NaN===NaN", "pre_bin", "number_isNaN", "===", 4]
 
                 warn("number_isNaN", thing);
             } else if (left.id === "typeof") {
@@ -5404,7 +5399,7 @@ function jslint_phase4_walk(state) {
                     if (right.id !== "typeof") {
 
 // test_cause:
-// ["typeof 0===0", "pre_bin", "expected_string_a", "0", 77]
+// ["typeof 0===0", "pre_bin", "expected_string_a", "0", 12]
 
                         warn("expected_string_a", right);
                     }
@@ -5415,7 +5410,7 @@ function jslint_phase4_walk(state) {
 // test_cause:
 // ["
 // typeof aa==="undefined"
-// ", "pre_bin", "unexpected_typeof_a", "undefined", 77]
+// ", "pre_bin", "unexpected_typeof_a", "undefined", 13]
 
                         warn("unexpected_typeof_a", right, value);
                     } else if (
@@ -5428,7 +5423,7 @@ function jslint_phase4_walk(state) {
                     ) {
 
 // test_cause:
-// ["typeof 0===\"aa\"", "pre_bin", "expected_type_string_a", "aa", 77]
+// ["typeof 0===\"aa\"", "pre_bin", "expected_type_string_a", "aa", 12]
 
                         warn("expected_type_string_a", right, value);
                     }
@@ -5439,14 +5434,14 @@ function jslint_phase4_walk(state) {
     preaction("binary", "==", function pre_bin_eqeq(thing) {
 
 // test_cause:
-// ["0==0", "pre_bin_eqeq", "expected_a_b", "==", 77]
+// ["0==0", "pre_bin_eqeq", "expected_a_b", "==", 2]
 
         warn("expected_a_b", thing, "===", "==");
     });
     preaction("binary", "!=", function pre_bin_noteq(thing) {
 
 // test_cause:
-// ["0!=0", "pre_bin_noteq", "expected_a_b", "!=", 77]
+// ["0!=0", "pre_bin_noteq", "expected_a_b", "!=", 2]
 
         warn("expected_a_b", thing, "!==", "!=");
     });
@@ -5456,7 +5451,7 @@ function jslint_phase4_walk(state) {
             if (thang.id === "&&" && !thang.wrapped) {
 
 // test_cause:
-// ["0&&0||0", "pre_bin_or", "and", "&&", 77]
+// ["0&&0||0", "pre_bin_or", "and", "&&", 2]
 
                 warn("and", thang);
             }
@@ -5490,14 +5485,14 @@ function jslint_phase4_walk(state) {
     preaction("binary", "in", function pre_bin_in(thing) {
 
 // test_cause:
-// ["aa in aa", "pre_bin_in", "infix_in", "in", 77]
+// ["aa in aa", "pre_bin_in", "infix_in", "in", 4]
 
         warn("infix_in", thing);
     });
     preaction("binary", "instanceof", function pre_bin_instanceof(thing) {
 
 // test_cause:
-// ["0 instanceof 0", "pre_bin_instanceof", "unexpected_a", "instanceof", 77]
+// ["0 instanceof 0", "pre_bin_instanceof", "unexpected_a", "instanceof", 3]
 
         warn("unexpected_a", thing);
     });
@@ -5515,7 +5510,7 @@ function jslint_phase4_walk(state) {
                 if (!the_variable.writable) {
 
 // test_cause:
-// ["const aa=0;for(aa in aa){}", "pre_stmt_for", "bad_assignment_a", "aa", 77]
+// ["const aa=0;for(aa in aa){}", "pre_stmt_for", "bad_assignment_a", "aa", 16]
 
                     warn("bad_assignment_a", thing.name);
                 }
@@ -5570,7 +5565,7 @@ function jslint_phase4_walk(state) {
             if (thing.names !== undefined) {
 
 // test_cause:
-// ["if(0){aa=0}", "post_assign", "=", "", 77]
+// ["if(0){aa=0}", "post_assign", "=", "", 0]
 
                 test_cause("=");
 
@@ -5599,7 +5594,7 @@ function jslint_phase4_walk(state) {
                 ) {
 
 // test_cause:
-// ["aa.aa=undefined", "post_assign", "expected_a_b", "undefined", 77]
+// ["aa.aa=undefined", "post_assign", "expected_a_b", "undefined", 1]
 
                     warn(
                         "expected_a_b",
@@ -5630,7 +5625,7 @@ function jslint_phase4_walk(state) {
             ) {
 
 // test_cause:
-// ["aa+=undefined", "post_assign", "unexpected_a", "undefined", 77]
+// ["aa+=undefined", "post_assign", "unexpected_a", "undefined", 5]
 
                 warn("unexpected_a", thing.expression[1]);
             }
@@ -5651,7 +5646,7 @@ function jslint_phase4_walk(state) {
             ) {
 
 // test_cause:
-// ["if(0===0){0}", "post_bin", "weird_relation_a", "===", 77]
+// ["if(0===0){0}", "post_bin", "weird_relation_a", "===", 5]
 
                 warn("weird_relation_a", thing);
             }
@@ -5661,13 +5656,13 @@ function jslint_phase4_walk(state) {
                 if (thing.expression[0].value === "") {
 
 // test_cause:
-// ["\"\"+0", "post_bin", "expected_a_b", "\"\" +", 77]
+// ["\"\"+0", "post_bin", "expected_a_b", "\"\" +", 3]
 
                     warn("expected_a_b", thing, "String(...)", "\"\" +");
                 } else if (thing.expression[1].value === "") {
 
 // test_cause:
-// ["0+\"\"", "post_bin", "expected_a_b", "+ \"\"", 77]
+// ["0+\"\"", "post_bin", "expected_a_b", "+ \"\"", 2]
 
                     warn("expected_a_b", thing, "String(...)", "+ \"\"");
                 }
@@ -5676,14 +5671,14 @@ function jslint_phase4_walk(state) {
             if (thing.expression[0].id === "window") {
 
 // test_cause:
-// ["aa=window[0]", "post_bin", "weird_expression_a", "window[...]", 77]
+// ["aa=window[0]", "post_bin", "weird_expression_a", "window[...]", 10]
 
                 warn("weird_expression_a", thing, "window[...]");
             }
             if (thing.expression[0].id === "self") {
 
 // test_cause:
-// ["aa=self[0]", "post_bin", "weird_expression_a", "self[...]", 77]
+// ["aa=self[0]", "post_bin", "weird_expression_a", "self[...]", 8]
 
                 warn("weird_expression_a", thing, "self[...]");
             }
@@ -5691,7 +5686,7 @@ function jslint_phase4_walk(state) {
             if (thing.expression.id === "RegExp") {
 
 // test_cause:
-// ["aa=RegExp.aa", "post_bin", "weird_expression_a", ".", 77]
+// ["aa=RegExp.aa", "post_bin", "weird_expression_a", ".", 10]
 
                 warn("weird_expression_a", thing);
             }
@@ -5705,7 +5700,7 @@ function jslint_phase4_walk(state) {
             ) {
 
 // test_cause:
-// ["0- -0", "post_bin", "wrap_unary", "-", 77]
+// ["0- -0", "post_bin", "wrap_unary", "-", 4]
 
                 warn("wrap_unary", right);
             }
@@ -5726,16 +5721,16 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["aa=(()=>0)&&(()=>0)", "post_bin_and", "weird_condition_a", "&&", 77]
-// ["aa=(``?``:``)&&(``?``:``)", "post_bin_and", "weird_condition_a", "&&", 77]
-// ["aa=/./&&/./", "post_bin_and", "weird_condition_a", "&&", 77]
-// ["aa=0&&0", "post_bin_and", "weird_condition_a", "&&", 77]
-// ["aa=[]&&[]", "post_bin_and", "weird_condition_a", "&&", 77]
-// ["aa=`${0}`&&`${0}`", "post_bin_and", "weird_condition_a", "&&", 77]
+// ["aa=(()=>0)&&(()=>0)", "post_bin_and", "weird_condition_a", "&&", 11]
+// ["aa=(``?``:``)&&(``?``:``)", "post_bin_and", "weird_condition_a", "&&", 14]
+// ["aa=/./&&/./", "post_bin_and", "weird_condition_a", "&&", 7]
+// ["aa=0&&0", "post_bin_and", "weird_condition_a", "&&", 5]
+// ["aa=[]&&[]", "post_bin_and", "weird_condition_a", "&&", 6]
+// ["aa=`${0}`&&`${0}`", "post_bin_and", "weird_condition_a", "&&", 10]
 // ["
 // aa=function aa(){}&&function aa(){}
-// ", "post_bin_and", "weird_condition_a", "&&", 77]
-// ["aa={}&&{}", "post_bin_and", "weird_condition_a", "&&", 77]
+// ", "post_bin_and", "weird_condition_a", "&&", 19]
+// ["aa={}&&{}", "post_bin_and", "weird_condition_a", "&&", 6]
 
             warn("weird_condition_a", thing);
         }
@@ -5748,7 +5743,7 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["aa=0||0", "post_bin_or", "weird_condition_a", "||", 77]
+// ["aa=0||0", "post_bin_or", "weird_condition_a", "||", 5]
 
             warn("weird_condition_a", thing);
         }
@@ -5770,7 +5765,7 @@ function jslint_phase4_walk(state) {
             if (!thing.wrapped) {
 
 // test_cause:
-// ["aa=function(){}()", "post_bin_lparen", "wrap_immediate", "(", 77]
+// ["aa=function(){}()", "post_bin_lparen", "wrap_immediate", "(", 16]
 
                 warn("wrap_immediate", thing);
             }
@@ -5785,18 +5780,18 @@ function jslint_phase4_walk(state) {
                 ) {
 
 // test_cause:
-// ["new Boolean()", "post_bin_lparen", "unexpected_a", "new", 77]
-// ["new Number()", "post_bin_lparen", "unexpected_a", "new", 77]
-// ["new String()", "post_bin_lparen", "unexpected_a", "new", 77]
-// ["new Symbol()", "post_bin_lparen", "unexpected_a", "new", 77]
-// ["new aa()", "post_bin_lparen", "unexpected_a", "new", 77]
+// ["new Boolean()", "post_bin_lparen", "unexpected_a", "new", 1]
+// ["new Number()", "post_bin_lparen", "unexpected_a", "new", 1]
+// ["new String()", "post_bin_lparen", "unexpected_a", "new", 1]
+// ["new Symbol()", "post_bin_lparen", "unexpected_a", "new", 1]
+// ["new aa()", "post_bin_lparen", "unexpected_a", "new", 1]
 
                     warn("unexpected_a", the_new);
                 } else if (left.id === "Function") {
                     if (!option_dict.eval) {
 
 // test_cause:
-// ["new Function()", "post_bin_lparen", "unexpected_a", "new Function", 77]
+// ["new Function()", "post_bin_lparen", "unexpected_a", "new Function", 5]
 
                         warn("unexpected_a", left, "new Function");
                     }
@@ -5805,14 +5800,14 @@ function jslint_phase4_walk(state) {
                     if (arg.length !== 2 || arg[1].id === "(string)") {
 
 // test_cause:
-// ["new Array()", "post_bin_lparen", "expected_a_b", "new Array", 77]
+// ["new Array()", "post_bin_lparen", "expected_a_b", "new Array", 5]
 
                         warn("expected_a_b", left, "[]", "new Array");
                     }
                 } else if (left.id === "Object") {
 
 // test_cause:
-// ["new Object()", "post_bin_lparen", "expected_a_b", "new Object", 77]
+// ["new Object()", "post_bin_lparen", "expected_a_b", "new Object", 5]
 
                     warn(
                         "expected_a_b",
@@ -5832,7 +5827,7 @@ function jslint_phase4_walk(state) {
                 ) {
 
 // test_cause:
-// ["let Aa=Aa()", "post_bin_lparen", "expected_a_before_b", "Aa", 77]
+// ["let Aa=Aa()", "post_bin_lparen", "expected_a_before_b", "Aa", 8]
 
                     warn("expected_a_before_b", left, "new", artifact(left));
                 }
@@ -5842,7 +5837,7 @@ function jslint_phase4_walk(state) {
             if (left.expression.id === "Date" && left.name.id === "UTC") {
 
 // test_cause:
-// ["new Date.UTC()", "post_bin_lparen", "cack", "", 77]
+// ["new Date.UTC()", "post_bin_lparen", "cack", "", 0]
 
                 test_cause("cack");
                 cack = !cack;
@@ -5854,13 +5849,13 @@ function jslint_phase4_walk(state) {
                 if (the_new !== undefined) {
 
 // test_cause:
-// ["new Date.UTC()", "post_bin_lparen", "unexpected_a", "new", 77]
+// ["new Date.UTC()", "post_bin_lparen", "unexpected_a", "new", 1]
 
                     warn("unexpected_a", the_new);
                 } else {
 
 // test_cause:
-// ["let Aa=Aa.Aa()", "post_bin_lparen", "expected_a_before_b", "Aa", 77]
+// ["let Aa=Aa.Aa()", "post_bin_lparen", "expected_a_before_b", "Aa", 8]
 
                     warn(
                         "expected_a_before_b",
@@ -5884,7 +5879,7 @@ function jslint_phase4_walk(state) {
 // test_cause:
 // ["
 // new Date().getTime()
-// ", "post_bin_lparen", "expected_a_b", "new Date().getTime()", 77]
+// ", "post_bin_lparen", "expected_a_b", "new Date().getTime()", 1]
 
                             warn(
                                 "expected_a_b",
@@ -5902,21 +5897,21 @@ function jslint_phase4_walk(state) {
         if (thing.expression[0].id === "RegExp") {
 
 // test_cause:
-// ["aa=RegExp[0]", "post_bin_lbracket", "weird_expression_a", "[", 77]
+// ["aa=RegExp[0]", "post_bin_lbracket", "weird_expression_a", "[", 10]
 
             warn("weird_expression_a", thing);
         }
         if (is_weird(thing.expression[1])) {
 
 // test_cause:
-// ["aa[[0]]", "post_bin_lbracket", "weird_expression_a", "[", 77]
+// ["aa[[0]]", "post_bin_lbracket", "weird_expression_a", "[", 4]
 
             warn("weird_expression_a", thing.expression[1]);
         }
     });
     postaction("statement", "{", pop_block);
     postaction("statement", "const", action_var);
-    postaction("statement", "export", check_top_level);
+    postaction("statement", "export", post_export_import);
     postaction("statement", "for", function (thing) {
         walk_statement(thing.inc);
     });
@@ -5935,7 +5930,7 @@ function jslint_phase4_walk(state) {
                 name.init = true;
                 blockage.live.push(name);
             }
-            return check_top_level(the_thing);
+            return post_export_import(the_thing);
         }
     });
     postaction("statement", "let", action_var);
@@ -5965,13 +5960,13 @@ function jslint_phase4_walk(state) {
         } else if (is_equal(thing.expression[0], thing.expression[1])) {
 
 // test_cause:
-// ["aa?aa:0", "post_ternary", "expected_a_b", "?", 77]
+// ["aa?aa:0", "post_ternary", "expected_a_b", "?", 3]
 
             warn("expected_a_b", thing, "||", "?");
         } else if (is_equal(thing.expression[0], thing.expression[2])) {
 
 // test_cause:
-// ["aa?0:aa", "post_ternary", "expected_a_b", "?", 77]
+// ["aa?0:aa", "post_ternary", "expected_a_b", "?", 3]
 
             warn("expected_a_b", thing, "&&", "?");
         } else if (
@@ -5980,7 +5975,7 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["aa?true:false", "post_ternary", "expected_a_b", "?", 77]
+// ["aa?true:false", "post_ternary", "expected_a_b", "?", 3]
 
             warn("expected_a_b", thing, "!!", "?");
         } else if (
@@ -5989,7 +5984,7 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["aa?false:true", "post_ternary", "expected_a_b", "?", 77]
+// ["aa?false:true", "post_ternary", "expected_a_b", "?", 3]
 
             warn("expected_a_b", thing, "!", "?");
         } else if (
@@ -6001,7 +5996,7 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["(aa&&!aa?0:1)", "post_ternary", "wrap_condition", "&&", 77]
+// ["(aa&&!aa?0:1)", "post_ternary", "wrap_condition", "&&", 4]
 
             warn("wrap_condition", thing.expression[0]);
         }
@@ -6021,7 +6016,7 @@ function jslint_phase4_walk(state) {
             if (!option_dict.convert) {
 
 // test_cause:
-// ["!!0", "post_unary", "expected_a_b", "!!", 77]
+// ["!!0", "post_unary", "expected_a_b", "!!", 1]
 
                 warn("expected_a_b", thing, "Boolean(...)", "!!");
             }
@@ -6042,7 +6037,7 @@ function jslint_phase4_walk(state) {
         if (!option_dict.convert) {
 
 // test_cause:
-// ["aa=+0", "post_unary_plus", "expected_a_b", "+", 77]
+// ["aa=+0", "post_unary_plus", "expected_a_b", "+", 4]
 
             warn("expected_a_b", thing, "Number(...)", "+");
         }
@@ -6152,7 +6147,7 @@ function jslint_phase5_whitage(state) {
             if (id !== "ignore" && name.parent === the_function) {
 
 // test_cause:
-// ["function aa(aa) {return aa;}", "delve", "id", "", 77]
+// ["function aa(aa) {return aa;}", "delve", "id", "", 0]
 
                 test_cause("id");
                 if (
@@ -6171,15 +6166,15 @@ function jslint_phase5_whitage(state) {
                 ) {
 
 // test_cause:
-// ["/*jslint node*/\nlet aa;", "delve", "unused_a", "aa", 77]
-// ["function aa(aa){return;}", "delve", "unused_a", "aa", 77]
-// ["let aa=0;try{aa();}catch(bb){aa();}", "delve", "unused_a", "bb", 77]
+// ["/*jslint node*/\nlet aa;", "delve", "unused_a", "aa", 5]
+// ["function aa(aa){return;}", "delve", "unused_a", "aa", 13]
+// ["let aa=0;try{aa();}catch(bb){aa();}", "delve", "unused_a", "bb", 26]
 
                     warn("unused_a", name);
                 } else if (!name.init) {
 
 // test_cause:
-// ["/*jslint node*/\nlet aa;aa();", "delve", "uninitialized_a", "aa", 77]
+// ["/*jslint node*/\nlet aa;aa();", "delve", "uninitialized_a", "aa", 5]
 
                     warn("uninitialized_a", name);
                 }
@@ -6198,7 +6193,7 @@ function jslint_phase5_whitage(state) {
             if (left.thru !== right.from && nr_comments_skipped === 0) {
 
 // test_cause:
-// ["let aa = aa( );", "no_space", "unexpected_space_a_b", ")", 77]
+// ["let aa = aa( );", "no_space", "unexpected_space_a_b", ")", 14]
 
                 warn(
                     "unexpected_space_a_b",
@@ -6239,12 +6234,7 @@ function jslint_phase5_whitage(state) {
             if (right.from < margin) {
 
 // test_cause:
-// ["
-// let aa = aa(
-//     aa
-// ()
-// );
-// ", "expected_at", "expected_a_at_b_c", "5", 77]
+// ["let aa = aa(\naa\n()\n);", "expected_at", "expected_a_at_b_c", "5", 1]
 
                 expected_at(margin);
             }
@@ -6351,10 +6341,10 @@ function jslint_phase5_whitage(state) {
             case "{":
 
 // test_cause:
-// ["let aa=[];", "whitage", "opener", "", 77]
-// ["let aa=`${0}`;", "whitage", "opener", "", 77]
-// ["let aa=aa();", "whitage", "opener", "", 77]
-// ["let aa={};", "whitage", "opener", "", 77]
+// ["let aa=[];", "whitage", "opener", "", 0]
+// ["let aa=`${0}`;", "whitage", "opener", "", 0]
+// ["let aa=aa();", "whitage", "opener", "", 0]
+// ["let aa={};", "whitage", "opener", "", 0]
 
                 test_cause("opener");
 
@@ -6374,21 +6364,21 @@ function jslint_phase5_whitage(state) {
 // on the openness. Illegal pairs (like '{]') have already been detected.
 
 // test_cause:
-// ["let aa=[];", "whitage", "opener_closer", "", 77]
-// ["let aa=aa();", "whitage", "opener_closer", "", 77]
-// ["let aa={};", "whitage", "opener_closer", "", 77]
+// ["let aa=[];", "whitage", "opener_closer", "", 0]
+// ["let aa=aa();", "whitage", "opener_closer", "", 0]
+// ["let aa={};", "whitage", "opener_closer", "", 0]
 
                     test_cause("opener_closer");
                     if (left.line === right.line) {
 
 // test_cause:
-// ["let aa = aa( );", "no_space", "unexpected_space_a_b", ")", 77]
+// ["let aa = aa( );", "no_space", "unexpected_space_a_b", ")", 14]
 
                         no_space();
                     } else {
 
 // test_cause:
-// ["let aa = aa(\n );", "expected_at", "expected_a_at_b_c", "1", 77]
+// ["let aa = aa(\n );", "expected_at", "expected_a_at_b_c", "1", 2]
 
                         at_margin(0);
                     }
@@ -6396,11 +6386,11 @@ function jslint_phase5_whitage(state) {
                 default:
 
 // test_cause:
-// ["let aa=(0);", "whitage", "opener_operand", "", 77]
-// ["let aa=[0];", "whitage", "opener_operand", "", 77]
-// ["let aa=`${0}`;", "whitage", "opener_operand", "", 77]
-// ["let aa=aa(0);", "whitage", "opener_operand", "", 77]
-// ["let aa={aa:0};", "whitage", "opener_operand", "", 77]
+// ["let aa=(0);", "whitage", "opener_operand", "", 0]
+// ["let aa=[0];", "whitage", "opener_operand", "", 0]
+// ["let aa=`${0}`;", "whitage", "opener_operand", "", 0]
+// ["let aa=aa(0);", "whitage", "opener_operand", "", 0]
+// ["let aa={aa:0};", "whitage", "opener_operand", "", 0]
 
                     test_cause("opener_operand");
                     opening = left.open || (left.line !== right.line);
@@ -6422,11 +6412,11 @@ function jslint_phase5_whitage(state) {
                     if (opening) {
 
 // test_cause:
-// ["function aa(){\nreturn;\n}", "whitage", "opening", "", 77]
-// ["let aa=(\n0\n);", "whitage", "opening", "", 77]
-// ["let aa=[\n0\n];", "whitage", "opening", "", 77]
-// ["let aa=`${\n0\n}`;", "whitage", "opening", "", 77]
-// ["let aa={\naa:0\n};", "whitage", "opening", "", 77]
+// ["function aa(){\nreturn;\n}", "whitage", "opening", "", 0]
+// ["let aa=(\n0\n);", "whitage", "opening", "", 0]
+// ["let aa=[\n0\n];", "whitage", "opening", "", 0]
+// ["let aa=`${\n0\n}`;", "whitage", "opening", "", 0]
+// ["let aa={\naa:0\n};", "whitage", "opening", "", 0]
 
                         test_cause("opening");
                         free = closer === ")" && left.free;
@@ -6445,7 +6435,7 @@ function jslint_phase5_whitage(state) {
 //         }
 //     }
 // }
-// ", "expected_at", "expected_a_at_b_c", "1", 77]
+// ", "expected_at", "expected_a_at_b_c", "1", 2]
 
                                 expected_at(0);
                             }
@@ -6464,7 +6454,7 @@ function jslint_phase5_whitage(state) {
 //         aa();
 //     }
 // }
-// ", "whitage", "expected_line_break_a_b", "bb", 77]
+// ", "whitage", "expected_line_break_a_b", "bb", 16]
 
                             warn(
                                 "expected_line_break_a_b",
@@ -6475,17 +6465,17 @@ function jslint_phase5_whitage(state) {
                         }
 
 // test_cause:
-// ["let aa=(0);", "whitage", "not_free", "", 77]
-// ["let aa=[0];", "whitage", "not_free", "", 77]
-// ["let aa=`${0}`;", "whitage", "not_free", "", 77]
-// ["let aa={aa:0};", "whitage", "not_free", "", 77]
+// ["let aa=(0);", "whitage", "not_free", "", 0]
+// ["let aa=[0];", "whitage", "not_free", "", 0]
+// ["let aa=`${0}`;", "whitage", "not_free", "", 0]
+// ["let aa={aa:0};", "whitage", "not_free", "", 0]
 
                         test_cause("not_free");
                         free = false;
                         open = false;
 
 // test_cause:
-// ["let aa = ( 0 );", "no_space_only", "unexpected_space_a_b", "0", 77]
+// ["let aa = ( 0 );", "no_space_only", "unexpected_space_a_b", "0", 12]
 
                         no_space_only();
                     }
@@ -6503,13 +6493,13 @@ function jslint_phase5_whitage(state) {
 // } else  if (aa) {
 //     aa();
 // }
-// ", "one_space_only", "expected_space_a_b", "if", 77]
+// ", "one_space_only", "expected_space_a_b", "if", 9]
 
                         one_space_only();
                     } else {
 
 // test_cause:
-// [" let aa = 0;", "expected_at", "expected_a_at_b_c", "1", 77]
+// [" let aa = 0;", "expected_at", "expected_a_at_b_c", "1", 2]
 
                         at_margin(0);
                         open = false;
@@ -6547,7 +6537,7 @@ function jslint_phase5_whitage(state) {
 //         }
 //     }
 // }
-// ", "expected_at", "expected_a_at_b_c", "1", 77]
+// ", "expected_at", "expected_a_at_b_c", "1", 10]
 
                             expected_at(0);
                         }
@@ -6558,7 +6548,7 @@ function jslint_phase5_whitage(state) {
                         )) {
 
 // test_cause:
-// ["let {aa,bb} = 0;", "one_space", "expected_space_a_b", "bb", 77]
+// ["let {aa,bb} = 0;", "one_space", "expected_space_a_b", "bb", 9]
 
                             one_space();
                         } else {
@@ -6570,7 +6560,7 @@ function jslint_phase5_whitage(state) {
 //         0,0
 //     );
 // }
-// ", "expected_at", "expected_a_at_b_c", "9", 77]
+// ", "expected_at", "expected_a_at_b_c", "9", 11]
 
                             at_margin(0);
                         }
@@ -6587,13 +6577,13 @@ function jslint_phase5_whitage(state) {
 //     ? 0
 // : 1
 // );
-// ", "expected_at", "expected_a_at_b_c", "5", 77]
+// ", "expected_at", "expected_a_at_b_c", "5", 1]
 
                             at_margin(0);
                         } else {
 
 // test_cause:
-// ["let aa = (aa ? 0 : 1);", "whitage", "use_open", "?", 77]
+// ["let aa = (aa ? 0 : 1);", "whitage", "use_open", "?", 14]
 
                             warn("use_open", right);
                         }
@@ -6604,11 +6594,7 @@ function jslint_phase5_whitage(state) {
                     ) {
 
 // test_cause:
-// ["
-// let aa = aa(
-//     aa ()
-// );
-// ", "no_space", "unexpected_space_a_b", "(", 77]
+// ["let aa = aa(\naa ()\n);", "no_space", "unexpected_space_a_b", "(", 4]
 
                         no_space();
                     } else if (
@@ -6630,8 +6616,8 @@ function jslint_phase5_whitage(state) {
                     ) {
 
 // test_cause:
-// ["let aa = 0 ;", "no_space_only", "unexpected_space_a_b", ";", 77]
-// ["let aa = aa ?.aa;", "no_space_only", "unexpected_space_a_b", "?.", 77]
+// ["let aa = 0 ;", "no_space_only", "unexpected_space_a_b", ";", 12]
+// ["let aa = aa ?.aa;", "no_space_only", "unexpected_space_a_b", "?.", 13]
 
                         no_space_only();
                     } else if (left.id === ";") {
@@ -6648,7 +6634,7 @@ function jslint_phase5_whitage(state) {
 //         aa();
 //     }
 // }
-// ", "expected_at", "expected_a_at_b_c", "9", 77]
+// ", "expected_at", "expected_a_at_b_c", "9", 1]
 
                         if (open) {
                             at_margin(0);
@@ -6675,7 +6661,7 @@ function jslint_phase5_whitage(state) {
 //         aa();
 //     } while(aa());
 // }
-// ", "one_space_only", "expected_space_a_b", "(", 77]
+// ", "one_space_only", "expected_space_a_b", "(", 12]
 
                         one_space_only();
                     } else if (
@@ -6710,18 +6696,8 @@ function jslint_phase5_whitage(state) {
                     ) {
 
 // test_cause:
-// ["
-// let aa = {
-//     aa:
-// 0
-// };
-// ", "expected_at", "expected_a_at_b_c", "5", 77]
-// ["let aa=0;", "one_space", "expected_space_a_b", "0", 77]
-// ["
-// let aa={
-//     aa: 0
-// };
-// ", "one_space", "expected_space_a_b", "{", 77]
+// ["let aa=0;", "one_space", "expected_space_a_b", "0", 8]
+// ["let aa={\naa:\n0\n};", "expected_at", "expected_a_at_b_c", "5", 1]
 
                         one_space();
                     } else if (left.arity === "unary" && left.id !== "`") {
@@ -7027,7 +7003,7 @@ function jslint(
         let bb_value;
 
 // test_cause:
-// ["0&&0", "is_equal", "", "", 77]
+// ["0&&0", "is_equal", "", "", 0]
 
         test_cause("");
 
@@ -7044,7 +7020,7 @@ function jslint(
                 && aa.every(function (value, index) {
 
 // test_cause:
-// ["`${0}`&&`${0}`", "is_equal", "recurse_isArray", "", 77]
+// ["`${0}`&&`${0}`", "is_equal", "recurse_isArray", "", 0]
 
                     test_cause("recurse_isArray");
                     return is_equal(value, bb[index]);
@@ -7077,7 +7053,7 @@ function jslint(
         if (is_weird(aa) || is_weird(bb)) {
 
 // test_cause:
-// ["aa(/./)||{}", "is_equal", "false", "", 77]
+// ["aa(/./)||{}", "is_equal", "false", "", 0]
 
             test_cause("false");
             return false;
@@ -7086,7 +7062,7 @@ function jslint(
             if (aa.id === ".") {
 
 // test_cause:
-// ["aa.bb&&aa.bb", "is_equal", "recurse_arity_id", "", 77]
+// ["aa.bb&&aa.bb", "is_equal", "recurse_arity_id", "", 0]
 
                 test_cause("recurse_arity_id");
                 return (
@@ -7097,7 +7073,7 @@ function jslint(
             if (aa.arity === "unary") {
 
 // test_cause:
-// ["+0&&+0", "is_equal", "recurse_unary", "", 77]
+// ["+0&&+0", "is_equal", "recurse_unary", "", 0]
 
                 test_cause("recurse_unary");
                 return is_equal(aa.expression, bb.expression);
@@ -7105,7 +7081,7 @@ function jslint(
             if (aa.arity === "binary") {
 
 // test_cause:
-// ["aa[0]&&aa[0]", "is_equal", "recurse_binary", "", 77]
+// ["aa[0]&&aa[0]", "is_equal", "recurse_binary", "", 0]
 
                 test_cause("recurse_binary");
                 return (
@@ -7117,7 +7093,7 @@ function jslint(
             if (aa.arity === "ternary") {
 
 // test_cause:
-// ["aa=(``?``:``)&&(``?``:``)", "is_equal", "recurse_ternary", "", 77]
+// ["aa=(``?``:``)&&(``?``:``)", "is_equal", "recurse_ternary", "", 0]
 
                 test_cause("recurse_ternary");
                 return (
@@ -7138,20 +7114,20 @@ function jslint(
             );
 
 // test_cause:
-// ["undefined&&undefined", "is_equal", "true", "", 77]
+// ["undefined&&undefined", "is_equal", "true", "", 0]
 
             test_cause("true");
             return true;
         }
 
 // test_cause:
-// ["null&&undefined", "is_equal", "false", "", 77]
+// ["null&&undefined", "is_equal", "false", "", 0]
 
         test_cause("false");
         return false;
     }
 
-    function test_cause(code, aa) {
+    function test_cause(code, aa, column) {
 
 // This function will instrument <cause> to <cause_dict> for test-purposes.
 
@@ -7170,7 +7146,7 @@ function jslint(
                     ? ""
                     : aa
                 ),
-                77
+                column || 0
             ])] = true;
         }
     }
@@ -7199,7 +7175,7 @@ function jslint(
             Math.min(warning.column, warning.line_source.length),
             jslint_fudge
         );
-        test_cause(code, b || a);
+        test_cause(code, b || a, warning.column);
         switch (code) {
 
 // The bundle contains the raw text messages that are generated by jslint. It
@@ -7499,7 +7475,7 @@ function jslint(
         if (warning.directive_quiet) {
 
 // test_cause:
-// ["0 //jslint-quiet", "semicolon", "directive_quiet", "", 77]
+// ["0 //jslint-quiet", "semicolon", "directive_quiet", "", 0]
 
             test_cause("directive_quiet");
             return warning;
@@ -7521,21 +7497,23 @@ function jslint(
 // If there is already a warning on this token, suppress the new one. It is
 // likely that the first warning will be the most meaningful.
 
+        let the_warning;
         the_token = the_token || state.token_nxt;
-        a = a || artifact(the_token);
+        the_warning = warn_at(
+            code,
+            the_token.line,
+            (the_token.from || 0) + jslint_fudge,
+            a || artifact(the_token),
+            b,
+            c,
+            d
+        );
         if (the_token.warning === undefined) {
-            the_token.warning = warn_at(
-                code,
-                the_token.line,
-                (the_token.from || 0) + jslint_fudge,
-                a || artifact(the_token),
-                b,
-                c,
-                d
-            );
-            return the_token.warning;
+            the_token.warning = the_warning;
+        } else {
+            warning_list.pop();
         }
-        test_cause(code, b || a);
+        return the_warning;
     }
 
     function stop(code, the_token, a, b, c, d) {
@@ -7659,7 +7637,7 @@ function jslint(
                 if (comment.directive === "global") {
 
 // test_cause:
-// ["/*global aa*/", "jslint", "missing_browser", "(comment)", 77]
+// ["/*global aa*/", "jslint", "missing_browser", "(comment)", 1]
 
                     warn("missing_browser", comment);
                 }
@@ -8040,3 +8018,6 @@ jslint_import_meta_url = import.meta.url;
         cjs_require
     });
 }());
+
+// Coverage-hack.
+noop(jslint_charset_ascii);

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -283,8 +283,8 @@ function jslint_phase2_lex(state) {
         if (match !== undefined && char !== match) {
 
 // test_cause:
-// ["aa=/[", "char_after", "expected_a", "7", 77]
-// ["aa=/aa{/", "char_after", "expected_a_b", "7", 77]
+// ["aa=/[", "char_after", "expected_a", "]", 77]
+// ["aa=/aa{/", "char_after", "expected_a_b", "/", 77]
 
             return (
                 char === ""
@@ -320,7 +320,7 @@ function jslint_phase2_lex(state) {
         if (!quiet && length === 0) {
 
 // test_cause:
-// ["0x", "read_digits", "expected_digits_after_a", "7", 77]
+// ["0x", "read_digits", "expected_digits_after_a", "0x", 77]
 
             warn_at("expected_digits_after_a", line, column, snippet);
         }
@@ -347,7 +347,7 @@ function jslint_phase2_lex(state) {
         ) {
 
 // test_cause:
-// ["/////////////////////////////////////////////////////////////////////////////////", "read_line", "too_long", "7", 77] //jslint-quiet
+// ["/////////////////////////////////////////////////////////////////////////////////", "read_line", "too_long", "", 77] //jslint-quiet
 
             warn_at("too_long", line);
         }
@@ -370,7 +370,7 @@ function jslint_phase2_lex(state) {
         if (line_source === "/*jslint-disable*/") {
 
 // test_cause:
-// ["/*jslint-disable*/", "read_line", "jslint_disable", "7", 77]
+// ["/*jslint-disable*/", "read_line", "jslint_disable", "", 77]
 
             test_cause("jslint_disable");
             line_disable = line;
@@ -378,7 +378,7 @@ function jslint_phase2_lex(state) {
             if (line_disable === undefined) {
 
 // test_cause:
-// ["/*jslint-enable*/", "read_line", "unopened_enable", "7", 77]
+// ["/*jslint-enable*/", "read_line", "unopened_enable", "", 77]
 
                 stop_at("unopened_enable", line);
             }
@@ -386,7 +386,7 @@ function jslint_phase2_lex(state) {
         } else if (line_source.endsWith(" //jslint-quiet")) {
 
 // test_cause:
-// ["0 //jslint-quiet", "read_line", "jslint_quiet", "7", 77]
+// ["0 //jslint-quiet", "read_line", "jslint_quiet", "", 77]
 
             test_cause("jslint_quiet");
             line_list[line].directive_quiet = true;
@@ -394,7 +394,7 @@ function jslint_phase2_lex(state) {
         if (line_disable !== undefined) {
 
 // test_cause:
-// ["/*jslint-disable*/\n0", "read_line", "line_disable", "7", 77]
+// ["/*jslint-disable*/\n0", "read_line", "line_disable", "", 77]
 
             test_cause("line_disable");
             line_source = "";
@@ -403,7 +403,7 @@ function jslint_phase2_lex(state) {
             if (!option_dict.white) {
 
 // test_cause:
-// ["\t", "read_line", "use_spaces", "7", 77]
+// ["\t", "read_line", "use_spaces", "", 77]
 
                 warn_at("use_spaces", line, line_source.indexOf("\t") + 1);
             }
@@ -415,7 +415,7 @@ function jslint_phase2_lex(state) {
         if (!option_dict.white && line_source.endsWith(" ")) {
 
 // test_cause:
-// [" ", "read_line", "unexpected_trailing_space", "7", 77]
+// [" ", "read_line", "unexpected_trailing_space", "", 77]
 
             warn_at("unexpected_trailing_space", line, line_source.length - 1);
         }
@@ -461,7 +461,7 @@ function jslint_phase2_lex(state) {
         ) {
 
 // test_cause:
-// ["/**//**/", "token_create", "expected_space_a_b", "7", 77]
+// ["/**//**/", "token_create", "expected_space_a_b", "(comment)", 77]
 
             warn(
                 "expected_space_a_b",
@@ -473,7 +473,7 @@ function jslint_phase2_lex(state) {
         if (token_prv.id === "." && id === "(number)") {
 
 // test_cause:
-// [".0", "token_create", "expected_a_before_b", "7", 77]
+// [".0", "token_create", "expected_a_before_b", ".", 77]
 
             warn("expected_a_before_b", token_prv, "0", ".");
         }
@@ -505,7 +505,7 @@ function jslint_phase2_lex(state) {
         case "":
 
 // test_cause:
-// ["\"\\", "char_after_escape", "unclosed_string", "7", 77]
+// ["\"\\", "char_after_escape", "unclosed_string", "", 77]
 
             return stop_at("unclosed_string", line, column);
         case "/":
@@ -525,7 +525,9 @@ function jslint_phase2_lex(state) {
         case "t":
 
 // test_cause:
-// ["\"\\/\\\\\\`\\b\\f\\n\\r\\t\"", "char_after_escape", "char_after", "7", 77] //jslint-quiet
+// ["
+// "\/\\\`\b\f\n\r\t"
+// ", "char_after_escape", "char_after", "", 77]
 
             test_cause("char_after");
             return char_after();
@@ -534,21 +536,21 @@ function jslint_phase2_lex(state) {
                 if (state.mode_json) {
 
 // test_cause:
-// ["[\"\\u{12345}\"]", "char_after_escape", "unexpected_a", "7", 77]
+// ["[\"\\u{12345}\"]", "char_after_escape", "unexpected_a", "{", 77]
 
                     warn_at("unexpected_a", line, column, char);
                 }
                 if (read_digits(rx_hexs) > 5) {
 
 // test_cause:
-// ["\"\\u{123456}\"", "char_after_escape", "too_many_digits", "7", 77]
+// ["\"\\u{123456}\"", "char_after_escape", "too_many_digits", "", 77]
 
                     warn_at("too_many_digits", line, column);
                 }
                 if (char !== "}") {
 
 // test_cause:
-// ["\"\\u{12345\"", "char_after_escape", "expected_a_before_b", "7", 77]
+// ["\"\\u{12345\"", "char_after_escape", "expected_a_before_b", "\"", 77]
 
                     stop_at("expected_a_before_b", line, column, "}", char);
                 }
@@ -558,7 +560,7 @@ function jslint_phase2_lex(state) {
             if (read_digits(rx_hexs, true) < 4) {
 
 // test_cause:
-// ["\"\\u0\"", "char_after_escape", "expected_four_digits", "7", 77]
+// ["\"\\u0\"", "char_after_escape", "expected_four_digits", "", 77]
 
                 warn_at("expected_four_digits", line, column);
             }
@@ -569,7 +571,7 @@ function jslint_phase2_lex(state) {
             }
 
 // test_cause:
-// ["\"\\0\"", "char_after_escape", "unexpected_a_before_b", "7", 77]
+// ["\"\\0\"", "char_after_escape", "unexpected_a_before_b", "0", 77]
 
             warn_at("unexpected_a_before_b", line, column, "\\", char);
         }
@@ -597,7 +599,7 @@ function jslint_phase2_lex(state) {
             if (mode_mega) {
 
 // test_cause:
-// ["`${//}`", "lex_comment", "unexpected_comment", "7", 77]
+// ["`${//}`", "lex_comment", "unexpected_comment", "`", 77]
 
                 warn("unexpected_comment", the_comment, "`");
             }
@@ -609,7 +611,7 @@ function jslint_phase2_lex(state) {
             if (line_source[0] === "/") {
 
 // test_cause:
-// ["/*/", "lex_comment", "unexpected_a", "7", 77]
+// ["/*/", "lex_comment", "unexpected_a", "/", 77]
 
                 warn_at("unexpected_a", line, column + ii, "/");
             }
@@ -628,7 +630,7 @@ function jslint_phase2_lex(state) {
                     if (jj >= 0) {
 
 // test_cause:
-// ["/*/*", "lex_comment", "nested_comment", "7", 77]
+// ["/*/*", "lex_comment", "nested_comment", "", 77]
 
                         warn_at("nested_comment", line, column + jj);
                     }
@@ -638,7 +640,7 @@ function jslint_phase2_lex(state) {
                 if (line_source === undefined) {
 
 // test_cause:
-// ["/*", "lex_comment", "unclosed_comment", "7", 77]
+// ["/*", "lex_comment", "unclosed_comment", "", 77]
 
                     return stop_at("unclosed_comment", line, column);
                 }
@@ -650,7 +652,7 @@ function jslint_phase2_lex(state) {
             if (jj >= 0) {
 
 // test_cause:
-// ["/*/**/", "lex_comment", "nested_comment", "7", 77]
+// ["/*/**/", "lex_comment", "nested_comment", "", 77]
 
                 warn_at("nested_comment", line, column + jj);
             }
@@ -672,7 +674,7 @@ function jslint_phase2_lex(state) {
         ) {
 
 // test_cause:
-// ["//todo", "lex_comment", "todo_comment", "7", 77] //jslint-quiet
+// ["//todo", "lex_comment", "todo_comment", "(comment)", 77] //jslint-quiet
 
             warn("todo_comment", the_comment);
         }
@@ -690,7 +692,7 @@ function jslint_phase2_lex(state) {
         if (!mode_directive) {
 
 // test_cause:
-// ["0\n/*global aa*/", "lex_comment", "misplaced_directive_a", "7", 77]
+// ["0\n/*global aa*/", "lex_comment", "misplaced_directive_a", "global", 77]
 
             warn_at("misplaced_directive_a", line, from, match[1]);
             return the_comment;
@@ -714,7 +716,7 @@ function jslint_phase2_lex(state) {
                 if (body) {
 
 // test_cause:
-// ["/*jslint !*/", "lex_comment", "bad_directive_a", "7", 77]
+// ["/*jslint !*/", "lex_comment", "bad_directive_a", "!", 77]
 
                     return stop("bad_directive_a", the_comment, body);
                 }
@@ -751,7 +753,7 @@ function jslint_phase2_lex(state) {
                 } else {
 
 // test_cause:
-// ["/*jslint undefined*/", "lex_comment", "bad_option_a", "7", 77]
+// ["/*jslint undefined*/", "lex_comment", "bad_option_a", "undefined", 77]
 
                     warn("bad_option_a", the_comment, name);
                 }
@@ -762,7 +764,7 @@ function jslint_phase2_lex(state) {
                 if (value) {
 
 // test_cause:
-// ["/*global aa:false*/", "lex_comment", "bad_option_a", "7", 77]
+// ["/*global aa:false*/", "lex_comment", "bad_option_a", "aa:false", 77]
 
                     warn("bad_option_a", the_comment, name + ":" + value);
                 }
@@ -782,7 +784,7 @@ function jslint_phase2_lex(state) {
         if (mode_mega) {
 
 // test_cause:
-// ["`${`", "lex_megastring", "expected_a_b", "7", 77]
+// ["`${`", "lex_megastring", "expected_a_b", "`", 77]
 
             return stop_at("expected_a_b", line, column, "}", "`");
         }
@@ -835,7 +837,7 @@ function jslint_phase2_lex(state) {
                     if (id === "{") {
 
 // test_cause:
-// ["`${{", "lex_megastring", "expected_a_b", "7", 77]
+// ["`${{", "lex_megastring", "expected_a_b", "{", 77]
 
                         return stop_at("expected_a_b", line, column, "}", "{");
                     }
@@ -871,7 +873,7 @@ function jslint_phase2_lex(state) {
                 if (read_line() === undefined) {
 
 // test_cause:
-// ["`", "lex_megastring", "unclosed_mega", "7", 77]
+// ["`", "lex_megastring", "unclosed_mega", "", 77]
 
                     return stop_at("unclosed_mega", line_mega, from_mega);
                 }
@@ -921,7 +923,7 @@ function jslint_phase2_lex(state) {
         ) {
 
 // test_cause:
-// ["0a", "lex_number", "unexpected_a_after_b", "7", 77]
+// ["0a", "lex_number", "unexpected_a_after_b", "0", 77]
 
             return stop_at(
                 "unexpected_a_after_b",
@@ -966,14 +968,14 @@ function jslint_phase2_lex(state) {
                 case "]":
 
 // test_cause:
-// ["aa=/[", "lex_regexp_bracketed", "closer", "7", 77]
-// ["aa=/[]/", "lex_regexp_bracketed", "closer", "7", 77]
+// ["aa=/[", "lex_regexp_bracketed", "closer", "", 77]
+// ["aa=/[]/", "lex_regexp_bracketed", "closer", "", 77]
 
                     test_cause("closer");
                     if (mode_regexp_range) {
 
 // test_cause:
-// ["aa=/[0-]/", "lex_regexp_bracketed", "unexpected_a", "7", 77]
+// ["aa=/[0-]/", "lex_regexp_bracketed", "unexpected_a", "-", 77]
 
                         warn_at("unexpected_a", line, column - 1, "-");
                     }
@@ -981,7 +983,7 @@ function jslint_phase2_lex(state) {
                 case " ":
 
 // test_cause:
-// ["aa=/[ ]/", "lex_regexp_bracketed", "expected_a_b", "7", 77]
+// ["aa=/[ ]/", "lex_regexp_bracketed", "expected_a_b", " ", 77]
 
                     warn_at("expected_a_b", line, column, "\\u0020", " ");
                     break;
@@ -991,11 +993,11 @@ function jslint_phase2_lex(state) {
                 case "^":
 
 // test_cause:
-// ["aa=/[-]/", "lex_regexp_bracketed", "expected_a_before_b", "7", 77]
-// ["aa=/[.^]/", "lex_regexp_bracketed", "expected_a_before_b", "7", 77]
-// ["aa=/[/", "lex_regexp_bracketed", "expected_a_before_b", "7", 77]
-// ["aa=/[\\\\/]/", "lex_regexp_bracketed", "expected_a_before_b", "7", 77]
-// ["aa=/[\\\\[]/", "lex_regexp_bracketed", "expected_a_before_b", "7", 77]
+// ["aa=/[-]/", "lex_regexp_bracketed", "expected_a_before_b", "-", 77]
+// ["aa=/[.^]/", "lex_regexp_bracketed", "expected_a_before_b", "^", 77]
+// ["aa=/[/", "lex_regexp_bracketed", "expected_a_before_b", "/", 77]
+// ["aa=/[\\\\/]/", "lex_regexp_bracketed", "expected_a_before_b", "/", 77]
+// ["aa=/[\\\\[]/", "lex_regexp_bracketed", "expected_a_before_b", "[", 77]
 
                     warn_at("expected_a_before_b", line, column, "\\", char);
                     break;
@@ -1007,7 +1009,7 @@ function jslint_phase2_lex(state) {
                     if (mode_mega) {
 
 // test_cause:
-// ["`${/[`]/}`", "lex_regexp_bracketed", "unexpected_a", "7", 77]
+// ["`${/[`]/}`", "lex_regexp_bracketed", "unexpected_a", "`", 77]
 
                         warn_at("unexpected_a", line, column, "`");
                     }
@@ -1041,9 +1043,9 @@ function jslint_phase2_lex(state) {
             case "]":
 
 // test_cause:
-// ["/ /", "lex_regexp_group", "expected_regexp_factor_a", "7", 77]
-// ["aa=/)", "lex_regexp_group", "expected_regexp_factor_a", "7", 77]
-// ["aa=/]", "lex_regexp_group", "expected_regexp_factor_a", "7", 77]
+// ["/ /", "lex_regexp_group", "expected_regexp_factor_a", "", 77]
+// ["aa=/)", "lex_regexp_group", "expected_regexp_factor_a", ")", 77]
+// ["aa=/]", "lex_regexp_group", "expected_regexp_factor_a", "]", 77]
 
                 warn_at("expected_regexp_factor_a", line, column, char);
                 break;
@@ -1058,7 +1060,7 @@ function jslint_phase2_lex(state) {
                 case " ":
 
 // test_cause:
-// ["aa=/ /", "lex_regexp_group", "expected_a_b", "7", 77]
+// ["aa=/ /", "lex_regexp_group", "expected_a_b", " ", 77]
 
                     warn_at("expected_a_b", line, column, "\\s", " ");
                     char_after();
@@ -1085,8 +1087,8 @@ function jslint_phase2_lex(state) {
                     } else if (char === ":") {
 
 // test_cause:
-// ["aa=/(:)/", "lex_regexp_group", "expected_a_before_b", "7", 77]
-// ["aa=/?/", "lex_regexp_group", "expected_a_before_b", "7", 77]
+// ["aa=/(:)/", "lex_regexp_group", "expected_a_before_b", ":", 77]
+// ["aa=/?/", "lex_regexp_group", "expected_a_before_b", "?", 77]
 
                         warn_at("expected_a_before_b", line, column, "?", ":");
                     }
@@ -1098,25 +1100,17 @@ function jslint_phase2_lex(state) {
                     char_after(")");
                     break;
                 case "*":
-
-// test_cause:
-// ["aa=/.**/", "lex_regexp_group", "expected_a_before_b", "7", 77]
-
-                    warn_at("expected_a_before_b", line, column, "\\", char);
-                    char_after();
-                    break;
                 case "+":
-
-// test_cause:
-// ["aa=/+/", "lex_regexp_group", "expected_a_before_b", "7", 77]
-
-                    warn_at("expected_a_before_b", line, column, "\\", char);
-                    char_after();
-                    break;
                 case "?":
+                case "{":
+                case "}":
 
 // test_cause:
-// ["aa=/?/", "lex_regexp_group", "expected_a_before_b", "7", 77]
+// ["aa=/+/", "lex_regexp_group", "expected_a_before_b", "+", 77]
+// ["aa=/.**/", "lex_regexp_group", "expected_a_before_b", "*", 77]
+// ["aa=/?/", "lex_regexp_group", "expected_a_before_b", "?", 77]
+// ["aa=/{/", "lex_regexp_group", "expected_a_before_b", "{", 77]
+// ["aa=/}/", "lex_regexp_group", "expected_a_before_b", "}", 77]
 
                     warn_at("expected_a_before_b", line, column, "\\", char);
                     char_after();
@@ -1127,7 +1121,7 @@ function jslint_phase2_lex(state) {
                 case "\\":
 
 // test_cause:
-// ["aa=/\\/", "lex_regexp_group", "escape", "7", 77]
+// ["aa=/\\/", "lex_regexp_group", "escape", "", 77]
 
                     test_cause("escape");
                     char_after_escape("BbDdSsWw^${}[]():=!.|*+?");
@@ -1142,26 +1136,10 @@ function jslint_phase2_lex(state) {
                     if (mode_mega) {
 
 // test_cause:
-// ["`${/`/}`", "lex_regexp_group", "unexpected_a", "7", 77]
+// ["`${/`/}`", "lex_regexp_group", "unexpected_a", "`", 77]
 
                         warn_at("unexpected_a", line, column, "`");
                     }
-                    char_after();
-                    break;
-                case "{":
-
-// test_cause:
-// ["aa=/{/", "lex_regexp_group", "expected_a_before_b", "7", 77]
-
-                    warn_at("expected_a_before_b", line, column, "\\", char);
-                    char_after();
-                    break;
-                case "}":
-
-// test_cause:
-// ["aa=/}/", "lex_regexp_group", "expected_a_before_b", "7", 77]
-
-                    warn_at("expected_a_before_b", line, column, "\\", char);
                     char_after();
                     break;
                 default:
@@ -1173,12 +1151,14 @@ function jslint_phase2_lex(state) {
 
                 switch (char) {
                 case "*":
-                    if (char_after("*") === "?") {
-                        char_after("?");
-                    }
-                    break;
                 case "+":
-                    if (char_after("+") === "?") {
+                    if (char_after(char) === "?") {
+
+// test_cause:
+// ["aa=/.*?/", "lex_regexp_group", "?", "", 77]
+// ["aa=/.+?/", "lex_regexp_group", "?", "", 77]
+
+                        test_cause("?");
                         char_after("?");
                     }
                     break;
@@ -1186,7 +1166,7 @@ function jslint_phase2_lex(state) {
                     if (char_after("?") === "?") {
 
 // test_cause:
-// ["aa=/.??/", "lex_regexp_group", "unexpected_a", "7", 77]
+// ["aa=/.??/", "lex_regexp_group", "unexpected_a", "?", 77]
 
                         warn_at("unexpected_a", line, column, char);
                         char_after("?");
@@ -1196,14 +1176,14 @@ function jslint_phase2_lex(state) {
                     if (read_digits(rx_digits, true) === 0) {
 
 // test_cause:
-// ["aa=/aa{/", "lex_regexp_group", "expected_a_before_b", "7", 77]
+// ["aa=/aa{/", "lex_regexp_group", "expected_a_before_b", ",", 77]
 
                         warn_at("expected_a_before_b", line, column, "0", ",");
                     }
                     if (char === ",") {
 
 // test_cause:
-// ["aa=/.{,/", "lex_regexp_group", "comma", "7", 77]
+// ["aa=/.{,/", "lex_regexp_group", "comma", "", 77]
 
                         test_cause("comma");
                         read_digits(rx_digits, true);
@@ -1211,7 +1191,7 @@ function jslint_phase2_lex(state) {
                     if (char_after("}") === "?") {
 
 // test_cause:
-// ["aa=/.{0}?/", "lex_regexp_group", "unexpected_a", "7", 77]
+// ["aa=/.{0}?/", "lex_regexp_group", "unexpected_a", "?", 77]
 
                         warn_at("unexpected_a", line, column, char);
                         char_after("?");
@@ -1230,7 +1210,7 @@ function jslint_phase2_lex(state) {
         if (char === "=") {
 
 // test_cause:
-// ["aa=/=/", "lex_regexp", "expected_a_before_b", "7", 77]
+// ["aa=/=/", "lex_regexp", "expected_a_before_b", "=", 77]
 
             warn_at("expected_a_before_b", line, column, "\\", "=");
         }
@@ -1275,15 +1255,15 @@ function jslint_phase2_lex(state) {
             case "y":
 
 // test_cause:
-// ["aa=/./gimuy", "lex_regexp", "flag", "7", 77]
+// ["aa=/./gimuy", "lex_regexp", "flag", "", 77]
 
                 test_cause("flag");
                 break;
             default:
 
 // test_cause:
-// ["aa=/./gg", "lex_regexp", "unexpected_a", "7", 77]
-// ["aa=/./z", "lex_regexp", "unexpected_a", "7", 77]
+// ["aa=/./gg", "lex_regexp", "unexpected_a", "g", 77]
+// ["aa=/./z", "lex_regexp", "unexpected_a", "z", 77]
 
                 warn_at("unexpected_a", line, column, char);
             }
@@ -1294,7 +1274,7 @@ function jslint_phase2_lex(state) {
         if (char === "/" || char === "*") {
 
 // test_cause:
-// ["aa=/.//", "lex_regexp", "unexpected_a", "7", 77]
+// ["aa=/.//", "lex_regexp", "unexpected_a", "/", 77]
 
             return stop_at("unexpected_a", line, from, char);
         }
@@ -1304,7 +1284,7 @@ function jslint_phase2_lex(state) {
         if (mode_regexp_multiline && !flag.m) {
 
 // test_cause:
-// ["aa=/$^/", "lex_regexp", "missing_m", "7", 77]
+// ["aa=/$^/", "lex_regexp", "missing_m", "", 77]
 
             warn_at("missing_m", line, column);
         }
@@ -1329,42 +1309,28 @@ function jslint_phase2_lex(state) {
             && token_prv_expr.id
         ) {
         case "case":
-            the_token = lex_regexp();
-            return stop("unexpected_a", the_token);
         case "delete":
-            the_token = lex_regexp();
-            return stop("unexpected_a", the_token);
         case "in":
-            the_token = lex_regexp();
-            return stop("unexpected_a", the_token);
         case "instanceof":
-            the_token = lex_regexp();
-            return stop("unexpected_a", the_token);
         case "new":
-            the_token = lex_regexp();
-            return stop("unexpected_a", the_token);
-        case "return":
-            return lex_regexp();
         case "typeof":
-            the_token = lex_regexp();
-            return stop("unexpected_a", the_token);
         case "void":
-            the_token = lex_regexp();
-            return stop("unexpected_a", the_token);
         case "yield":
             the_token = lex_regexp();
 
 // test_cause:
-// ["case /./", "lex_slash_or_regexp", "unexpected_a", "7", 77]
-// ["delete /./", "lex_slash_or_regexp", "unexpected_a", "7", 77]
-// ["in /./", "lex_slash_or_regexp", "unexpected_a", "7", 77]
-// ["instanceof /./", "lex_slash_or_regexp", "unexpected_a", "7", 77]
-// ["new /./", "lex_slash_or_regexp", "unexpected_a", "7", 77]
-// ["typeof /./", "lex_slash_or_regexp", "unexpected_a", "7", 77]
-// ["void /./", "lex_slash_or_regexp", "unexpected_a", "7", 77]
-// ["yield /./", "lex_slash_or_regexp", "unexpected_a", "7", 77]
+// ["case /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 77]
+// ["delete /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 77]
+// ["in /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 77]
+// ["instanceof /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 77]
+// ["new /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 77]
+// ["typeof /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 77]
+// ["void /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 77]
+// ["yield /./", "lex_slash_or_regexp", "unexpected_a", "(regexp)", 77]
 
             return stop("unexpected_a", the_token);
+        case "return":
+            return lex_regexp();
         }
         switch (!token_prv_expr.identifier && token_prv_expr.id.slice(-1)) {
         case "!":
@@ -1385,21 +1351,21 @@ function jslint_phase2_lex(state) {
             the_token = lex_regexp();
 
 // test_cause:
-// ["!/./", "lex_slash_or_regexp", "wrap_regexp", "7", 77]
-// ["%/./", "lex_slash_or_regexp", "wrap_regexp", "7", 77]
-// ["&/./", "lex_slash_or_regexp", "wrap_regexp", "7", 77]
-// ["+/./", "lex_slash_or_regexp", "wrap_regexp", "7", 77]
-// ["-/./", "lex_slash_or_regexp", "wrap_regexp", "7", 77]
-// ["0 * /./", "lex_slash_or_regexp", "wrap_regexp", "7", 77]
-// ["0 / /./", "lex_slash_or_regexp", "wrap_regexp", "7", 77]
-// [";/./", "lex_slash_or_regexp", "wrap_regexp", "7", 77]
-// ["</./", "lex_slash_or_regexp", "wrap_regexp", "7", 77]
-// [">/./", "lex_slash_or_regexp", "wrap_regexp", "7", 77]
-// ["^/./", "lex_slash_or_regexp", "wrap_regexp", "7", 77]
-// ["{/./", "lex_slash_or_regexp", "wrap_regexp", "7", 77]
-// ["|/./", "lex_slash_or_regexp", "wrap_regexp", "7", 77]
-// ["}/./", "lex_slash_or_regexp", "wrap_regexp", "7", 77]
-// ["~/./", "lex_slash_or_regexp", "wrap_regexp", "7", 77]
+// ["!/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
+// ["%/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
+// ["&/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
+// ["+/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
+// ["-/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
+// ["0 * /./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
+// ["0 / /./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
+// [";/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
+// ["</./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
+// [">/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
+// ["^/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
+// ["{/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
+// ["|/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
+// ["}/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
+// ["~/./", "lex_slash_or_regexp", "wrap_regexp", "(regexp)", 77]
 
             warn("wrap_regexp", the_token);
             return the_token;
@@ -1411,12 +1377,12 @@ function jslint_phase2_lex(state) {
         case "[":
 
 // test_cause:
-// ["(/./", "lex_slash_or_regexp", "recurse", "7", 77]
-// [",/./", "lex_slash_or_regexp", "recurse", "7", 77]
-// [":/./", "lex_slash_or_regexp", "recurse", "7", 77]
-// ["=/./", "lex_slash_or_regexp", "recurse", "7", 77]
-// ["?/./", "lex_slash_or_regexp", "recurse", "7", 77]
-// ["aa[/./", "lex_slash_or_regexp", "recurse", "7", 77]
+// ["(/./", "lex_slash_or_regexp", "recurse", "", 77]
+// [",/./", "lex_slash_or_regexp", "recurse", "", 77]
+// [":/./", "lex_slash_or_regexp", "recurse", "", 77]
+// ["=/./", "lex_slash_or_regexp", "recurse", "", 77]
+// ["?/./", "lex_slash_or_regexp", "recurse", "", 77]
+// ["aa[/./", "lex_slash_or_regexp", "recurse", "", 77]
 
             test_cause("recurse");
             return lex_regexp();
@@ -1438,7 +1404,7 @@ function jslint_phase2_lex(state) {
         if (!option_dict.single && quote === "'") {
 
 // test_cause:
-// ["''", "lex_string", "use_double", "7", 77]
+// ["''", "lex_string", "use_double", "", 77]
 
             warn_at("use_double", line, column);
         }
@@ -1452,7 +1418,7 @@ function jslint_phase2_lex(state) {
             case "":
 
 // test_cause:
-// ["\"", "lex_string", "unclosed_string", "7", 77]
+// ["\"", "lex_string", "unclosed_string", "", 77]
 
                 return stop_at("unclosed_string", line, column);
             case "\\":
@@ -1462,7 +1428,7 @@ function jslint_phase2_lex(state) {
                 if (mode_mega) {
 
 // test_cause:
-// ["`${\"`\"}`", "lex_string", "unexpected_a", "7", 77]
+// ["`${\"`\"}`", "lex_string", "unexpected_a", "`", 77]
 
                     warn_at("unexpected_a", line, column, "`");
                 }
@@ -1499,13 +1465,13 @@ function jslint_phase2_lex(state) {
                         mode_mega
 
 // test_cause:
-// ["`${//}`", "lex_token", "unclosed_mega", "7", 77]
+// ["`${//}`", "lex_token", "unclosed_mega", "", 77]
 
                         ? stop_at("unclosed_mega", line_mega, from_mega)
                         : line_disable !== undefined
 
 // test_cause:
-// ["/*jslint-disable*/", "lex_token", "unclosed_disable", "7", 77]
+// ["/*jslint-disable*/", "lex_token", "unclosed_disable", "", 77]
 
                         ? stop_at("unclosed_disable", line_disable)
                         : token_create("(end)")
@@ -1524,7 +1490,7 @@ function jslint_phase2_lex(state) {
             if (!match) {
 
 // test_cause:
-// ["#", "lex_token", "unexpected_char_a", "7", 77]
+// ["#", "lex_token", "unexpected_char_a", "#", 77]
 
                 return stop_at(
                     "unexpected_char_a",
@@ -1651,27 +1617,20 @@ function jslint_phase3_parse(state) {
     let token_nxt = token_global;       // The next token to be examined in
                                         // ... <token_list>.
 
-    function warn_if_unordered(type, token_list) {
+    function check_ordered(type, token_list) {
 
 // This function will warn if <token_list> is unordered.
 
         token_list.reduce(function (aa, token) {
             const bb = artifact(token);
             if (!option_dict.unordered && aa > bb) {
-                warn(
-                    "expected_a_b_ordered_before_c_d",
-                    token,
-                    type,
-                    bb,
-                    type,
-                    aa
-                );
+                warn("expected_a_b_before_c_d", token, type, bb, type, aa);
             }
             return bb;
         }, "");
     }
 
-    function warn_if_unordered_case_statement(case_list) {
+    function check_ordered_case(case_list) {
 
 // This function will warn if <case_list> is unordered.
 
@@ -1709,7 +1668,7 @@ function jslint_phase3_parse(state) {
                 )
             ) {
                 warn(
-                    "expected_a_b_ordered_before_c_d",
+                    "expected_a_b_before_c_d",
                     bb.token,
                     `case-${bb.type}`,
                     bb.value,
@@ -1743,12 +1702,12 @@ function jslint_phase3_parse(state) {
                 match === undefined
 
 // test_cause:
-// ["()", "advance", "expected_a_b", "7", 77]
+// ["()", "advance", "expected_a_b", "(end)", 77]
 
                 ? stop("expected_a_b", token_nxt, id, artifact())
 
 // test_cause:
-// ["{\"aa\":0", "advance", "expected_a_b_from_c_d", "7", 77]
+// ["{\"aa\":0", "advance", "expected_a_b_from_c_d", "{", 77]
 
                 : stop(
                     "expected_a_b_from_c_d",
@@ -1777,7 +1736,7 @@ function jslint_phase3_parse(state) {
             if (state.mode_json) {
 
 // test_cause:
-// ["[//]", "advance", "unexpected_a", "7", 77]
+// ["[//]", "advance", "unexpected_a", "(comment)", 77]
 
                 warn("unexpected_a");
             }
@@ -1815,7 +1774,7 @@ function jslint_phase3_parse(state) {
         if (syntax_dict[id] !== undefined && id !== "ignore") {
 
 // test_cause:
-// ["let undefined", "enroll", "reserved_a", "7", 77]
+// ["let undefined", "enroll", "reserved_a", "undefined", 77]
 
             warn("reserved_a", name);
         } else {
@@ -1826,7 +1785,7 @@ function jslint_phase3_parse(state) {
             if (earlier) {
 
 // test_cause:
-// ["let aa;let aa", "enroll", "redefinition_a_b", "7", 77]
+// ["let aa;let aa", "enroll", "redefinition_a_b", "1", 77]
 
                 warn("redefinition_a_b", name, name.id, earlier.line);
 
@@ -1844,7 +1803,7 @@ function jslint_phase3_parse(state) {
                         if (earlier.role === "variable") {
 
 // test_cause:
-// ["let ignore;function aa(ignore){}", "enroll", "unexpected_a", "7", 77]
+// ["let ignore;function aa(ignore){}", "enroll", "unexpected_a", "ignore", 77]
 
                             warn("unexpected_a", name);
                         }
@@ -1860,8 +1819,8 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // function aa(){try{aa();}catch(aa){aa();}}
-// ", "enroll", "redefinition_a_b", "7", 77]
-// ["function aa(){var aa;}", "enroll", "redefinition_a_b", "7", 77]
+// ", "enroll", "redefinition_a_b", "1", 77]
+// ["function aa(){var aa;}", "enroll", "redefinition_a_b", "1", 77]
 
                             warn(
                                 "redefinition_a_b",
@@ -1924,14 +1883,14 @@ function jslint_phase3_parse(state) {
         if (the_symbol !== undefined && the_symbol.nud !== undefined) {
 
 // test_cause:
-// ["0", "parse_expression", "symbol", "7", 77]
+// ["0", "parse_expression", "symbol", "", 77]
 
             test_cause("symbol");
             left = the_symbol.nud();
         } else if (token_now.identifier) {
 
 // test_cause:
-// ["aa", "parse_expression", "identifier", "7", 77]
+// ["aa", "parse_expression", "identifier", "", 77]
 
             test_cause("identifier");
             left = token_now;
@@ -1939,9 +1898,9 @@ function jslint_phase3_parse(state) {
         } else {
 
 // test_cause:
-// ["!", "parse_expression", "unexpected_a", "7", 77]
-// ["/./", "parse_expression", "unexpected_a", "7", 77]
-// ["let aa=`${}`;", "parse_expression", "unexpected_a", "7", 77]
+// ["!", "parse_expression", "unexpected_a", "(end)", 77]
+// ["/./", "parse_expression", "unexpected_a", "/", 77]
+// ["let aa=`${}`;", "parse_expression", "unexpected_a", "}", 77]
 
             return stop("unexpected_a", token_now);
         }
@@ -1971,9 +1930,9 @@ function jslint_phase3_parse(state) {
         let the_value;
 
 // test_cause:
-// ["do{}while()", "condition", "", "7", 77]
-// ["if(){}", "condition", "", "7", 77]
-// ["while(){}", "condition", "", "7", 77]
+// ["do{}while()", "condition", "", "", 77]
+// ["if(){}", "condition", "", "", 77]
+// ["while(){}", "condition", "", "", 77]
 
         test_cause("");
         the_paren.free = true;
@@ -1983,7 +1942,7 @@ function jslint_phase3_parse(state) {
         if (the_value.wrapped === true) {
 
 // test_cause:
-// ["while((0)){}", "condition", "unexpected_a", "7", 77]
+// ["while((0)){}", "condition", "unexpected_a", "(", 77]
 
             warn("unexpected_a", the_paren);
         }
@@ -2039,22 +1998,22 @@ function jslint_phase3_parse(state) {
         case "~":
 
 // test_cause:
-// ["if(0%0){}", "condition", "unexpected_a", "7", 77]
-// ["if(0&0){}", "condition", "unexpected_a", "7", 77]
-// ["if(0){}", "condition", "unexpected_a", "7", 77]
-// ["if(0*0){}", "condition", "unexpected_a", "7", 77]
-// ["if(0+0){}", "condition", "unexpected_a", "7", 77]
-// ["if(0-0){}", "condition", "unexpected_a", "7", 77]
-// ["if(0/0){}", "condition", "unexpected_a", "7", 77]
-// ["if(0<<0){}", "condition", "unexpected_a", "7", 77]
-// ["if(0>>0){}", "condition", "unexpected_a", "7", 77]
-// ["if(0>>>0){}", "condition", "unexpected_a", "7", 77]
-// ["if(0?0:0){}", "condition", "unexpected_a", "7", 77]
-// ["if(0^0){}", "condition", "unexpected_a", "7", 77]
-// ["if(0|0){}", "condition", "unexpected_a", "7", 77]
-// ["if(\"aa\"){}", "condition", "unexpected_a", "7", 77]
-// ["if(typeof 0){}", "condition", "unexpected_a", "7", 77]
-// ["if(~0){}", "condition", "unexpected_a", "7", 77]
+// ["if(0%0){}", "condition", "unexpected_a", "%", 77]
+// ["if(0&0){}", "condition", "unexpected_a", "&", 77]
+// ["if(0){}", "condition", "unexpected_a", "0", 77]
+// ["if(0*0){}", "condition", "unexpected_a", "*", 77]
+// ["if(0+0){}", "condition", "unexpected_a", "+", 77]
+// ["if(0-0){}", "condition", "unexpected_a", "-", 77]
+// ["if(0/0){}", "condition", "unexpected_a", "/", 77]
+// ["if(0<<0){}", "condition", "unexpected_a", "<<", 77]
+// ["if(0>>0){}", "condition", "unexpected_a", ">>", 77]
+// ["if(0>>>0){}", "condition", "unexpected_a", ">>>", 77]
+// ["if(0?0:0){}", "condition", "unexpected_a", "?", 77]
+// ["if(0^0){}", "condition", "unexpected_a", "^", 77]
+// ["if(0|0){}", "condition", "unexpected_a", "|", 77]
+// ["if(\"aa\"){}", "condition", "unexpected_a", "aa", 77]
+// ["if(typeof 0){}", "condition", "unexpected_a", "typeof", 77]
+// ["if(~0){}", "condition", "unexpected_a", "~", 77]
 
             warn("unexpected_a", the_value);
             break;
@@ -2071,7 +2030,7 @@ function jslint_phase3_parse(state) {
         } else {
 
 // test_cause:
-// ["0", "semicolon", "expected_a_b", "7", 77]
+// ["0", "semicolon", "expected_a_b", "(end)", 77]
 
             warn_at(
                 "expected_a_b",
@@ -2100,7 +2059,7 @@ function jslint_phase3_parse(state) {
             if (the_label.id === "ignore") {
 
 // test_cause:
-// ["ignore:", "parse_statement", "unexpected_a", "7", 77]
+// ["ignore:", "parse_statement", "unexpected_a", "ignore", 77]
 
                 warn("unexpected_a", the_label);
             }
@@ -2123,7 +2082,7 @@ function jslint_phase3_parse(state) {
             advance();
 
 // test_cause:
-// ["aa:", "parse_statement", "unexpected_label_a", "7", 77]
+// ["aa:", "parse_statement", "unexpected_label_a", "aa", 77]
 
             warn("unexpected_label_a", the_label);
         }
@@ -2137,7 +2096,7 @@ function jslint_phase3_parse(state) {
             the_symbol !== undefined
             && the_symbol.fud !== undefined
 
-// Fixes issues #316, #317 - dynamic-import().
+// Bugfix - Fixes issues #316, #317 - dynamic-import().
 
             && !(the_symbol.id === "import" && token_nxt.id === "(")
         ) {
@@ -2155,7 +2114,7 @@ function jslint_phase3_parse(state) {
             if (the_statement.wrapped && the_statement.id !== "(") {
 
 // test_cause:
-// ["(0)", "parse_statement", "unexpected_a", "7", 77]
+// ["(0)", "parse_statement", "unexpected_a", "(", 77]
 
                 warn("unexpected_a", first);
             }
@@ -2187,11 +2146,11 @@ function jslint_phase3_parse(state) {
             case "}":
 
 // test_cause:
-// [";", "parse_statements", "closer", "7", 77]
-// ["case", "parse_statements", "closer", "7", 77]
-// ["default", "parse_statements", "closer", "7", 77]
-// ["else", "parse_statements", "closer", "7", 77]
-// ["}", "parse_statements", "closer", "7", 77]
+// [";", "parse_statements", "closer", "", 77]
+// ["case", "parse_statements", "closer", "", 77]
+// ["default", "parse_statements", "closer", "", 77]
+// ["else", "parse_statements", "closer", "", 77]
+// ["}", "parse_statements", "closer", "", 77]
 
                 test_cause("closer");
                 return statement_list;
@@ -2201,7 +2160,7 @@ function jslint_phase3_parse(state) {
             if (disrupt) {
 
 // test_cause:
-// ["while(0){break;0;}", "parse_statements", "unreachable_a", "7", 77]
+// ["while(0){break;0;}", "parse_statements", "unreachable_a", "0", 77]
 
                 warn("unreachable_a", a_statement);
             }
@@ -2209,14 +2168,16 @@ function jslint_phase3_parse(state) {
         }
     }
 
-    function warn_if_top_level(thing) {
+    function check_not_top_level(thing) {
 
 // Some features should not be at the outermost level.
 
         if (functionage === token_global) {
 
 // test_cause:
-// ["while(0){}", "warn_if_top_level", "unexpected_at_top_level_a", "7", 77]
+// ["
+// while(0){}
+// ", "check_not_top_level", "unexpected_at_top_level_a", "while", 77]
 
             warn("unexpected_at_top_level_a", thing);
         }
@@ -2259,7 +2220,7 @@ function jslint_phase3_parse(state) {
             if (!option_dict.devel && special !== "ignore") {
 
 // test_cause:
-// ["function aa(){}", "block", "empty_block", "7", 77]
+// ["function aa(){}", "block", "empty_block", "{", 77]
 
                 warn("empty_block", the_block);
             }
@@ -2271,7 +2232,7 @@ function jslint_phase3_parse(state) {
         return the_block;
     }
 
-    function mutation_check(the_thing) {
+    function check_mutation(the_thing) {
 
 // The only expressions that may be assigned to are
 //      e.b
@@ -2288,7 +2249,7 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["0=0", "mutation_check", "bad_assignment_a", "7", 77]
+// ["0=0", "check_mutation", "bad_assignment_a", "0", 77]
 
             warn("bad_assignment_a", the_thing);
             return false;
@@ -2296,7 +2257,7 @@ function jslint_phase3_parse(state) {
         return true;
     }
 
-    function left_check(left, right) {
+    function check_left(left, right) {
 
 // Warn if the left is not one of these:
 //      ?.
@@ -2312,8 +2273,8 @@ function jslint_phase3_parse(state) {
             && (
                 left.arity !== "ternary"
                 || (
-                    !left_check(left.expression[1])
-                    && !left_check(left.expression[2])
+                    !check_left(left.expression[1])
+                    && !check_left(left.expression[2])
                 )
             )
             && (
@@ -2369,7 +2330,7 @@ function jslint_phase3_parse(state) {
             ) {
                 warn("unexpected_a", right);
             }
-            mutation_check(left);
+            check_mutation(left);
             return the_token;
         };
         return the_symbol;
@@ -2423,7 +2384,7 @@ function jslint_phase3_parse(state) {
             const the_token = token_now;
 
 // test_cause:
-// ["0**0", "parse_infixr_led", "led", "7", 77]
+// ["0**0", "parse_infixr_led", "led", "", 77]
 
             test_cause("led");
             the_token.arity = "binary";
@@ -2441,7 +2402,7 @@ function jslint_phase3_parse(state) {
         the_symbol.led = function (left) {
             token_now.expression = left;
             token_now.arity = "post";
-            mutation_check(token_now.expression);
+            check_mutation(token_now.expression);
             return token_now;
         };
         return the_symbol;
@@ -2456,7 +2417,7 @@ function jslint_phase3_parse(state) {
             const the_token = token_now;
             the_token.arity = "pre";
             the_token.expression = parse_expression(150);
-            mutation_check(the_token.expression);
+            check_mutation(the_token.expression);
             return the_token;
         };
         return the_symbol;
@@ -2509,7 +2470,7 @@ function jslint_phase3_parse(state) {
         } else if (!name.identifier) {
 
 // test_cause:
-// ["let aa={0:0}", "survey", "expected_identifier_a", "7", 77]
+// ["let aa={0:0}", "survey", "expected_identifier_a", "0", 77]
 
             return stop("expected_identifier_a", name);
         }
@@ -2528,7 +2489,7 @@ function jslint_phase3_parse(state) {
                 if (tenure[id] !== true) {
 
 // test_cause:
-// ["/*property aa*/\naa.bb", "survey", "unregistered_property_a", "7", 77]
+// ["/*property aa*/\naa.bb", "survey", "unregistered_property_a", "bb", 77]
 
                     warn("unregistered_property_a", name);
                 }
@@ -2542,11 +2503,11 @@ function jslint_phase3_parse(state) {
             ) {
 
 // test_cause:
-// ["aa.$", "survey", "weird_property_a", "7", 77]
-// ["aa._", "survey", "weird_property_a", "7", 77]
-// ["aa._aa", "survey", "weird_property_a", "7", 77]
-// ["aa.aaSync", "survey", "weird_property_a", "7", 77]
-// ["aa.aa_", "survey", "weird_property_a", "7", 77]
+// ["aa.$", "survey", "weird_property_a", "$", 77]
+// ["aa._", "survey", "weird_property_a", "_", 77]
+// ["aa._aa", "survey", "weird_property_a", "_aa", 77]
+// ["aa.aaSync", "survey", "weird_property_a", "aaSync", 77]
+// ["aa.aa_", "survey", "weird_property_a", "aa_", 77]
 
                 warn("weird_property_a", name);
             }
@@ -2571,7 +2532,7 @@ function jslint_phase3_parse(state) {
             if (token_nxt.id !== ")") {
 
 // test_cause:
-// ["0?0:0", "parse_ternary_led", "use_open", "7", 77]
+// ["0?0:0", "parse_ternary_led", "use_open", "?", 77]
 
                 warn("use_open", the_token);
             }
@@ -2612,36 +2573,36 @@ function jslint_phase3_parse(state) {
     constant("(number)", "number");
     constant("(regexp)", "regexp");
     constant("(string)", "string");
-    constant("arguments", "object", function constant_arguments() {
+    constant("arguments", "object", function const_arguments() {
 
 // test_cause:
-// ["arguments", "constant_arguments", "unexpected_a", "7", 77]
+// ["arguments", "const_arguments", "unexpected_a", "arguments", 77]
 
         warn("unexpected_a", token_now);
         return token_now;
     });
-    constant("eval", "function", function constant_eval() {
+    constant("eval", "function", function const_eval() {
         if (!option_dict.eval) {
 
 // test_cause:
-// ["eval", "constant_eval", "unexpected_a", "7", 77]
+// ["eval", "const_eval", "unexpected_a", "eval", 77]
 
             warn("unexpected_a", token_now);
         } else if (token_nxt.id !== "(") {
 
 // test_cause:
-// ["/*jslint eval*/\neval", "constant_eval", "expected_a_before_b", "7", 77]
+// ["/*jslint eval*/\neval", "const_eval", "expected_a_before_b", "(end)", 77]
 
             warn("expected_a_before_b", token_nxt, "(", artifact());
         }
         return token_now;
     });
     constant("false", "boolean", false);
-    constant("Function", "function", function constant_Function() {
+    constant("Function", "function", function const_Function() {
         if (!option_dict.eval) {
 
 // test_cause:
-// ["Function", "constant_Function", "unexpected_a", "7", 77]
+// ["Function", "const_Function", "unexpected_a", "Function", 77]
 
             warn("unexpected_a", token_now);
         } else if (token_nxt.id !== "(") {
@@ -2650,44 +2611,44 @@ function jslint_phase3_parse(state) {
 // ["
 // /*jslint eval*/
 // Function
-// ", "constant_Function", "expected_a_before_b", "7", 77]
+// ", "const_Function", "expected_a_before_b", "(end)", 77]
 
             warn("expected_a_before_b", token_nxt, "(", artifact());
         }
         return token_now;
     });
-    constant("ignore", "undefined", function constant_ignore() {
+    constant("ignore", "undefined", function const_ignore() {
 
 // test_cause:
-// ["ignore", "constant_ignore", "unexpected_a", "7", 77]
+// ["ignore", "const_ignore", "unexpected_a", "ignore", 77]
 
         warn("unexpected_a", token_now);
         return token_now;
     });
     constant("Infinity", "number", Infinity);
-    constant("isFinite", "function", function constant_isInfinite() {
+    constant("isFinite", "function", function const_isInfinite() {
 
 // test_cause:
-// ["isFinite", "constant_isInfinite", "expected_a_b", "7", 77]
+// ["isFinite", "const_isInfinite", "expected_a_b", "isFinite", 77]
 
         warn("expected_a_b", token_now, "Number.isFinite", "isFinite");
         return token_now;
     });
-    constant("isNaN", "function", function constant_isNaN() {
+    constant("isNaN", "function", function const_isNaN() {
 
 // test_cause:
-// ["isNaN(0)", "constant_isNaN", "number_isNaN", "7", 77]
+// ["isNaN(0)", "const_isNaN", "number_isNaN", "isNaN", 77]
 
         warn("number_isNaN", token_now);
         return token_now;
     });
     constant("NaN", "number", NaN);
     constant("null", "null", null);
-    constant("this", "object", function constant_this() {
+    constant("this", "object", function const_this() {
         if (!option_dict.this) {
 
 // test_cause:
-// ["this", "constant_this", "unexpected_a", "7", 77]
+// ["this", "const_this", "unexpected_a", "this", 77]
 
             warn("unexpected_a", token_now);
         }
@@ -2734,17 +2695,17 @@ function jslint_phase3_parse(state) {
     infix("/", 140);
     infix("%", 140);
     infixr("**", 150);
-    infix("(", 160, function infix_left_paren(left) {
+    infix("(", 160, function infix_lparen(left) {
         const the_paren = token_now;
         let ellipsis;
         let the_argument;
         if (left.id !== "function") {
 
 // test_cause:
-// ["(0?0:0)()", "left_check", "unexpected_a", "7", 77]
-// ["0()", "left_check", "unexpected_a", "7", 77]
+// ["(0?0:0)()", "check_left", "unexpected_a", "(", 77]
+// ["0()", "check_left", "unexpected_a", "(", 77]
 
-            left_check(left, the_paren);
+            check_left(left, the_paren);
         }
         if (functionage.arity === "statement" && left.identifier) {
             functionage.name.calls[left.id] = left;
@@ -2774,14 +2735,14 @@ function jslint_phase3_parse(state) {
         if (the_paren.expression.length === 2) {
 
 // test_cause:
-// ["aa(0)", "infix_left_paren", "free", "7", 77]
+// ["aa(0)", "infix_lparen", "free", "", 77]
 
             test_cause("free");
             the_paren.free = true;
             if (the_argument.wrapped === true) {
 
 // test_cause:
-// ["aa((0))", "infix_left_paren", "unexpected_a", "7", 77]
+// ["aa((0))", "infix_lparen", "unexpected_a", "(", 77]
 
                 warn("unexpected_a", the_paren);
             }
@@ -2791,8 +2752,8 @@ function jslint_phase3_parse(state) {
         } else {
 
 // test_cause:
-// ["aa()", "infix_left_paren", "not_free", "7", 77]
-// ["aa(0,0)", "infix_left_paren", "not_free", "7", 77]
+// ["aa()", "infix_lparen", "not_free", "", 77]
+// ["aa(0,0)", "infix_lparen", "not_free", "", 77]
 
             test_cause("not_free");
             the_paren.free = false;
@@ -2825,14 +2786,14 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["\"\".aa", "left_check", "unexpected_a", "7", 77]
+// ["\"\".aa", "check_left", "unexpected_a", ".", 77]
 
-            left_check(left, the_token);
+            check_left(left, the_token);
         }
         if (!name.identifier) {
 
 // test_cause:
-// ["aa.0", "infix_dot", "expected_identifier_a", "7", 77]
+// ["aa.0", "infix_dot", "expected_identifier_a", "0", 77]
 
             stop("expected_identifier_a");
         }
@@ -2865,7 +2826,7 @@ function jslint_phase3_parse(state) {
             )
 
 // test_cause:
-// ["(0+0)?.0", "infix_option_chain", "left_check", "7", 77]
+// ["(0+0)?.0", "infix_option_chain", "check_left", "", 77]
 
             && (left.id !== "+" || name.id !== "slice")
             && (
@@ -2873,19 +2834,19 @@ function jslint_phase3_parse(state) {
                 || (name.id !== "exec" && name.id !== "test")
             )
         ) {
-            test_cause("left_check");
+            test_cause("check_left");
 
 // test_cause:
-// ["(/./)?.0", "left_check", "unexpected_a", "7", 77]
-// ["\"aa\"?.0", "left_check", "unexpected_a", "7", 77]
-// ["aa=[]?.aa", "left_check", "unexpected_a", "7", 77]
+// ["(/./)?.0", "check_left", "unexpected_a", "?.", 77]
+// ["\"aa\"?.0", "check_left", "unexpected_a", "?.", 77]
+// ["aa=[]?.aa", "check_left", "unexpected_a", "?.", 77]
 
-            left_check(left, the_token);
+            check_left(left, the_token);
         }
         if (!name.identifier) {
 
 // test_cause:
-// ["aa?.0", "infix_option_chain", "expected_identifier_a", "7", 77]
+// ["aa?.0", "infix_option_chain", "expected_identifier_a", "0", 77]
 
             stop("expected_identifier_a");
         }
@@ -2898,7 +2859,7 @@ function jslint_phase3_parse(state) {
         the_token.expression = left;
         return the_token;
     });
-    infix("[", 170, function infix_left_bracket(left) {
+    infix("[", 170, function infix_lbracket(left) {
         const the_token = token_now;
         let name;
         let the_subscript = parse_expression(0);
@@ -2907,16 +2868,16 @@ function jslint_phase3_parse(state) {
             if (rx_identifier.test(name)) {
 
 // test_cause:
-// ["aa[`aa`]", "infix_left_bracket", "subscript_a", "7", 77]
+// ["aa[`aa`]", "infix_lbracket", "subscript_a", "aa", 77]
 
                 warn("subscript_a", the_subscript, name);
             }
         }
 
 // test_cause:
-// ["0[0]", "left_check", "unexpected_a", "7", 77]
+// ["0[0]", "check_left", "unexpected_a", "[", 77]
 
-        left_check(left, the_token);
+        check_left(left, the_token);
         the_token.expression = [left, the_subscript];
         advance("]");
         return the_token;
@@ -2924,7 +2885,7 @@ function jslint_phase3_parse(state) {
     infix("=>", 170, function infix_fart_unwrapped(left) {
 
 // test_cause:
-// ["aa=>0", "infix_fart_unwrapped", "wrap_parameter", "7", 77]
+// ["aa=>0", "infix_fart_unwrapped", "wrap_parameter", "aa", 77]
 
         return stop("wrap_parameter", left);
     });
@@ -2946,7 +2907,7 @@ function jslint_phase3_parse(state) {
                 advance("${");
 
 // test_cause:
-// ["let aa=`${}`;", "parse_tick", "${", "7", 77]
+// ["let aa=`${}`;", "parse_tick", "${", "", 77]
 
                 test_cause("${");
                 the_tick.expression.push(parse_expression(0));
@@ -2961,9 +2922,9 @@ function jslint_phase3_parse(state) {
         const the_tick = parse_tick();
 
 // test_cause:
-// ["0``", "left_check", "unexpected_a", "7", 77]
+// ["0``", "check_left", "unexpected_a", "`", 77]
 
-        left_check(left, the_tick);
+        check_left(left, the_tick);
         the_tick.expression = [left].concat(the_tick.expression);
         return the_tick;
     });
@@ -2978,7 +2939,7 @@ function jslint_phase3_parse(state) {
     prefix("~");
     prefix("!");
     prefix("!!");
-    prefix("[", function prefix_left_bracket() {
+    prefix("[", function prefix_lbracket() {
         const the_token = token_now;
         let element;
         let ellipsis;
@@ -3005,7 +2966,7 @@ function jslint_phase3_parse(state) {
                 if (token_nxt.id === "]") {
 
 // test_cause:
-// ["let aa=[0,]", "prefix_left_bracket", "unexpected_a", "7", 77]
+// ["let aa=[0,]", "prefix_lbracket", "unexpected_a", ",", 77]
 
                     warn("unexpected_a", token_now);
                     break;
@@ -3018,14 +2979,14 @@ function jslint_phase3_parse(state) {
     prefix("/=", function prefix_assign_divide() {
 
 // test_cause:
-// ["/=", "prefix_assign_divide", "expected_a_b", "7", 77]
+// ["/=", "prefix_assign_divide", "expected_a_b", "/=", 77]
 
         stop("expected_a_b", token_now, "/\\=", "/=");
     });
     prefix("=>", function prefix_fart() {
 
 // test_cause:
-// ["=>0", "prefix_fart", "expected_a_before_b", "7", 77]
+// ["=>0", "prefix_fart", "expected_a_before_b", "=>", 77]
 
         return stop("expected_a_before_b", token_now, "()", "=>");
     });
@@ -3036,7 +2997,7 @@ function jslint_phase3_parse(state) {
         if (token_nxt.id !== "(") {
 
 // test_cause:
-// ["new aa", "prefix_new", "expected_a_before_b", "7", 77]
+// ["new aa", "prefix_new", "expected_a_before_b", "(end)", 77]
 
             warn("expected_a_before_b", token_nxt, "()", artifact());
         }
@@ -3048,8 +3009,8 @@ function jslint_phase3_parse(state) {
         const the_void = token_now;
 
 // test_cause:
-// ["void 0", "prefix_void", "unexpected_a", "7", 77]
-// ["void", "prefix_void", "unexpected_a", "7", 77]
+// ["void 0", "prefix_void", "unexpected_a", "void", 77]
+// ["void", "prefix_void", "unexpected_a", "void", 77]
 
         warn("unexpected_a", the_void);
         the_void.expression = parse_expression(0);
@@ -3069,7 +3030,7 @@ function jslint_phase3_parse(state) {
                     if (optional !== undefined) {
 
 // test_cause:
-// ["function aa(aa=0,{}){}", "parameter", "required_a_optional_b", "7", 77]
+// ["function aa(aa=0,{}){}", "parameter", "required_a_optional_b", "aa", 77]
 
                         warn(
                             "required_a_optional_b",
@@ -3087,8 +3048,8 @@ function jslint_phase3_parse(state) {
                         if (!subparam.identifier) {
 
 // test_cause:
-// ["function aa(aa=0,{}){}", "parameter", "expected_identifier_a", "7", 77]
-// ["function aa({0}){}", "parameter", "expected_identifier_a", "7", 77]
+// ["function aa(aa=0,{}){}", "parameter", "expected_identifier_a", "}", 77]
+// ["function aa({0}){}", "parameter", "expected_identifier_a", "0", 77]
 
                             return stop("expected_identifier_a");
                         }
@@ -3103,7 +3064,7 @@ function jslint_phase3_parse(state) {
                             if (!subparam.identifier) {
 
 // test_cause:
-// ["function aa({aa:0}){}", "parameter", "expected_identifier_a", "7", 77]
+// ["function aa({aa:0}){}", "parameter", "expected_identifier_a", "}", 77]
 
                                 return stop(
                                     "expected_identifier_a",
@@ -3113,7 +3074,7 @@ function jslint_phase3_parse(state) {
                         }
 
 // test_cause:
-// ["function aa({aa=aa},aa){}", "parameter", "equal", "7", 77]
+// ["function aa({aa=aa},aa){}", "parameter", "equal", "", 77]
 
                         test_cause("equal");
                         if (token_nxt.id === "=") {
@@ -3134,9 +3095,9 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // function aa({bb,aa}){}
-// ", "warn_if_unordered", "expected_a_b_ordered_before_c_d", "7", 77]
+// ", "check_ordered", "expected_a_b_before_c_d", "aa", 77]
 
-                    warn_if_unordered("parameter", param.names);
+                    check_ordered("parameter", param.names);
                     advance("}");
                     signature.push("}");
                     if (token_nxt.id === ",") {
@@ -3148,7 +3109,7 @@ function jslint_phase3_parse(state) {
                     if (optional !== undefined) {
 
 // test_cause:
-// ["function aa(aa=0,[]){}", "parameter", "required_a_optional_b", "7", 77]
+// ["function aa(aa=0,[]){}", "parameter", "required_a_optional_b", "aa", 77]
 
                         warn(
                             "required_a_optional_b",
@@ -3166,7 +3127,7 @@ function jslint_phase3_parse(state) {
                         if (!subparam.identifier) {
 
 // test_cause:
-// ["function aa(aa=0,[]){}", "parameter", "expected_identifier_a", "7", 77]
+// ["function aa(aa=0,[]){}", "parameter", "expected_identifier_a", "]", 77]
 
                             return stop("expected_identifier_a");
                         }
@@ -3174,7 +3135,7 @@ function jslint_phase3_parse(state) {
                         param.names.push(subparam);
 
 // test_cause:
-// ["function aa([aa=aa],aa){}", "parameter", "id", "7", 77]
+// ["function aa([aa=aa],aa){}", "parameter", "id", "", 77]
 
                         test_cause("id");
                         if (token_nxt.id === "=") {
@@ -3203,7 +3164,7 @@ function jslint_phase3_parse(state) {
                         if (optional !== undefined) {
 
 // test_cause:
-// ["function aa(aa=0,...){}", "parameter", "required_a_optional_b", "7", 77]
+// ["function aa(aa=0,...){}", "parameter", "required_a_optional_b", "aa", 77]
 
                             warn(
                                 "required_a_optional_b",
@@ -3216,7 +3177,7 @@ function jslint_phase3_parse(state) {
                     if (!token_nxt.identifier) {
 
 // test_cause:
-// ["function aa(0){}", "parameter", "expected_identifier_a", "7", 77]
+// ["function aa(0){}", "parameter", "expected_identifier_a", "0", 77]
 
                         return stop("expected_identifier_a");
                     }
@@ -3235,7 +3196,7 @@ function jslint_phase3_parse(state) {
                             if (optional !== undefined) {
 
 // test_cause:
-// ["function aa(aa=0,bb){}", "parameter", "required_a_optional_b", "7", 77]
+// ["function aa(aa=0,bb){}", "parameter", "required_a_optional_b", "aa", 77]
 
                                 warn(
                                     "required_a_optional_b",
@@ -3270,8 +3231,8 @@ function jslint_phase3_parse(state) {
                 if (!token_nxt.identifier) {
 
 // test_cause:
-// ["function(){}", "parse_function", "expected_identifier_a", "7", 77]
-// ["function*aa(){}", "parse_function", "expected_identifier_a", "7", 77]
+// ["function(){}", "parse_function", "expected_identifier_a", "(", 77]
+// ["function*aa(){}", "parse_function", "expected_identifier_a", "*", 77]
 
                     return stop("expected_identifier_a");
                 }
@@ -3280,7 +3241,7 @@ function jslint_phase3_parse(state) {
                 the_function.name = Object.assign(name, {
                     calls: empty(),
 
-// Fixes issue #272 - function hoisting not allowed.
+// Bugfix - Fixes issue #272 - function hoisting not allowed.
 
                     dead: false,
                     init: true
@@ -3314,7 +3275,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // while(0){aa.map(function(){});}
-// ", "parse_function", "function_in_loop", "7", 77]
+// ", "parse_function", "function_in_loop", "function", 77]
 
             warn("function_in_loop", the_function);
         }
@@ -3333,7 +3294,7 @@ function jslint_phase3_parse(state) {
         if (the_function.arity !== "statement" && typeof name === "object") {
 
 // test_cause:
-// ["let aa=function bb(){return;};", "parse_function", "expression", "7", 77]
+// ["let aa=function bb(){return;};", "parse_function", "expression", "", 77]
 
             test_cause("expression");
             enroll(name, "function", true);
@@ -3342,6 +3303,7 @@ function jslint_phase3_parse(state) {
             name.used = 1;
         }
 
+// Bugfix - fix function-redefinitions not warned inside function-calls.
 // Push the current function context and establish a new one.
 
         function_stack.push(functionage);
@@ -3353,7 +3315,7 @@ function jslint_phase3_parse(state) {
         advance("(");
 
 // test_cause:
-// ["function aa(){}", "parse_function", "opener", "7", 77]
+// ["function aa(){}", "parse_function", "opener", "", 77]
 
         test_cause("opener");
         token_now.free = false;
@@ -3376,7 +3338,7 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["function aa(){}0", "parse_function", "unexpected_a", "7", 77]
+// ["function aa(){}0", "parse_function", "unexpected_a", "0", 77]
 
             return stop("unexpected_a");
         }
@@ -3387,7 +3349,9 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["function aa(){}\n[]", "parse_function", "unexpected_a", "7", 77]
+// ["function aa(){}\n.aa", "parse_function", "unexpected_a", ".", 77]
+// ["function aa(){}\n?.aa", "parse_function", "unexpected_a", "?.", 77]
+// ["function aa(){}\n[]", "parse_function", "unexpected_a", "[", 77]
 
             warn("unexpected_a");
         }
@@ -3411,7 +3375,9 @@ function jslint_phase3_parse(state) {
         if (the_function.async === 1) {
 
 // test_cause:
-// ["async function aa(){}", "parse_async", "missing_await_statement", "7", 77]
+// ["
+// async function aa(){}
+// ", "parse_async", "missing_await_statement", "function", 77]
 
             warn("missing_await_statement", the_function);
         }
@@ -3423,9 +3389,9 @@ function jslint_phase3_parse(state) {
         if (functionage.async === 0) {
 
 // test_cause:
-// ["await", "parse_await", "unexpected_a", "7", 77]
-// ["function aa(){aa=await 0;}", "parse_await", "unexpected_a", "7", 77]
-// ["function aa(){await 0;}", "parse_await", "unexpected_a", "7", 77]
+// ["await", "parse_await", "unexpected_a", "await", 77]
+// ["function aa(){aa=await 0;}", "parse_await", "unexpected_a", "await", 77]
+// ["function aa(){await 0;}", "parse_await", "unexpected_a", "await", 77]
 
             warn("unexpected_a", the_await);
         } else {
@@ -3455,7 +3421,7 @@ function jslint_phase3_parse(state) {
         if (functionage.loop > 0) {
 
 // test_cause:
-// ["while(0){aa.map(()=>0);}", "parse_fart", "function_in_loop", "7", 77]
+// ["while(0){aa.map(()=>0);}", "parse_fart", "function_in_loop", "=>", 77]
 
             warn("function_in_loop", the_fart);
         }
@@ -3478,7 +3444,7 @@ function jslint_phase3_parse(state) {
         the_fart.parameters.forEach(function (name) {
 
 // test_cause:
-// ["(aa)=>{}", "parse_fart", "parameter", "7", 77]
+// ["(aa)=>{}", "parse_fart", "parameter", "", 77]
 
             test_cause("parameter");
             enroll(name, "parameter", true);
@@ -3486,7 +3452,7 @@ function jslint_phase3_parse(state) {
         if (token_nxt.id === "{") {
 
 // test_cause:
-// ["()=>{}", "parse_fart", "expected_a_b", "7", 77]
+// ["()=>{}", "parse_fart", "expected_a_b", "=>", 77]
 
             warn("expected_a_b", the_fart, "function", "=>");
             the_fart.block = block("body");
@@ -3497,7 +3463,7 @@ function jslint_phase3_parse(state) {
         return the_fart;
     }
 
-    prefix("(", function prefix_left_paren() {
+    prefix("(", function prefix_lparen() {
         const cadet = lookahead().id;
         const the_paren = token_now;
         let the_value;
@@ -3512,7 +3478,7 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["()=>0", "prefix_left_paren", "fart", "7", 77]
+// ["()=>0", "prefix_lparen", "fart", "", 77]
 
             test_cause("fart");
             the_paren.free = false;
@@ -3520,7 +3486,7 @@ function jslint_phase3_parse(state) {
         }
 
 // test_cause:
-// ["(0)", "prefix_left_paren", "expr", "7", 77]
+// ["(0)", "prefix_lparen", "expr", "", 77]
 
         test_cause("expr");
         the_paren.free = true;
@@ -3528,7 +3494,7 @@ function jslint_phase3_parse(state) {
         if (the_value.wrapped === true) {
 
 // test_cause:
-// ["((0))", "prefix_left_paren", "unexpected_a", "7", 77]
+// ["((0))", "prefix_lparen", "unexpected_a", "(", 77]
 
             warn("unexpected_a", the_paren);
         }
@@ -3539,20 +3505,20 @@ function jslint_phase3_parse(state) {
                 if (the_value.id === "{" || the_value.id === "[") {
 
 // test_cause:
-// ["([])=>0", "prefix_left_paren", "expected_a_before_b", "7", 77]
-// ["({})=>0", "prefix_left_paren", "expected_a_before_b", "7", 77]
+// ["([])=>0", "prefix_lparen", "expected_a_before_b", "(", 77]
+// ["({})=>0", "prefix_lparen", "expected_a_before_b", "(", 77]
 
                     warn("expected_a_before_b", the_paren, "function", "(");
 
 // test_cause:
-// ["([])=>0", "prefix_left_paren", "expected_a_b", "7", 77]
-// ["({})=>0", "prefix_left_paren", "expected_a_b", "7", 77]
+// ["([])=>0", "prefix_lparen", "expected_a_b", "=>", 77]
+// ["({})=>0", "prefix_lparen", "expected_a_b", "=>", 77]
 
                     return stop("expected_a_b", token_nxt, "{", "=>");
                 }
 
 // test_cause:
-// ["(0)=>0", "prefix_left_paren", "expected_identifier_a", "7", 77]
+// ["(0)=>0", "prefix_lparen", "expected_identifier_a", "0", 77]
 
                 return stop("expected_identifier_a", the_value);
             }
@@ -3562,7 +3528,7 @@ function jslint_phase3_parse(state) {
         return the_value;
     });
     prefix("`", parse_tick);
-    prefix("{", function prefix_left_brace() {
+    prefix("{", function prefix_lbrace() {
         const seen = empty();
         const the_brace = token_now;
         let extra;
@@ -3586,7 +3552,7 @@ function jslint_phase3_parse(state) {
                     if (!option_dict.getset) {
 
 // test_cause:
-// ["aa={get aa(){}}", "prefix_left_brace", "unexpected_a", "7", 77]
+// ["aa={get aa(){}}", "prefix_lbrace", "unexpected_a", "get", 77]
 
                         warn("unexpected_a", name);
                     }
@@ -3598,7 +3564,7 @@ function jslint_phase3_parse(state) {
                     if (seen[full] === true || seen[id] === true) {
 
 // test_cause:
-// ["aa={get aa(){},get aa(){}}", "prefix_left_brace", "duplicate_a", "7", 77]
+// ["aa={get aa(){},get aa(){}}", "prefix_lbrace", "duplicate_a", "aa", 77]
 
                         warn("duplicate_a", name);
                     }
@@ -3609,7 +3575,7 @@ function jslint_phase3_parse(state) {
                     if (typeof seen[id] === "boolean") {
 
 // test_cause:
-// ["aa={aa,aa}", "prefix_left_brace", "duplicate_a", "7", 77]
+// ["aa={aa,aa}", "prefix_lbrace", "duplicate_a", "aa", 77]
 
                         warn("duplicate_a", name);
                     }
@@ -3620,7 +3586,7 @@ function jslint_phase3_parse(state) {
                         if (typeof extra === "string") {
 
 // test_cause:
-// ["aa={get aa}", "prefix_left_brace", "closer", "7", 77]
+// ["aa={get aa}", "prefix_lbrace", "closer", "", 77]
 
                             test_cause("closer");
                             advance("(");
@@ -3629,8 +3595,8 @@ function jslint_phase3_parse(state) {
                     } else if (token_nxt.id === "(") {
 
 // test_cause:
-// ["aa={aa()}", "prefix_left_brace", "paren", "7", 77]
-// ["aa={get aa(){}}", "prefix_left_brace", "paren", "7", 77]
+// ["aa={aa()}", "prefix_lbrace", "paren", "", 77]
+// ["aa={get aa(){}}", "prefix_lbrace", "paren", "", 77]
 
                         test_cause("paren");
                         value = parse_function({
@@ -3649,7 +3615,7 @@ function jslint_phase3_parse(state) {
                         if (typeof extra === "string") {
 
 // test_cause:
-// ["aa={get aa.aa}", "prefix_left_brace", "paren", "7", 77]
+// ["aa={get aa.aa}", "prefix_lbrace", "paren", "", 77]
 
                             test_cause("paren");
                             advance("(");
@@ -3663,7 +3629,7 @@ function jslint_phase3_parse(state) {
                         ) {
 
 // test_cause:
-// ["aa={aa:aa}", "prefix_left_brace", "unexpected_a", "7", 77]
+// ["aa={aa:aa}", "prefix_lbrace", "unexpected_a", ": aa", 77]
 
                             warn("unexpected_a", the_colon, ": " + name.id);
                         }
@@ -3676,7 +3642,7 @@ function jslint_phase3_parse(state) {
                 } else {
 
 // test_cause:
-// ["aa={\"aa\":0}", "prefix_left_brace", "colon", "7", 77]
+// ["aa={\"aa\":0}", "prefix_lbrace", "colon", "", 77]
 
                     test_cause("colon");
                     advance(":");
@@ -3689,14 +3655,14 @@ function jslint_phase3_parse(state) {
                 }
 
 // test_cause:
-// ["aa={\"aa\":0,\"bb\":0}", "prefix_left_brace", "comma", "7", 77]
+// ["aa={\"aa\":0,\"bb\":0}", "prefix_lbrace", "comma", "", 77]
 
                 test_cause("comma");
                 advance(",");
                 if (token_nxt.id === "}") {
 
 // test_cause:
-// ["let aa={aa:0,}", "prefix_left_brace", "unexpected_a", "7", 77]
+// ["let aa={aa:0,}", "prefix_lbrace", "unexpected_a", ",", 77]
 
                     warn("unexpected_a", token_now);
                     break;
@@ -3705,11 +3671,9 @@ function jslint_phase3_parse(state) {
         }
 
 // test_cause:
-// ["
-// aa={bb,aa}
-// ", "warn_if_unordered", "expected_a_b_ordered_before_c_d", "7", 77]
+// ["aa={bb,aa}", "check_ordered", "expected_a_b_before_c_d", "aa", 77]
 
-        warn_if_unordered(
+        check_ordered(
             "property",
             the_brace.expression.map(function ({
                 label
@@ -3724,16 +3688,16 @@ function jslint_phase3_parse(state) {
     stmt(";", function stmt_semicolon() {
 
 // test_cause:
-// [";", "stmt_semicolon", "unexpected_a", "7", 77]
+// [";", "stmt_semicolon", "unexpected_a", ";", 77]
 
         warn("unexpected_a", token_now);
         return token_now;
     });
-    stmt("{", function stmt_left_brace() {
+    stmt("{", function stmt_lbrace() {
 
 // test_cause:
-// [";{}", "stmt_left_brace", "naked_block", "7", 77]
-// ["class aa{}", "stmt_left_brace", "naked_block", "7", 77]
+// [";{}", "stmt_lbrace", "naked_block", "{", 77]
+// ["class aa{}", "stmt_lbrace", "naked_block", "{", 77]
 
         warn("naked_block", token_now);
         return block("naked");
@@ -3749,7 +3713,7 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["break", "stmt_break", "unexpected_a", "7", 77]
+// ["break", "stmt_break", "unexpected_a", "break", 77]
 
             warn("unexpected_a", the_break);
         }
@@ -3764,13 +3728,13 @@ function jslint_phase3_parse(state) {
                 if (the_label !== undefined && the_label.dead) {
 
 // test_cause:
-// ["aa:{function aa(aa){break aa;}}", "stmt_break", "out_of_scope_a", "7", 77]
+// ["aa:{function aa(aa){break aa;}}", "stmt_break", "out_of_scope_a", "aa", 77]
 
                     warn("out_of_scope_a");
                 } else {
 
 // test_cause:
-// ["aa:{break aa;}", "stmt_break", "not_label_a", "7", 77]
+// ["aa:{break aa;}", "stmt_break", "not_label_a", "aa", 77]
 
                     warn("not_label_a");
                 }
@@ -3803,7 +3767,7 @@ function jslint_phase3_parse(state) {
             } else if (the_variable.id !== mode_var) {
 
 // test_cause:
-// ["let aa;var aa", "parse_var", "expected_a_b", "7", 77]
+// ["let aa;var aa", "parse_var", "expected_a_b", "var", 77]
 
                 warn("expected_a_b", the_variable, mode_var, the_variable.id);
             }
@@ -3814,7 +3778,7 @@ function jslint_phase3_parse(state) {
         if (functionage.switch > 0) {
 
 // test_cause:
-// ["switch(0){case 0:var aa}", "parse_var", "var_switch", "7", 77]
+// ["switch(0){case 0:var aa}", "parse_var", "var_switch", "var", 77]
 
             warn("var_switch", the_variable);
         }
@@ -3827,9 +3791,9 @@ function jslint_phase3_parse(state) {
         case "var":
 
 // test_cause:
-// ["const aa=0;const bb=0;", "parse_var", "declare", "7", 77]
-// ["let aa=0;let bb=0;", "parse_var", "declare", "7", 77]
-// ["var aa=0;var bb=0;", "parse_var", "declare", "7", 77]
+// ["const aa=0;const bb=0;", "parse_var", "declare", "", 77]
+// ["let aa=0;let bb=0;", "parse_var", "declare", "", 77]
+// ["var aa=0;var bb=0;", "parse_var", "declare", "", 77]
 
             test_cause("declare");
             variable_prv = functionage.last_statement;
@@ -3837,7 +3801,7 @@ function jslint_phase3_parse(state) {
         case "import":
 
 // test_cause:
-// ["import aa from \"aa\";\nlet bb=0;", "parse_var", "import", "7", 77]
+// ["import aa from \"aa\";\nlet bb=0;", "parse_var", "import", "", 77]
 
             test_cause("import");
             break;
@@ -3853,10 +3817,10 @@ function jslint_phase3_parse(state) {
 // ["
 // /*jslint beta*/
 // console.log();let aa=0;
-// ", "parse_var", "var_on_top", "7", 77]
-// ["console.log();var aa=0;", "parse_var", "var_on_top", "7", 77]
-// ["try{aa();}catch(aa){var aa=0;}", "parse_var", "var_on_top", "7", 77]
-// ["while(0){var aa;}", "parse_var", "var_on_top", "7", 77]
+// ", "parse_var", "var_on_top", "let", 77]
+// ["console.log();var aa=0;", "parse_var", "var_on_top", "var", 77]
+// ["try{aa();}catch(aa){var aa=0;}", "parse_var", "var_on_top", "var", 77]
+// ["while(0){var aa;}", "parse_var", "var_on_top", "var", 77]
 
                 warn("var_on_top", token_now);
             }
@@ -3866,7 +3830,7 @@ function jslint_phase3_parse(state) {
                 if (the_variable.id === "var") {
 
 // test_cause:
-// ["var{aa}=0", "parse_var", "unexpected_a", "7", 77]
+// ["var{aa}=0", "parse_var", "unexpected_a", "var", 77]
 
                     warn("unexpected_a", the_variable);
                 }
@@ -3877,7 +3841,7 @@ function jslint_phase3_parse(state) {
                     if (!name.identifier) {
 
 // test_cause:
-// ["let {0}", "parse_var", "expected_identifier_a", "7", 77]
+// ["let {0}", "parse_var", "expected_identifier_a", "0", 77]
 
                         return stop("expected_identifier_a");
                     }
@@ -3888,8 +3852,8 @@ function jslint_phase3_parse(state) {
                         if (!token_nxt.identifier) {
 
 // test_cause:
-// ["let {aa:0}", "parse_var", "expected_identifier_a", "7", 77]
-// ["let {aa:{aa}}", "parse_var", "expected_identifier_a", "7", 77]
+// ["let {aa:0}", "parse_var", "expected_identifier_a", "0", 77]
+// ["let {aa:{aa}}", "parse_var", "expected_identifier_a", "{", 77]
 
                             return stop("expected_identifier_a");
                         }
@@ -3907,7 +3871,7 @@ function jslint_phase3_parse(state) {
                     if (token_nxt.id === "=") {
 
 // test_cause:
-// ["let {aa=0}", "parse_var", "assign", "7", 77]
+// ["let {aa=0}", "parse_var", "assign", "", 77]
 
                         test_cause("assign");
                         advance("=");
@@ -3921,11 +3885,9 @@ function jslint_phase3_parse(state) {
                 }
 
 // test_cause:
-// ["
-// let{bb,aa}
-// ", "warn_if_unordered", "expected_a_b_ordered_before_c_d", "7", 77]
+// ["let{bb,aa}", "check_ordered", "expected_a_b_before_c_d", "aa", 77]
 
-                warn_if_unordered(the_variable.id, the_variable.names);
+                check_ordered(the_variable.id, the_variable.names);
                 advance("}");
                 advance("=");
                 the_variable.expression = parse_expression(0);
@@ -3933,7 +3895,7 @@ function jslint_phase3_parse(state) {
                 if (the_variable.id === "var") {
 
 // test_cause:
-// ["var[aa]=0", "parse_var", "unexpected_a", "7", 77]
+// ["var[aa]=0", "parse_var", "unexpected_a", "var", 77]
 
                     warn("unexpected_a", the_variable);
                 }
@@ -3948,7 +3910,7 @@ function jslint_phase3_parse(state) {
                     if (!token_nxt.identifier) {
 
 // test_cause:
-// ["let[]", "parse_var", "expected_identifier_a", "7", 77]
+// ["let[]", "parse_var", "expected_identifier_a", "]", 77]
 
                         return stop("expected_identifier_a");
                     }
@@ -3981,7 +3943,9 @@ function jslint_phase3_parse(state) {
                 if (name.id === "ignore") {
 
 // test_cause:
-// ["let ignore;function aa(ignore) {}", "parse_var", "unexpected_a", "7", 77]
+// ["
+// let ignore;function aa(ignore) {}
+// ", "parse_var", "unexpected_a", "ignore", 77]
 
                     warn("unexpected_a", name);
                 }
@@ -3996,8 +3960,8 @@ function jslint_phase3_parse(state) {
             } else {
 
 // test_cause:
-// ["let 0", "parse_var", "expected_identifier_a", "7", 77]
-// ["var{aa:{aa}}", "parse_var", "expected_identifier_a", "7", 77]
+// ["let 0", "parse_var", "expected_identifier_a", "0", 77]
+// ["var{aa:{aa}}", "parse_var", "expected_identifier_a", "{", 77]
 
                 return stop("expected_identifier_a");
             }
@@ -4006,7 +3970,7 @@ function jslint_phase3_parse(state) {
             }
 
 // test_cause:
-// ["let aa,bb;", "parse_var", "expected_a_b", "7", 77]
+// ["let aa,bb;", "parse_var", "expected_a_b", ",", 77]
 
             warn("expected_a_b", token_nxt, ";", ",");
             advance(",");
@@ -4029,18 +3993,18 @@ function jslint_phase3_parse(state) {
 // ["
 // /*jslint beta*/
 // const bb=0;const aa=0;
-// ", "parse_var", "expected_a_b_ordered_before_c_d", "7", 77]
+// ", "parse_var", "expected_a_b_before_c_d", "aa", 77]
 // ["
 // /*jslint beta*/
 // let bb;let aa;
-// ", "parse_var", "expected_a_b_ordered_before_c_d", "7", 77]
+// ", "parse_var", "expected_a_b_before_c_d", "aa", 77]
 // ["
 // /*jslint beta*/
 // var bb;var aa;
-// ", "parse_var", "expected_a_b_ordered_before_c_d", "7", 77]
+// ", "parse_var", "expected_a_b_before_c_d", "aa", 77]
 
             warn(
-                "expected_a_b_ordered_before_c_d",
+                "expected_a_b_before_c_d",
                 the_variable,
                 the_variable.id,
                 the_variable.names[0].id,
@@ -4058,14 +4022,14 @@ function jslint_phase3_parse(state) {
         if (functionage.loop < 1 || functionage.finally > 0) {
 
 // test_cause:
-// ["continue", "parse_continue", "unexpected_a", "7", 77]
+// ["continue", "parse_continue", "unexpected_a", "continue", 77]
 // ["
 // function aa(){while(0){try{}finally{continue}}}
-// ", "parse_continue", "unexpected_a", "7", 77]
+// ", "parse_continue", "unexpected_a", "continue", 77]
 
             warn("unexpected_a", the_continue);
         }
-        warn_if_top_level(the_continue);
+        check_not_top_level(the_continue);
         the_continue.disrupt = true;
         warn("unexpected_a", the_continue);
         advance(";");
@@ -4076,7 +4040,7 @@ function jslint_phase3_parse(state) {
         if (!option_dict.devel) {
 
 // test_cause:
-// ["debugger", "stmt_debugger", "unexpected_a", "7", 77]
+// ["debugger", "stmt_debugger", "unexpected_a", "debugger", 77]
 
             warn("unexpected_a", the_debug);
         }
@@ -4092,7 +4056,7 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["delete 0", "stmt_delete", "expected_a_b", "7", 77]
+// ["delete 0", "stmt_delete", "expected_a_b", "0", 77]
 
             stop("expected_a_b", the_value, ".", artifact(the_value));
         }
@@ -4102,7 +4066,7 @@ function jslint_phase3_parse(state) {
     });
     stmt("do", function stmt_do() {
         const the_do = token_now;
-        warn_if_top_level(the_do);
+        check_not_top_level(the_do);
         functionage.loop += 1;
         the_do.block = block();
         advance("while");
@@ -4111,7 +4075,7 @@ function jslint_phase3_parse(state) {
         if (the_do.block.disrupt === true) {
 
 // test_cause:
-// ["function aa(){do{break;}while(0)}", "stmt_do", "weird_loop", "7", 77]
+// ["function aa(){do{break;}while(0)}", "stmt_do", "weird_loop", "do", 77]
 
             warn("weird_loop", the_do);
         }
@@ -4129,7 +4093,9 @@ function jslint_phase3_parse(state) {
             if (export_dict.default !== undefined) {
 
 // test_cause:
-// ["export default 0;export default 0", "stmt_export", "duplicate_a", "7", 77]
+// ["
+// export default 0;export default 0
+// ", "stmt_export", "duplicate_a", "default", 77]
 
                 warn("duplicate_a");
             }
@@ -4143,16 +4109,18 @@ function jslint_phase3_parse(state) {
             ) {
 
 // test_cause:
-// ["export default {}", "stmt_export", "freeze_exports", "7", 77]
+// ["export default {}", "stmt_export", "freeze_exports", "{", 77]
 
                 warn("freeze_exports", the_thing);
 
-// Fixes issues #282 - optional-semicolon.
+// Bugfix - Fixes issues #282 - optional-semicolon.
 
             } else {
 
 // test_cause:
-// ["export default Object.freeze({})", "semicolon", "expected_a_b", "7", 77]
+// ["
+// export default Object.freeze({})
+// ", "semicolon", "expected_a_b", "(end)", 77]
 
                 semicolon();
             }
@@ -4162,7 +4130,7 @@ function jslint_phase3_parse(state) {
             if (token_nxt.id === "function") {
 
 // test_cause:
-// ["export function aa(){}", "stmt_export", "freeze_exports", "7", 77]
+// ["export function aa(){}", "stmt_export", "freeze_exports", "function", 77]
 
                 warn("freeze_exports");
                 the_thing = parse_statement();
@@ -4174,7 +4142,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // let aa;export{aa};export function aa(){}
-// ", "stmt_export", "duplicate_a", "7", 77]
+// ", "stmt_export", "duplicate_a", "aa", 77]
 
                     warn("duplicate_a", the_name);
                 }
@@ -4189,16 +4157,16 @@ function jslint_phase3_parse(state) {
             ) {
 
 // test_cause:
-// ["export const", "stmt_export", "unexpected_a", "7", 77]
-// ["export let", "stmt_export", "unexpected_a", "7", 77]
-// ["export var", "stmt_export", "unexpected_a", "7", 77]
+// ["export const", "stmt_export", "unexpected_a", "const", 77]
+// ["export let", "stmt_export", "unexpected_a", "let", 77]
+// ["export var", "stmt_export", "unexpected_a", "var", 77]
 
                 warn("unexpected_a");
                 parse_statement();
             } else if (token_nxt.id === "{") {
 
 // test_cause:
-// ["export {}", "stmt_export", "advance{", "7", 77]
+// ["export {}", "stmt_export", "advance{", "", 77]
 
                 test_cause("advance{");
                 advance("{");
@@ -4206,7 +4174,7 @@ function jslint_phase3_parse(state) {
                     if (!token_nxt.identifier) {
 
 // test_cause:
-// ["export {}", "stmt_export", "expected_identifier_a", "7", 77]
+// ["export {}", "stmt_export", "expected_identifier_a", "}", 77]
 
                         stop("expected_identifier_a");
                     }
@@ -4215,7 +4183,7 @@ function jslint_phase3_parse(state) {
                     if (the_name === undefined) {
 
 // test_cause:
-// ["export {aa}", "stmt_export", "unexpected_a", "7", 77]
+// ["export {aa}", "stmt_export", "unexpected_a", "aa", 77]
 
                         warn("unexpected_a");
                     } else {
@@ -4223,7 +4191,7 @@ function jslint_phase3_parse(state) {
                         if (export_dict[the_id] !== undefined) {
 
 // test_cause:
-// ["let aa;export{aa,aa}", "stmt_export", "duplicate_a", "7", 77]
+// ["let aa;export{aa,aa}", "stmt_export", "duplicate_a", "aa", 77]
 
                             warn("duplicate_a");
                         }
@@ -4242,7 +4210,7 @@ function jslint_phase3_parse(state) {
             } else {
 
 // test_cause:
-// ["export", "stmt_export", "unexpected_a", "7", 77]
+// ["export", "stmt_export", "unexpected_a", "(end)", 77]
 
                 stop("unexpected_a");
             }
@@ -4256,18 +4224,18 @@ function jslint_phase3_parse(state) {
         if (!option_dict.for) {
 
 // test_cause:
-// ["for", "stmt_for", "unexpected_a", "7", 77]
+// ["for", "stmt_for", "unexpected_a", "for", 77]
 
             warn("unexpected_a", the_for);
         }
-        warn_if_top_level(the_for);
+        check_not_top_level(the_for);
         functionage.loop += 1;
         advance("(");
         token_now.free = true;
         if (token_nxt.id === ";") {
 
 // test_cause:
-// ["for(;;){}", "stmt_for", "expected_a_b", "7", 77]
+// ["for(;;){}", "stmt_for", "expected_a_b", "for (;", 77]
 
             return stop("expected_a_b", the_for, "while (", "for (;");
         }
@@ -4278,7 +4246,7 @@ function jslint_phase3_parse(state) {
         ) {
 
 // test_cause:
-// ["for(const aa in aa){}", "stmt_for", "unexpected_a", "7", 77]
+// ["for(const aa in aa){}", "stmt_for", "unexpected_a", "const", 77]
 
             return stop("unexpected_a");
         }
@@ -4287,7 +4255,7 @@ function jslint_phase3_parse(state) {
             if (first.expression[0].arity !== "variable") {
 
 // test_cause:
-// ["for(0 in aa){}", "stmt_for", "bad_assignment_a", "7", 77]
+// ["for(0 in aa){}", "stmt_for", "bad_assignment_a", "0", 77]
 
                 warn("bad_assignment_a", first.expression[0]);
             }
@@ -4303,7 +4271,7 @@ function jslint_phase3_parse(state) {
             if (the_for.inc.id === "++") {
 
 // test_cause:
-// ["for(aa;aa;aa++){}", "stmt_for", "expected_a_b", "7", 77]
+// ["for(aa;aa;aa++){}", "stmt_for", "expected_a_b", "++", 77]
 
                 warn("expected_a_b", the_for.inc, "+= 1", "++");
             }
@@ -4316,7 +4284,7 @@ function jslint_phase3_parse(state) {
 // ["
 // /*jslint for*/
 // function aa(bb,cc){for(0;0;0){break;}}
-// ", "stmt_for", "weird_loop", "7", 77]
+// ", "stmt_for", "weird_loop", "for", 77]
 
             warn("weird_loop", the_for);
         }
@@ -4339,22 +4307,22 @@ function jslint_phase3_parse(state) {
             );
 
 // test_cause:
-// ["if(0){0}else if(0){0}", "stmt_if", "else", "7", 77]
-// ["if(0){0}else{0}", "stmt_if", "else", "7", 77]
+// ["if(0){0}else if(0){0}", "stmt_if", "else", "", 77]
+// ["if(0){0}else{0}", "stmt_if", "else", "", 77]
 
             test_cause("else");
             if (the_if.block.disrupt === true) {
                 if (the_if.else.disrupt === true) {
 
 // test_cause:
-// ["if(0){break;}else{break;}", "stmt_if", "disrupt", "7", 77]
+// ["if(0){break;}else{break;}", "stmt_if", "disrupt", "", 77]
 
                     test_cause("disrupt");
                     the_if.disrupt = true;
                 } else {
 
 // test_cause:
-// ["if(0){break;}else{}", "stmt_if", "unexpected_a", "7", 77]
+// ["if(0){break;}else{}", "stmt_if", "unexpected_a", "else", 77]
 
                     warn("unexpected_a", the_else);
                 }
@@ -4372,7 +4340,7 @@ function jslint_phase3_parse(state) {
 // ["
 // /*global aa*/
 // import aa from "aa"
-// ", "stmt_import", "unexpected_directive_a", "7", 77]
+// ", "stmt_import", "unexpected_directive_a", "global", 77]
 
             warn(
                 "unexpected_directive_a",
@@ -4387,7 +4355,7 @@ function jslint_phase3_parse(state) {
             if (name.id === "ignore") {
 
 // test_cause:
-// ["import ignore from \"aa\"", "stmt_import", "unexpected_a", "7", 77]
+// ["import ignore from \"aa\"", "stmt_import", "unexpected_a", "ignore", 77]
 
                 warn("unexpected_a", name);
             }
@@ -4401,7 +4369,7 @@ function jslint_phase3_parse(state) {
                     if (!token_nxt.identifier) {
 
 // test_cause:
-// ["import {", "stmt_import", "expected_identifier_a", "7", 77]
+// ["import {", "stmt_import", "expected_identifier_a", "(end)", 77]
 
                         stop("expected_identifier_a");
                     }
@@ -4410,7 +4378,7 @@ function jslint_phase3_parse(state) {
                     if (name.id === "ignore") {
 
 // test_cause:
-// ["import {ignore} from \"aa\"", "stmt_import", "unexpected_a", "7", 77]
+// ["import {ignore} from \"aa\"", "stmt_import", "unexpected_a", "ignore", 77]
 
                         warn("unexpected_a", name);
                     }
@@ -4434,7 +4402,7 @@ function jslint_phase3_parse(state) {
         ).test(token_now.value)) {
 
 // test_cause:
-// ["import aa from \"!aa\"", "stmt_import", "bad_module_name_a", "7", 77]
+// ["import aa from \"!aa\"", "stmt_import", "bad_module_name_a", "!aa", 77]
 
             warn("bad_module_name_a", token_now);
         }
@@ -4445,13 +4413,13 @@ function jslint_phase3_parse(state) {
     stmt("let", parse_var);
     stmt("return", function stmt_return() {
         const the_return = token_now;
-        warn_if_top_level(the_return);
+        check_not_top_level(the_return);
         if (functionage.finally > 0) {
 
 // test_cause:
 // ["
 // function aa(){try{}finally{return;}}
-// ", "stmt_return", "unexpected_a", "7", 77]
+// ", "stmt_return", "unexpected_a", "return", 77]
 
             warn("unexpected_a", the_return);
         }
@@ -4476,13 +4444,13 @@ function jslint_phase3_parse(state) {
         function is_dup(thing) {
             return is_equal(thing, exp);
         }
-        warn_if_top_level(the_switch);
+        check_not_top_level(the_switch);
         if (functionage.finally > 0) {
 
 // test_cause:
 // ["
 // function aa(){try{}finally{switch(0){}}}
-// ", "stmt_switch", "unexpected_a", "7", 77]
+// ", "stmt_switch", "unexpected_a", "switch", 77]
 
             warn("unexpected_a", the_switch);
         }
@@ -4512,7 +4480,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // switch(0){case 0:break;case 0:break}
-// ", "stmt_switch", "unexpected_a", "7", 77]
+// ", "stmt_switch", "unexpected_a", "0", 77]
 
                     warn("unexpected_a", exp);
                 }
@@ -4525,18 +4493,28 @@ function jslint_phase3_parse(state) {
             }
 
 // test_cause:
-// ["switch(0){case 1:case 0:break;}", "warn_if_unordered_case_statement", "expected_a_b_ordered_before_c_d", "7", 77] //jslint-quiet
-// ["switch(0){case \"aa\":case 0:break;}", "warn_if_unordered_case_statement", "expected_a_b_ordered_before_c_d", "7", 77] //jslint-quiet
-// ["switch(0){case \"bb\":case \"aa\":break;}", "warn_if_unordered_case_statement", "expected_a_b_ordered_before_c_d", "7", 77] //jslint-quiet
-// ["switch(0){case aa:case \"aa\":break;}", "warn_if_unordered_case_statement", "expected_a_b_ordered_before_c_d", "7", 77] //jslint-quiet
-// ["switch(0){case bb:case aa:break;}", "warn_if_unordered_case_statement", "expected_a_b_ordered_before_c_d", "7", 77] //jslint-quiet
+// ["
+// switch(0){case 1:case 0:break;}
+// ", "check_ordered_case", "expected_a_b_before_c_d", "case-number", 77]
+// ["
+// switch(0){case "aa":case 0:break;}
+// ", "check_ordered_case", "expected_a_b_before_c_d", "case-number", 77]
+// ["
+// switch(0){case "bb":case "aa":break;}
+// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 77]
+// ["
+// switch(0){case aa:case "aa":break;}
+// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 77]
+// ["
+// switch(0){case bb:case aa:break;}
+// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 77]
 
-            warn_if_unordered_case_statement(the_case.expression);
+            check_ordered_case(the_case.expression);
             stmts = parse_statements();
             if (stmts.length < 1) {
 
 // test_cause:
-// ["switch(0){case 0:}", "stmt_switch", "expected_statements_a", "7", 77]
+// ["switch(0){case 0:}", "stmt_switch", "expected_statements_a", "}", 77]
 
                 warn("expected_statements_a");
                 return;
@@ -4557,13 +4535,23 @@ function jslint_phase3_parse(state) {
         }
 
 // test_cause:
-// ["switch(0){case 1:break;case 0:break;}", "warn_if_unordered_case_statement", "expected_a_b_ordered_before_c_d", "7", 77] //jslint-quiet
-// ["switch(0){case \"aa\":break;case 0:break;}", "warn_if_unordered_case_statement", "expected_a_b_ordered_before_c_d", "7", 77] //jslint-quiet
-// ["switch(0){case \"bb\":break;case \"aa\":break;}", "warn_if_unordered_case_statement", "expected_a_b_ordered_before_c_d", "7", 77] //jslint-quiet
-// ["switch(0){case aa:break;case \"aa\":break;}", "warn_if_unordered_case_statement", "expected_a_b_ordered_before_c_d", "7", 77] //jslint-quiet
-// ["switch(0){case bb:break;case aa:break;}", "warn_if_unordered_case_statement", "expected_a_b_ordered_before_c_d", "7", 77] //jslint-quiet
+// ["
+// switch(0){case 1:break;case 0:break;}
+// ", "check_ordered_case", "expected_a_b_before_c_d", "case-number", 77]
+// ["
+// switch(0){case "aa":break;case 0:break;}
+// ", "check_ordered_case", "expected_a_b_before_c_d", "case-number", 77]
+// ["
+// switch(0){case "bb":break;case "aa":break;}
+// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 77]
+// ["
+// switch(0){case aa:break;case "aa":break;}
+// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 77]
+// ["
+// switch(0){case bb:break;case aa:break;}
+// ", "check_ordered_case", "expected_a_b_before_c_d", "aa", 77]
 
-        warn_if_unordered_case_statement(the_cases.map(function ({
+        check_ordered_case(the_cases.map(function ({
             expression
         }) {
             return expression[0];
@@ -4578,7 +4566,9 @@ function jslint_phase3_parse(state) {
             if (the_switch.else.length < 1) {
 
 // test_cause:
-// ["switch(0){case 0:break;default:}", "stmt_switch", "unexpected_a", "7", 77]
+// ["
+// switch(0){case 0:break;default:}
+// ", "stmt_switch", "unexpected_a", "default", 77]
 
                 warn("unexpected_a", the_default);
                 the_disrupt = false;
@@ -4594,7 +4584,7 @@ function jslint_phase3_parse(state) {
 // test_cause:
 // ["
 // switch(0){case 0:break;default:break;}
-// ", "stmt_switch", "unexpected_a", "7", 77]
+// ", "stmt_switch", "unexpected_a", "break", 77]
 
                     warn("unexpected_a", the_last);
                     the_last.disrupt = false;
@@ -4617,7 +4607,7 @@ function jslint_phase3_parse(state) {
         if (functionage.try > 0) {
 
 // test_cause:
-// ["try{throw 0}catch(){}", "stmt_throw", "unexpected_a", "7", 77]
+// ["try{throw 0}catch(){}", "stmt_throw", "unexpected_a", "throw", 77]
 
             warn("unexpected_a", the_throw);
         }
@@ -4631,7 +4621,7 @@ function jslint_phase3_parse(state) {
         if (functionage.try > 0) {
 
 // test_cause:
-// ["try{try{}catch(){}}catch(){}", "stmt_try", "unexpected_a", "7", 77]
+// ["try{try{}catch(){}}catch(){}", "stmt_try", "unexpected_a", "try", 77]
 
             warn("unexpected_a", the_try);
         }
@@ -4655,7 +4645,7 @@ function jslint_phase3_parse(state) {
                 if (!token_nxt.identifier) {
 
 // test_cause:
-// ["try{}catch(){}", "stmt_try", "expected_identifier_a", "7", 77]
+// ["try{}catch(){}", "stmt_try", "expected_identifier_a", ")", 77]
 
                     return stop("expected_identifier_a");
                 }
@@ -4678,7 +4668,7 @@ function jslint_phase3_parse(state) {
         } else {
 
 // test_cause:
-// ["try{}finally{break;}", "stmt_try", "expected_a_before_b", "7", 77]
+// ["try{}finally{break;}", "stmt_try", "expected_a_before_b", "finally", 77]
 
             warn("expected_a_before_b", token_nxt, "catch", artifact());
 
@@ -4697,14 +4687,14 @@ function jslint_phase3_parse(state) {
     stmt("var", parse_var);
     stmt("while", function stmt_while() {
         const the_while = token_now;
-        warn_if_top_level(the_while);
+        check_not_top_level(the_while);
         functionage.loop += 1;
         the_while.expression = condition();
         the_while.block = block();
         if (the_while.block.disrupt === true) {
 
 // test_cause:
-// ["function aa(){while(0){break;}}", "stmt_while", "weird_loop", "7", 77]
+// ["function aa(){while(0){break;}}", "stmt_while", "weird_loop", "while", 77]
 
             warn("weird_loop", the_while);
         }
@@ -4714,7 +4704,7 @@ function jslint_phase3_parse(state) {
     stmt("with", function stmt_with() {
 
 // test_cause:
-// ["with", "stmt_with", "unexpected_a", "7", 77]
+// ["with", "stmt_with", "unexpected_a", "with", 77]
 
         stop("unexpected_a", token_now);
     });
@@ -4735,7 +4725,7 @@ function jslint_phase3_parse(state) {
             if (!rx_json_number.test(token_nxt.value)) {
 
 // test_cause:
-// ["[0x0]", "parse_json", "unexpected_a", "7", 77]
+// ["[0x0]", "parse_json", "unexpected_a", "0x0", 77]
 
                 warn("unexpected_a");
             }
@@ -4745,7 +4735,7 @@ function jslint_phase3_parse(state) {
             if (token_nxt.quote !== "\"") {
 
 // test_cause:
-// ["['']", "parse_json", "unexpected_a", "7", 77]
+// ["['']", "parse_json", "unexpected_a", "'", 77]
 
                 warn("unexpected_a", token_nxt, token_nxt.quote);
             }
@@ -4759,7 +4749,7 @@ function jslint_phase3_parse(state) {
             if (!rx_json_number.test(token_now.value)) {
 
 // test_cause:
-// ["[-0x0]", "parse_json", "unexpected_a", "7", 77]
+// ["[-0x0]", "parse_json", "unexpected_a", "0x0", 77]
 
                 warn("unexpected_a", token_now);
             }
@@ -4768,7 +4758,7 @@ function jslint_phase3_parse(state) {
         case "[":
 
 // test_cause:
-// ["[]", "parse_json", "bracket", "7", 77]
+// ["[]", "parse_json", "bracket", "", 77]
 
             test_cause("bracket");
             container = token_nxt;
@@ -4783,7 +4773,7 @@ function jslint_phase3_parse(state) {
                     if (token_nxt.id !== ",") {
 
 // test_cause:
-// ["[0,0]", "parse_json", "comma", "7", 77]
+// ["[0,0]", "parse_json", "comma", "", 77]
 
                         test_cause("comma");
                         break;
@@ -4798,9 +4788,9 @@ function jslint_phase3_parse(state) {
         case "true":
 
 // test_cause:
-// ["[false]", "parse_json", "advance", "7", 77]
-// ["[null]", "parse_json", "advance", "7", 77]
-// ["[true]", "parse_json", "advance", "7", 77]
+// ["[false]", "parse_json", "advance", "", 77]
+// ["[null]", "parse_json", "advance", "", 77]
+// ["[true]", "parse_json", "advance", "", 77]
 
             test_cause("advance");
             advance();
@@ -4808,7 +4798,7 @@ function jslint_phase3_parse(state) {
         case "{":
 
 // test_cause:
-// ["{}", "parse_json", "brace", "7", 77]
+// ["{}", "parse_json", "brace", "", 77]
 
             test_cause("brace");
             container = token_nxt;
@@ -4827,7 +4817,7 @@ function jslint_phase3_parse(state) {
                     if (token_nxt.quote !== "\"") {
 
 // test_cause:
-// ["{0:0}", "parse_json", "unexpected_a", "7", 77]
+// ["{0:0}", "parse_json", "unexpected_a", "0", 77]
 
                         warn(
                             "unexpected_a",
@@ -4840,13 +4830,13 @@ function jslint_phase3_parse(state) {
                     if (is_dup[token_now.value] !== undefined) {
 
 // test_cause:
-// ["{\"aa\":0,\"aa\":0}", "parse_json", "duplicate_a", "7", 77]
+// ["{\"aa\":0,\"aa\":0}", "parse_json", "duplicate_a", "aa", 77]
 
                         warn("duplicate_a", token_now);
                     } else if (token_now.value === "__proto__") {
 
 // test_cause:
-// ["{\"__proto__\":0}", "parse_json", "weird_property_a", "7", 77]
+// ["{\"__proto__\":0}", "parse_json", "weird_property_a", "__proto__", 77]
 
                         warn("weird_property_a", token_now);
                     } else {
@@ -4872,7 +4862,7 @@ function jslint_phase3_parse(state) {
         default:
 
 // test_cause:
-// ["[undefined]", "parse_json", "unexpected_a", "7", 77]
+// ["[undefined]", "parse_json", "unexpected_a", "undefined", 77]
 
             stop("unexpected_a");
         }
@@ -5020,7 +5010,7 @@ function jslint_phase4_walk(state) {
         };
     }
 
-    function warn_if_not_top_level(the_thing) {
+    function check_top_level(the_thing) {
 
 // Some features must be at the most outermost level.
 
@@ -5029,7 +5019,7 @@ function jslint_phase4_walk(state) {
 // test_cause:
 // ["
 // if(0){import aa from "aa";}
-// ", "warn_if_not_top_level", "misplaced_a", "7", 77]
+// ", "check_top_level", "misplaced_a", "import", 77]
 
             warn("misplaced_a", the_thing);
         }
@@ -5040,8 +5030,8 @@ function jslint_phase4_walk(state) {
             if (Array.isArray(thing)) {
 
 // test_cause:
-// ["(function(){}())", "walk_expression", "isArray", "7", 77]
-// ["0&&0", "walk_expression", "isArray", "7", 77]
+// ["(function(){}())", "walk_expression", "isArray", "", 77]
+// ["0&&0", "walk_expression", "isArray", "", 77]
 
                 test_cause("isArray");
                 thing.forEach(walk_expression);
@@ -5051,7 +5041,7 @@ function jslint_phase4_walk(state) {
                 if (thing.id === "function") {
 
 // test_cause:
-// ["aa=function(){}", "walk_expression", "function", "7", 77]
+// ["aa=function(){}", "walk_expression", "function", "", 77]
 
                     test_cause("function");
                     walk_statement(thing.block);
@@ -5059,8 +5049,8 @@ function jslint_phase4_walk(state) {
                 if (thing.arity === "pre" || thing.arity === "post") {
 
 // test_cause:
-// ["aa=++aa", "walk_expression", "unexpected_a", "7", 77]
-// ["aa=--aa", "walk_expression", "unexpected_a", "7", 77]
+// ["aa=++aa", "walk_expression", "unexpected_a", "++", 77]
+// ["aa=--aa", "walk_expression", "unexpected_a", "--", 77]
 
                     warn("unexpected_a", thing);
                 } else if (
@@ -5069,13 +5059,13 @@ function jslint_phase4_walk(state) {
                 ) {
 
 // test_cause:
-// ["aa[aa=0]", "walk_expression", "unexpected_statement_a", "7", 77]
+// ["aa[aa=0]", "walk_expression", "unexpected_statement_a", "=", 77]
 
                     warn("unexpected_statement_a", thing);
                 }
 
 // test_cause:
-// ["aa=0", "walk_expression", "default", "7", 77]
+// ["aa=0", "walk_expression", "default", "", 77]
 
                 test_cause("default");
                 postamble(thing);
@@ -5088,7 +5078,7 @@ function jslint_phase4_walk(state) {
             if (Array.isArray(thing)) {
 
 // test_cause:
-// ["+[]", "walk_statement", "isArray", "7", 77]
+// ["+[]", "walk_statement", "isArray", "", 77]
 
                 test_cause("isArray");
                 thing.forEach(walk_statement);
@@ -5099,7 +5089,7 @@ function jslint_phase4_walk(state) {
                     if (thing.id !== "(") {
 
 // test_cause:
-// ["0&&0", "walk_statement", "unexpected_expression_a", "7", 77]
+// ["0&&0", "walk_statement", "unexpected_expression_a", "&&", 77]
 
                         warn("unexpected_expression_a", thing);
                     }
@@ -5110,14 +5100,14 @@ function jslint_phase4_walk(state) {
                 ) {
 
 // test_cause:
-// ["!0", "walk_statement", "unexpected_expression_a", "7", 77]
-// ["+[]", "walk_statement", "unexpected_expression_a", "7", 77]
-// ["+new aa()", "walk_statement", "unexpected_expression_a", "7", 77]
-// ["0", "walk_statement", "unexpected_expression_a", "7", 77]
+// ["!0", "walk_statement", "unexpected_expression_a", "!", 77]
+// ["+[]", "walk_statement", "unexpected_expression_a", "+", 77]
+// ["+new aa()", "walk_statement", "unexpected_expression_a", "+", 77]
+// ["0", "walk_statement", "unexpected_expression_a", "0", 77]
 // ["
 // async function aa(){await 0;}
-// ", "walk_statement", "unexpected_expression_a", "7", 77]
-// ["typeof 0", "walk_statement", "unexpected_expression_a", "7", 77]
+// ", "walk_statement", "unexpected_expression_a", "0", 77]
+// ["typeof 0", "walk_statement", "unexpected_expression_a", "typeof", 77]
 
                     warn("unexpected_expression_a", thing);
                 }
@@ -5159,14 +5149,14 @@ function jslint_phase4_walk(state) {
                     if (global_dict[thing.id] === undefined) {
 
 // test_cause:
-// ["aa", "lookup", "undeclared_a", "7", 77]
-// ["class aa{}", "lookup", "undeclared_a", "7", 77]
+// ["aa", "lookup", "undeclared_a", "aa", 77]
+// ["class aa{}", "lookup", "undeclared_a", "aa", 77]
 // ["
 // let aa=0;try{aa();}catch(bb){bb();}bb();
-// ", "lookup", "undeclared_a", "7", 77]
+// ", "lookup", "undeclared_a", "bb", 77]
 // ["
 // let aa=0;try{aa();}catch(ignore){bb();}
-// ", "lookup", "undeclared_a", "7", 77]
+// ", "lookup", "undeclared_a", "bb", 77]
 
                         warn("undeclared_a", thing);
                         return;
@@ -5187,7 +5177,7 @@ function jslint_phase4_walk(state) {
             } else if (the_variable.role === "label") {
 
 // test_cause:
-// ["aa:while(0){aa;}", "lookup", "label_a", "7", 77]
+// ["aa:while(0){aa;}", "lookup", "label_a", "aa", 77]
 
                 warn("label_a", thing);
             }
@@ -5201,7 +5191,7 @@ function jslint_phase4_walk(state) {
             ) {
 
 // test_cause:
-// ["let aa;if(aa){let bb;}bb;", "lookup", "out_of_scope_a", "7", 77]
+// ["let aa;if(aa){let bb;}bb;", "lookup", "out_of_scope_a", "bb", 77]
 
                 warn("out_of_scope_a", thing);
             }
@@ -5218,15 +5208,15 @@ function jslint_phase4_walk(state) {
     function pre_function(thing) {
 
 // test_cause:
-// ["()=>0", "pre_function", "", "7", 77]
-// ["(function (){}())", "pre_function", "", "7", 77]
-// ["function aa(){}", "pre_function", "", "7", 77]
+// ["()=>0", "pre_function", "", "", 77]
+// ["(function (){}())", "pre_function", "", "", 77]
+// ["function aa(){}", "pre_function", "", "", 77]
 
         test_cause("");
         if (thing.arity === "statement" && blockage.body !== true) {
 
 // test_cause:
-// ["if(0){function aa(){}\n}", "pre_function", "unexpected_a", "7", 77]
+// ["if(0){function aa(){}\n}", "pre_function", "unexpected_a", "function", 77]
 
             warn("unexpected_a", thing);
         }
@@ -5243,7 +5233,10 @@ function jslint_phase4_walk(state) {
             if (thing.parameters.length !== 0) {
 
 // test_cause:
-// ["/*jslint getset*/\naa={get aa(aa){}}", "pre_function", "bad_get", "7", 77]
+// ["
+// /*jslint getset*/
+// aa={get aa(aa){}}
+// ", "pre_function", "bad_get", "function", 77]
 
                 warn("bad_get", thing);
             }
@@ -5251,7 +5244,10 @@ function jslint_phase4_walk(state) {
             if (thing.parameters.length !== 1) {
 
 // test_cause:
-// ["/*jslint getset*/\naa={set aa(){}}", "pre_function", "bad_set", "7", 77]
+// ["
+// /*jslint getset*/
+// aa={set aa(){}}
+// ", "pre_function", "bad_set", "function", 77]
 
                 warn("bad_set", thing);
             }
@@ -5287,19 +5283,19 @@ function jslint_phase4_walk(state) {
         case "~":
 
 // test_cause:
-// ["0&0", "pre_bitwise", "unexpected_a", "7", 77]
-// ["0&=0", "pre_bitwise", "unexpected_a", "7", 77]
-// ["0<<0", "pre_bitwise", "unexpected_a", "7", 77]
-// ["0<<=0", "pre_bitwise", "unexpected_a", "7", 77]
-// ["0>>0", "pre_bitwise", "unexpected_a", "7", 77]
-// ["0>>=0", "pre_bitwise", "unexpected_a", "7", 77]
-// ["0>>>0", "pre_bitwise", "unexpected_a", "7", 77]
-// ["0>>>=0", "pre_bitwise", "unexpected_a", "7", 77]
-// ["0^0", "pre_bitwise", "unexpected_a", "7", 77]
-// ["0^=0", "pre_bitwise", "unexpected_a", "7", 77]
-// ["0|0", "pre_bitwise", "unexpected_a", "7", 77]
-// ["0|=0", "pre_bitwise", "unexpected_a", "7", 77]
-// ["~0", "pre_bitwise", "unexpected_a", "7", 77]
+// ["0&0", "pre_bitwise", "unexpected_a", "&", 77]
+// ["0&=0", "pre_bitwise", "unexpected_a", "&=", 77]
+// ["0<<0", "pre_bitwise", "unexpected_a", "<<", 77]
+// ["0<<=0", "pre_bitwise", "unexpected_a", "<<=", 77]
+// ["0>>0", "pre_bitwise", "unexpected_a", ">>", 77]
+// ["0>>=0", "pre_bitwise", "unexpected_a", ">>=", 77]
+// ["0>>>0", "pre_bitwise", "unexpected_a", ">>>", 77]
+// ["0>>>=0", "pre_bitwise", "unexpected_a", ">>>=", 77]
+// ["0^0", "pre_bitwise", "unexpected_a", "^", 77]
+// ["0^=0", "pre_bitwise", "unexpected_a", "^=", 77]
+// ["0|0", "pre_bitwise", "unexpected_a", "|", 77]
+// ["0|=0", "pre_bitwise", "unexpected_a", "|=", 77]
+// ["~0", "pre_bitwise", "unexpected_a", "~", 77]
 
             warn("unexpected_a", thing);
             break;
@@ -5318,7 +5314,7 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["0<0<0", "pre_bitwise", "unexpected_a", "7", 77]
+// ["0<0<0", "pre_bitwise", "unexpected_a", "<", 77]
 
             warn("unexpected_a", thing);
         }
@@ -5376,7 +5372,7 @@ function jslint_phase4_walk(state) {
         if (thing.wrapped) {
 
 // test_cause:
-// ["aa=(function(){})", "post_function", "unexpected_parens", "7", 77]
+// ["aa=(function(){})", "post_function", "unexpected_parens", "function", 77]
 
             warn("unexpected_parens", thing);
         }
@@ -5400,7 +5396,7 @@ function jslint_phase4_walk(state) {
             if (left.id === "NaN" || right.id === "NaN") {
 
 // test_cause:
-// ["NaN===NaN", "pre_bin", "number_isNaN", "7", 77]
+// ["NaN===NaN", "pre_bin", "number_isNaN", "===", 77]
 
                 warn("number_isNaN", thing);
             } else if (left.id === "typeof") {
@@ -5408,7 +5404,7 @@ function jslint_phase4_walk(state) {
                     if (right.id !== "typeof") {
 
 // test_cause:
-// ["typeof 0===0", "pre_bin", "expected_string_a", "7", 77]
+// ["typeof 0===0", "pre_bin", "expected_string_a", "0", 77]
 
                         warn("expected_string_a", right);
                     }
@@ -5417,7 +5413,9 @@ function jslint_phase4_walk(state) {
                     if (value === "null" || value === "undefined") {
 
 // test_cause:
-// ["typeof aa===\"undefined\"", "pre_bin", "unexpected_typeof_a", "7", 77]
+// ["
+// typeof aa==="undefined"
+// ", "pre_bin", "unexpected_typeof_a", "undefined", 77]
 
                         warn("unexpected_typeof_a", right, value);
                     } else if (
@@ -5430,7 +5428,7 @@ function jslint_phase4_walk(state) {
                     ) {
 
 // test_cause:
-// ["typeof 0===\"aa\"", "pre_bin", "expected_type_string_a", "7", 77]
+// ["typeof 0===\"aa\"", "pre_bin", "expected_type_string_a", "aa", 77]
 
                         warn("expected_type_string_a", right, value);
                     }
@@ -5441,14 +5439,14 @@ function jslint_phase4_walk(state) {
     preaction("binary", "==", function pre_bin_eqeq(thing) {
 
 // test_cause:
-// ["0==0", "pre_bin_eqeq", "expected_a_b", "7", 77]
+// ["0==0", "pre_bin_eqeq", "expected_a_b", "==", 77]
 
         warn("expected_a_b", thing, "===", "==");
     });
     preaction("binary", "!=", function pre_bin_noteq(thing) {
 
 // test_cause:
-// ["0!=0", "pre_bin_noteq", "expected_a_b", "7", 77]
+// ["0!=0", "pre_bin_noteq", "expected_a_b", "!=", 77]
 
         warn("expected_a_b", thing, "!==", "!=");
     });
@@ -5458,13 +5456,13 @@ function jslint_phase4_walk(state) {
             if (thang.id === "&&" && !thang.wrapped) {
 
 // test_cause:
-// ["0&&0||0", "pre_bin_or", "and", "7", 77]
+// ["0&&0||0", "pre_bin_or", "and", "&&", 77]
 
                 warn("and", thang);
             }
         });
     });
-    preaction("binary", "(", function pre_bin_left_paren(thing) {
+    preaction("binary", "(", function pre_bin_lparen(thing) {
         const left = thing.expression[0];
         let left_variable;
         let parent;
@@ -5492,18 +5490,18 @@ function jslint_phase4_walk(state) {
     preaction("binary", "in", function pre_bin_in(thing) {
 
 // test_cause:
-// ["aa in aa", "pre_bin_in", "infix_in", "7", 77]
+// ["aa in aa", "pre_bin_in", "infix_in", "in", 77]
 
         warn("infix_in", thing);
     });
     preaction("binary", "instanceof", function pre_bin_instanceof(thing) {
 
 // test_cause:
-// ["0 instanceof 0", "pre_bin_instanceof", "unexpected_a", "7", 77]
+// ["0 instanceof 0", "pre_bin_instanceof", "unexpected_a", "instanceof", 77]
 
         warn("unexpected_a", thing);
     });
-    preaction("statement", "{", function pre_stmt_left_brace(thing) {
+    preaction("statement", "{", function pre_stmt_lbrace(thing) {
         block_stack.push(blockage);
         blockage = thing;
         thing.live = [];
@@ -5517,7 +5515,7 @@ function jslint_phase4_walk(state) {
                 if (!the_variable.writable) {
 
 // test_cause:
-// ["const aa=0;for(aa in aa){}", "pre_stmt_for", "bad_assignment_a", "7", 77]
+// ["const aa=0;for(aa in aa){}", "pre_stmt_for", "bad_assignment_a", "aa", 77]
 
                     warn("bad_assignment_a", thing.name);
                 }
@@ -5572,7 +5570,7 @@ function jslint_phase4_walk(state) {
             if (thing.names !== undefined) {
 
 // test_cause:
-// ["if(0){aa=0}", "post_assign", "=", "7", 77]
+// ["if(0){aa=0}", "post_assign", "=", "", 77]
 
                 test_cause("=");
 
@@ -5601,7 +5599,7 @@ function jslint_phase4_walk(state) {
                 ) {
 
 // test_cause:
-// ["aa.aa=undefined", "post_assign", "expected_a_b", "7", 77]
+// ["aa.aa=undefined", "post_assign", "expected_a_b", "undefined", 77]
 
                     warn(
                         "expected_a_b",
@@ -5632,7 +5630,7 @@ function jslint_phase4_walk(state) {
             ) {
 
 // test_cause:
-// ["aa+=undefined", "post_assign", "unexpected_a", "7", 77]
+// ["aa+=undefined", "post_assign", "unexpected_a", "undefined", 77]
 
                 warn("unexpected_a", thing.expression[1]);
             }
@@ -5653,7 +5651,7 @@ function jslint_phase4_walk(state) {
             ) {
 
 // test_cause:
-// ["if(0===0){0}", "post_bin", "weird_relation_a", "7", 77]
+// ["if(0===0){0}", "post_bin", "weird_relation_a", "===", 77]
 
                 warn("weird_relation_a", thing);
             }
@@ -5663,13 +5661,13 @@ function jslint_phase4_walk(state) {
                 if (thing.expression[0].value === "") {
 
 // test_cause:
-// ["\"\"+0", "post_bin", "expected_a_b", "7", 77]
+// ["\"\"+0", "post_bin", "expected_a_b", "\"\" +", 77]
 
                     warn("expected_a_b", thing, "String(...)", "\"\" +");
                 } else if (thing.expression[1].value === "") {
 
 // test_cause:
-// ["0+\"\"", "post_bin", "expected_a_b", "7", 77]
+// ["0+\"\"", "post_bin", "expected_a_b", "+ \"\"", 77]
 
                     warn("expected_a_b", thing, "String(...)", "+ \"\"");
                 }
@@ -5678,14 +5676,14 @@ function jslint_phase4_walk(state) {
             if (thing.expression[0].id === "window") {
 
 // test_cause:
-// ["aa=window[0]", "post_bin", "weird_expression_a", "7", 77]
+// ["aa=window[0]", "post_bin", "weird_expression_a", "window[...]", 77]
 
                 warn("weird_expression_a", thing, "window[...]");
             }
             if (thing.expression[0].id === "self") {
 
 // test_cause:
-// ["aa=self[0]", "post_bin", "weird_expression_a", "7", 77]
+// ["aa=self[0]", "post_bin", "weird_expression_a", "self[...]", 77]
 
                 warn("weird_expression_a", thing, "self[...]");
             }
@@ -5693,7 +5691,7 @@ function jslint_phase4_walk(state) {
             if (thing.expression.id === "RegExp") {
 
 // test_cause:
-// ["aa=RegExp.aa", "post_bin", "weird_expression_a", "7", 77]
+// ["aa=RegExp.aa", "post_bin", "weird_expression_a", ".", 77]
 
                 warn("weird_expression_a", thing);
             }
@@ -5707,7 +5705,7 @@ function jslint_phase4_walk(state) {
             ) {
 
 // test_cause:
-// ["0- -0", "post_bin", "wrap_unary", "7", 77]
+// ["0- -0", "post_bin", "wrap_unary", "-", 77]
 
                 warn("wrap_unary", right);
             }
@@ -5728,16 +5726,16 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["aa=(()=>0)&&(()=>0)", "post_bin_and", "weird_condition_a", "7", 77]
-// ["aa=(``?``:``)&&(``?``:``)", "post_bin_and", "weird_condition_a", "7", 77]
-// ["aa=/./&&/./", "post_bin_and", "weird_condition_a", "7", 77]
-// ["aa=0&&0", "post_bin_and", "weird_condition_a", "7", 77]
-// ["aa=[]&&[]", "post_bin_and", "weird_condition_a", "7", 77]
-// ["aa=`${0}`&&`${0}`", "post_bin_and", "weird_condition_a", "7", 77]
+// ["aa=(()=>0)&&(()=>0)", "post_bin_and", "weird_condition_a", "&&", 77]
+// ["aa=(``?``:``)&&(``?``:``)", "post_bin_and", "weird_condition_a", "&&", 77]
+// ["aa=/./&&/./", "post_bin_and", "weird_condition_a", "&&", 77]
+// ["aa=0&&0", "post_bin_and", "weird_condition_a", "&&", 77]
+// ["aa=[]&&[]", "post_bin_and", "weird_condition_a", "&&", 77]
+// ["aa=`${0}`&&`${0}`", "post_bin_and", "weird_condition_a", "&&", 77]
 // ["
 // aa=function aa(){}&&function aa(){}
-// ", "post_bin_and", "weird_condition_a", "7", 77]
-// ["aa={}&&{}", "post_bin_and", "weird_condition_a", "7", 77]
+// ", "post_bin_and", "weird_condition_a", "&&", 77]
+// ["aa={}&&{}", "post_bin_and", "weird_condition_a", "&&", 77]
 
             warn("weird_condition_a", thing);
         }
@@ -5750,13 +5748,13 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["aa=0||0", "post_bin_or", "weird_condition_a", "7", 77]
+// ["aa=0||0", "post_bin_or", "weird_condition_a", "||", 77]
 
             warn("weird_condition_a", thing);
         }
     });
     postaction("binary", "=>", post_function);
-    postaction("binary", "(", function post_bin_left_paren(thing) {
+    postaction("binary", "(", function post_bin_lparen(thing) {
         let arg;
         let array;
         let cack;
@@ -5772,7 +5770,7 @@ function jslint_phase4_walk(state) {
             if (!thing.wrapped) {
 
 // test_cause:
-// ["aa=function(){}()", "post_bin_left_paren", "wrap_immediate", "7", 77]
+// ["aa=function(){}()", "post_bin_lparen", "wrap_immediate", "(", 77]
 
                 warn("wrap_immediate", thing);
             }
@@ -5787,18 +5785,18 @@ function jslint_phase4_walk(state) {
                 ) {
 
 // test_cause:
-// ["new Boolean()", "post_bin_left_paren", "unexpected_a", "7", 77]
-// ["new Number()", "post_bin_left_paren", "unexpected_a", "7", 77]
-// ["new String()", "post_bin_left_paren", "unexpected_a", "7", 77]
-// ["new Symbol()", "post_bin_left_paren", "unexpected_a", "7", 77]
-// ["new aa()", "post_bin_left_paren", "unexpected_a", "7", 77]
+// ["new Boolean()", "post_bin_lparen", "unexpected_a", "new", 77]
+// ["new Number()", "post_bin_lparen", "unexpected_a", "new", 77]
+// ["new String()", "post_bin_lparen", "unexpected_a", "new", 77]
+// ["new Symbol()", "post_bin_lparen", "unexpected_a", "new", 77]
+// ["new aa()", "post_bin_lparen", "unexpected_a", "new", 77]
 
                     warn("unexpected_a", the_new);
                 } else if (left.id === "Function") {
                     if (!option_dict.eval) {
 
 // test_cause:
-// ["new Function()", "post_bin_left_paren", "unexpected_a", "7", 77]
+// ["new Function()", "post_bin_lparen", "unexpected_a", "new Function", 77]
 
                         warn("unexpected_a", left, "new Function");
                     }
@@ -5807,14 +5805,14 @@ function jslint_phase4_walk(state) {
                     if (arg.length !== 2 || arg[1].id === "(string)") {
 
 // test_cause:
-// ["new Array()", "post_bin_left_paren", "expected_a_b", "7", 77]
+// ["new Array()", "post_bin_lparen", "expected_a_b", "new Array", 77]
 
                         warn("expected_a_b", left, "[]", "new Array");
                     }
                 } else if (left.id === "Object") {
 
 // test_cause:
-// ["new Object()", "post_bin_left_paren", "expected_a_b", "7", 77]
+// ["new Object()", "post_bin_lparen", "expected_a_b", "new Object", 77]
 
                     warn(
                         "expected_a_b",
@@ -5834,7 +5832,7 @@ function jslint_phase4_walk(state) {
                 ) {
 
 // test_cause:
-// ["let Aa=Aa()", "post_bin_left_paren", "expected_a_before_b", "7", 77]
+// ["let Aa=Aa()", "post_bin_lparen", "expected_a_before_b", "Aa", 77]
 
                     warn("expected_a_before_b", left, "new", artifact(left));
                 }
@@ -5844,7 +5842,7 @@ function jslint_phase4_walk(state) {
             if (left.expression.id === "Date" && left.name.id === "UTC") {
 
 // test_cause:
-// ["new Date.UTC()", "post_bin_left_paren", "cack", "7", 77]
+// ["new Date.UTC()", "post_bin_lparen", "cack", "", 77]
 
                 test_cause("cack");
                 cack = !cack;
@@ -5856,13 +5854,13 @@ function jslint_phase4_walk(state) {
                 if (the_new !== undefined) {
 
 // test_cause:
-// ["new Date.UTC()", "post_bin_left_paren", "unexpected_a", "7", 77]
+// ["new Date.UTC()", "post_bin_lparen", "unexpected_a", "new", 77]
 
                     warn("unexpected_a", the_new);
                 } else {
 
 // test_cause:
-// ["let Aa=Aa.Aa()", "post_bin_left_paren", "expected_a_before_b", "7", 77]
+// ["let Aa=Aa.Aa()", "post_bin_lparen", "expected_a_before_b", "Aa", 77]
 
                     warn(
                         "expected_a_before_b",
@@ -5884,7 +5882,9 @@ function jslint_phase4_walk(state) {
                         ) {
 
 // test_cause:
-// ["new Date().getTime()", "post_bin_left_paren", "expected_a_b", "7", 77]
+// ["
+// new Date().getTime()
+// ", "post_bin_lparen", "expected_a_b", "new Date().getTime()", 77]
 
                             warn(
                                 "expected_a_b",
@@ -5898,25 +5898,25 @@ function jslint_phase4_walk(state) {
             }
         }
     });
-    postaction("binary", "[", function post_bin_left_bracket(thing) {
+    postaction("binary", "[", function post_bin_lbracket(thing) {
         if (thing.expression[0].id === "RegExp") {
 
 // test_cause:
-// ["aa=RegExp[0]", "post_bin_left_bracket", "weird_expression_a", "7", 77]
+// ["aa=RegExp[0]", "post_bin_lbracket", "weird_expression_a", "[", 77]
 
             warn("weird_expression_a", thing);
         }
         if (is_weird(thing.expression[1])) {
 
 // test_cause:
-// ["aa[[0]]", "post_bin_left_bracket", "weird_expression_a", "7", 77]
+// ["aa[[0]]", "post_bin_lbracket", "weird_expression_a", "[", 77]
 
             warn("weird_expression_a", thing.expression[1]);
         }
     });
     postaction("statement", "{", pop_block);
     postaction("statement", "const", action_var);
-    postaction("statement", "export", warn_if_not_top_level);
+    postaction("statement", "export", check_top_level);
     postaction("statement", "for", function (thing) {
         walk_statement(thing.inc);
     });
@@ -5935,7 +5935,7 @@ function jslint_phase4_walk(state) {
                 name.init = true;
                 blockage.live.push(name);
             }
-            return warn_if_not_top_level(the_thing);
+            return check_top_level(the_thing);
         }
     });
     postaction("statement", "let", action_var);
@@ -5965,13 +5965,13 @@ function jslint_phase4_walk(state) {
         } else if (is_equal(thing.expression[0], thing.expression[1])) {
 
 // test_cause:
-// ["aa?aa:0", "post_ternary", "expected_a_b", "7", 77]
+// ["aa?aa:0", "post_ternary", "expected_a_b", "?", 77]
 
             warn("expected_a_b", thing, "||", "?");
         } else if (is_equal(thing.expression[0], thing.expression[2])) {
 
 // test_cause:
-// ["aa?0:aa", "post_ternary", "expected_a_b", "7", 77]
+// ["aa?0:aa", "post_ternary", "expected_a_b", "?", 77]
 
             warn("expected_a_b", thing, "&&", "?");
         } else if (
@@ -5980,7 +5980,7 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["aa?true:false", "post_ternary", "expected_a_b", "7", 77]
+// ["aa?true:false", "post_ternary", "expected_a_b", "?", 77]
 
             warn("expected_a_b", thing, "!!", "?");
         } else if (
@@ -5989,7 +5989,7 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["aa?false:true", "post_ternary", "expected_a_b", "7", 77]
+// ["aa?false:true", "post_ternary", "expected_a_b", "?", 77]
 
             warn("expected_a_b", thing, "!", "?");
         } else if (
@@ -6001,7 +6001,7 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["(aa&&!aa?0:1)", "post_ternary", "wrap_condition", "7", 77]
+// ["(aa&&!aa?0:1)", "post_ternary", "wrap_condition", "&&", 77]
 
             warn("wrap_condition", thing.expression[0]);
         }
@@ -6021,7 +6021,7 @@ function jslint_phase4_walk(state) {
             if (!option_dict.convert) {
 
 // test_cause:
-// ["!!0", "post_unary", "expected_a_b", "7", 77]
+// ["!!0", "post_unary", "expected_a_b", "!!", 77]
 
                 warn("expected_a_b", thing, "Boolean(...)", "!!");
             }
@@ -6042,7 +6042,7 @@ function jslint_phase4_walk(state) {
         if (!option_dict.convert) {
 
 // test_cause:
-// ["aa=+0", "post_unary_plus", "expected_a_b", "7", 77]
+// ["aa=+0", "post_unary_plus", "expected_a_b", "+", 77]
 
             warn("expected_a_b", thing, "Number(...)", "+");
         }
@@ -6152,7 +6152,7 @@ function jslint_phase5_whitage(state) {
             if (id !== "ignore" && name.parent === the_function) {
 
 // test_cause:
-// ["function aa(aa) {return aa;}", "delve", "id", "7", 77]
+// ["function aa(aa) {return aa;}", "delve", "id", "", 77]
 
                 test_cause("id");
                 if (
@@ -6171,15 +6171,15 @@ function jslint_phase5_whitage(state) {
                 ) {
 
 // test_cause:
-// ["/*jslint node*/\nlet aa;", "delve", "unused_a", "7", 77]
-// ["function aa(aa){return;}", "delve", "unused_a", "7", 77]
-// ["let aa=0;try{aa();}catch(bb){aa();}", "delve", "unused_a", "7", 77]
+// ["/*jslint node*/\nlet aa;", "delve", "unused_a", "aa", 77]
+// ["function aa(aa){return;}", "delve", "unused_a", "aa", 77]
+// ["let aa=0;try{aa();}catch(bb){aa();}", "delve", "unused_a", "bb", 77]
 
                     warn("unused_a", name);
                 } else if (!name.init) {
 
 // test_cause:
-// ["/*jslint node*/\nlet aa;aa();", "delve", "uninitialized_a", "7", 77]
+// ["/*jslint node*/\nlet aa;aa();", "delve", "uninitialized_a", "aa", 77]
 
                     warn("uninitialized_a", name);
                 }
@@ -6198,7 +6198,7 @@ function jslint_phase5_whitage(state) {
             if (left.thru !== right.from && nr_comments_skipped === 0) {
 
 // test_cause:
-// ["let aa = aa( );", "no_space", "unexpected_space_a_b", "7", 77]
+// ["let aa = aa( );", "no_space", "unexpected_space_a_b", ")", 77]
 
                 warn(
                     "unexpected_space_a_b",
@@ -6244,7 +6244,7 @@ function jslint_phase5_whitage(state) {
 //     aa
 // ()
 // );
-// ", "expected_at", "expected_a_at_b_c", "7", 77]
+// ", "expected_at", "expected_a_at_b_c", "5", 77]
 
                 expected_at(margin);
             }
@@ -6351,10 +6351,10 @@ function jslint_phase5_whitage(state) {
             case "{":
 
 // test_cause:
-// ["let aa=[];", "whitage", "opener", "7", 77]
-// ["let aa=`${0}`;", "whitage", "opener", "7", 77]
-// ["let aa=aa();", "whitage", "opener", "7", 77]
-// ["let aa={};", "whitage", "opener", "7", 77]
+// ["let aa=[];", "whitage", "opener", "", 77]
+// ["let aa=`${0}`;", "whitage", "opener", "", 77]
+// ["let aa=aa();", "whitage", "opener", "", 77]
+// ["let aa={};", "whitage", "opener", "", 77]
 
                 test_cause("opener");
 
@@ -6374,21 +6374,21 @@ function jslint_phase5_whitage(state) {
 // on the openness. Illegal pairs (like '{]') have already been detected.
 
 // test_cause:
-// ["let aa=[];", "whitage", "opener_closer", "7", 77]
-// ["let aa=aa();", "whitage", "opener_closer", "7", 77]
-// ["let aa={};", "whitage", "opener_closer", "7", 77]
+// ["let aa=[];", "whitage", "opener_closer", "", 77]
+// ["let aa=aa();", "whitage", "opener_closer", "", 77]
+// ["let aa={};", "whitage", "opener_closer", "", 77]
 
                     test_cause("opener_closer");
                     if (left.line === right.line) {
 
 // test_cause:
-// ["let aa = aa( );", "no_space", "unexpected_space_a_b", "7", 77]
+// ["let aa = aa( );", "no_space", "unexpected_space_a_b", ")", 77]
 
                         no_space();
                     } else {
 
 // test_cause:
-// ["let aa = aa(\n );", "expected_at", "expected_a_at_b_c", "7", 77]
+// ["let aa = aa(\n );", "expected_at", "expected_a_at_b_c", "1", 77]
 
                         at_margin(0);
                     }
@@ -6396,11 +6396,11 @@ function jslint_phase5_whitage(state) {
                 default:
 
 // test_cause:
-// ["let aa=(0);", "whitage", "opener_operand", "7", 77]
-// ["let aa=[0];", "whitage", "opener_operand", "7", 77]
-// ["let aa=`${0}`;", "whitage", "opener_operand", "7", 77]
-// ["let aa=aa(0);", "whitage", "opener_operand", "7", 77]
-// ["let aa={aa:0};", "whitage", "opener_operand", "7", 77]
+// ["let aa=(0);", "whitage", "opener_operand", "", 77]
+// ["let aa=[0];", "whitage", "opener_operand", "", 77]
+// ["let aa=`${0}`;", "whitage", "opener_operand", "", 77]
+// ["let aa=aa(0);", "whitage", "opener_operand", "", 77]
+// ["let aa={aa:0};", "whitage", "opener_operand", "", 77]
 
                     test_cause("opener_operand");
                     opening = left.open || (left.line !== right.line);
@@ -6422,11 +6422,11 @@ function jslint_phase5_whitage(state) {
                     if (opening) {
 
 // test_cause:
-// ["function aa(){\nreturn;\n}", "whitage", "opening", "7", 77]
-// ["let aa=(\n0\n);", "whitage", "opening", "7", 77]
-// ["let aa=[\n0\n];", "whitage", "opening", "7", 77]
-// ["let aa=`${\n0\n}`;", "whitage", "opening", "7", 77]
-// ["let aa={\naa:0\n};", "whitage", "opening", "7", 77]
+// ["function aa(){\nreturn;\n}", "whitage", "opening", "", 77]
+// ["let aa=(\n0\n);", "whitage", "opening", "", 77]
+// ["let aa=[\n0\n];", "whitage", "opening", "", 77]
+// ["let aa=`${\n0\n}`;", "whitage", "opening", "", 77]
+// ["let aa={\naa:0\n};", "whitage", "opening", "", 77]
 
                         test_cause("opening");
                         free = closer === ")" && left.free;
@@ -6445,7 +6445,7 @@ function jslint_phase5_whitage(state) {
 //         }
 //     }
 // }
-// ", "expected_at", "expected_a_at_b_c", "7", 77]
+// ", "expected_at", "expected_a_at_b_c", "1", 77]
 
                                 expected_at(0);
                             }
@@ -6460,10 +6460,11 @@ function jslint_phase5_whitage(state) {
 // test_cause:
 // ["
 // function aa() {bb:
-//     while (aa) {aa();
+//     while (aa) {
+//         aa();
 //     }
 // }
-// ", "whitage", "expected_line_break_a_b", "7", 77]
+// ", "whitage", "expected_line_break_a_b", "bb", 77]
 
                             warn(
                                 "expected_line_break_a_b",
@@ -6474,17 +6475,17 @@ function jslint_phase5_whitage(state) {
                         }
 
 // test_cause:
-// ["let aa=(0);", "whitage", "not_free", "7", 77]
-// ["let aa=[0];", "whitage", "not_free", "7", 77]
-// ["let aa=`${0}`;", "whitage", "not_free", "7", 77]
-// ["let aa={aa:0};", "whitage", "not_free", "7", 77]
+// ["let aa=(0);", "whitage", "not_free", "", 77]
+// ["let aa=[0];", "whitage", "not_free", "", 77]
+// ["let aa=`${0}`;", "whitage", "not_free", "", 77]
+// ["let aa={aa:0};", "whitage", "not_free", "", 77]
 
                         test_cause("not_free");
                         free = false;
                         open = false;
 
 // test_cause:
-// ["let aa = ( 0 );", "no_space_only", "unexpected_space_a_b", "7", 77]
+// ["let aa = ( 0 );", "no_space_only", "unexpected_space_a_b", "0", 77]
 
                         no_space_only();
                     }
@@ -6502,13 +6503,13 @@ function jslint_phase5_whitage(state) {
 // } else  if (aa) {
 //     aa();
 // }
-// ", "one_space_only", "expected_space_a_b", "7", 77]
+// ", "one_space_only", "expected_space_a_b", "if", 77]
 
                         one_space_only();
                     } else {
 
 // test_cause:
-// [" let aa = 0;", "expected_at", "expected_a_at_b_c", "7", 77]
+// [" let aa = 0;", "expected_at", "expected_a_at_b_c", "1", 77]
 
                         at_margin(0);
                         open = false;
@@ -6546,7 +6547,7 @@ function jslint_phase5_whitage(state) {
 //         }
 //     }
 // }
-// ", "expected_at", "expected_a_at_b_c", "7", 77]
+// ", "expected_at", "expected_a_at_b_c", "1", 77]
 
                             expected_at(0);
                         }
@@ -6557,7 +6558,7 @@ function jslint_phase5_whitage(state) {
                         )) {
 
 // test_cause:
-// ["let {aa,bb} = 0;", "one_space", "expected_space_a_b", "7", 77]
+// ["let {aa,bb} = 0;", "one_space", "expected_space_a_b", "bb", 77]
 
                             one_space();
                         } else {
@@ -6569,7 +6570,7 @@ function jslint_phase5_whitage(state) {
 //         0,0
 //     );
 // }
-// ", "expected_at", "expected_a_at_b_c", "7", 77]
+// ", "expected_at", "expected_a_at_b_c", "9", 77]
 
                             at_margin(0);
                         }
@@ -6586,13 +6587,13 @@ function jslint_phase5_whitage(state) {
 //     ? 0
 // : 1
 // );
-// ", "expected_at", "expected_a_at_b_c", "7", 77]
+// ", "expected_at", "expected_a_at_b_c", "5", 77]
 
                             at_margin(0);
                         } else {
 
 // test_cause:
-// ["let aa = (aa ? 0 : 1);", "whitage", "use_open", "7", 77]
+// ["let aa = (aa ? 0 : 1);", "whitage", "use_open", "?", 77]
 
                             warn("use_open", right);
                         }
@@ -6607,7 +6608,7 @@ function jslint_phase5_whitage(state) {
 // let aa = aa(
 //     aa ()
 // );
-// ", "no_space", "unexpected_space_a_b", "7", 77]
+// ", "no_space", "unexpected_space_a_b", "(", 77]
 
                         no_space();
                     } else if (
@@ -6629,8 +6630,8 @@ function jslint_phase5_whitage(state) {
                     ) {
 
 // test_cause:
-// ["let aa = 0 ;", "no_space_only", "unexpected_space_a_b", "7", 77]
-// ["let aa = aa ?.aa;", "no_space_only", "unexpected_space_a_b", "7", 77]
+// ["let aa = 0 ;", "no_space_only", "unexpected_space_a_b", ";", 77]
+// ["let aa = aa ?.aa;", "no_space_only", "unexpected_space_a_b", "?.", 77]
 
                         no_space_only();
                     } else if (left.id === ";") {
@@ -6647,7 +6648,7 @@ function jslint_phase5_whitage(state) {
 //         aa();
 //     }
 // }
-// ", "expected_at", "expected_a_at_b_c", "7", 77]
+// ", "expected_at", "expected_a_at_b_c", "9", 77]
 
                         if (open) {
                             at_margin(0);
@@ -6674,7 +6675,7 @@ function jslint_phase5_whitage(state) {
 //         aa();
 //     } while(aa());
 // }
-// ", "one_space_only", "expected_space_a_b", "7", 77]
+// ", "one_space_only", "expected_space_a_b", "(", 77]
 
                         one_space_only();
                     } else if (
@@ -6709,13 +6710,18 @@ function jslint_phase5_whitage(state) {
                     ) {
 
 // test_cause:
-// ["let aa=0;", "one_space", "expected_space_a_b", "7", 77]
 // ["
-// let aa={
+// let aa = {
 //     aa:
 // 0
 // };
-// ", "one_space", "expected_space_a_b", "7", 77]
+// ", "expected_at", "expected_a_at_b_c", "5", 77]
+// ["let aa=0;", "one_space", "expected_space_a_b", "0", 77]
+// ["
+// let aa={
+//     aa: 0
+// };
+// ", "one_space", "expected_space_a_b", "{", 77]
 
                         one_space();
                     } else if (left.arity === "unary" && left.id !== "`") {
@@ -7021,7 +7027,7 @@ function jslint(
         let bb_value;
 
 // test_cause:
-// ["0&&0", "is_equal", "", "7", 77]
+// ["0&&0", "is_equal", "", "", 77]
 
         test_cause("");
 
@@ -7038,7 +7044,7 @@ function jslint(
                 && aa.every(function (value, index) {
 
 // test_cause:
-// ["`${0}`&&`${0}`", "is_equal", "recurse_isArray", "7", 77]
+// ["`${0}`&&`${0}`", "is_equal", "recurse_isArray", "", 77]
 
                     test_cause("recurse_isArray");
                     return is_equal(value, bb[index]);
@@ -7071,7 +7077,7 @@ function jslint(
         if (is_weird(aa) || is_weird(bb)) {
 
 // test_cause:
-// ["aa(/./)||{}", "is_equal", "false", "7", 77]
+// ["aa(/./)||{}", "is_equal", "false", "", 77]
 
             test_cause("false");
             return false;
@@ -7080,7 +7086,7 @@ function jslint(
             if (aa.id === ".") {
 
 // test_cause:
-// ["aa.bb&&aa.bb", "is_equal", "recurse_arity_id", "7", 77]
+// ["aa.bb&&aa.bb", "is_equal", "recurse_arity_id", "", 77]
 
                 test_cause("recurse_arity_id");
                 return (
@@ -7091,7 +7097,7 @@ function jslint(
             if (aa.arity === "unary") {
 
 // test_cause:
-// ["+0&&+0", "is_equal", "recurse_unary", "7", 77]
+// ["+0&&+0", "is_equal", "recurse_unary", "", 77]
 
                 test_cause("recurse_unary");
                 return is_equal(aa.expression, bb.expression);
@@ -7099,7 +7105,7 @@ function jslint(
             if (aa.arity === "binary") {
 
 // test_cause:
-// ["aa[0]&&aa[0]", "is_equal", "recurse_binary", "7", 77]
+// ["aa[0]&&aa[0]", "is_equal", "recurse_binary", "", 77]
 
                 test_cause("recurse_binary");
                 return (
@@ -7111,7 +7117,7 @@ function jslint(
             if (aa.arity === "ternary") {
 
 // test_cause:
-// ["aa=(``?``:``)&&(``?``:``)", "is_equal", "recurse_ternary", "7", 77]
+// ["aa=(``?``:``)&&(``?``:``)", "is_equal", "recurse_ternary", "", 77]
 
                 test_cause("recurse_ternary");
                 return (
@@ -7132,20 +7138,20 @@ function jslint(
             );
 
 // test_cause:
-// ["undefined&&undefined", "is_equal", "true", "7", 77]
+// ["undefined&&undefined", "is_equal", "true", "", 77]
 
             test_cause("true");
             return true;
         }
 
 // test_cause:
-// ["null&&undefined", "is_equal", "false", "7", 77]
+// ["null&&undefined", "is_equal", "false", "", 77]
 
         test_cause("false");
         return false;
     }
 
-    function test_cause(code) {
+    function test_cause(code, aa) {
 
 // This function will instrument <cause> to <cause_dict> for test-purposes.
 
@@ -7159,12 +7165,11 @@ function jslint(
                     /^Object\./
                 ), ""),
                 code,
-                //!! (
-                    //!! (aa === undefined || (typeof aa === "object" && aa))
-                    //!! ? artifact(aa)
-                    //!! : aa
-                //!! ),
-                "7",
+                String(
+                    (aa === undefined || aa === token_global)
+                    ? ""
+                    : aa
+                ),
                 77
             ])] = true;
         }
@@ -7194,7 +7199,7 @@ function jslint(
             Math.min(warning.column, warning.line_source.length),
             jslint_fudge
         );
-        test_cause(code);
+        test_cause(code, b || a);
         switch (code) {
 
 // The bundle contains the raw text messages that are generated by jslint. It
@@ -7240,14 +7245,14 @@ function jslint(
         case "expected_a_b":
             mm = `Expected '${a}' and instead saw '${b}'.`;
             break;
+        case "expected_a_b_before_c_d":
+            mm = `Expected ${a} '${b}' to be ordered before ${c} '${d}'.`;
+            break;
         case "expected_a_b_from_c_d":
             mm = (
                 `Expected '${a}' to match '${b}' from line ${c}`
                 + ` and instead saw '${d}'.`
             );
-            break;
-        case "expected_a_b_ordered_before_c_d":
-            mm = `Expected ${a} '${b}' to be ordered before ${c} '${d}'.`;
             break;
         case "expected_a_before_b":
             mm = `Expected '${a}' before '${b}'.`;
@@ -7494,7 +7499,7 @@ function jslint(
         if (warning.directive_quiet) {
 
 // test_cause:
-// ["0 //jslint-quiet", "semicolon", "directive_quiet", "7", 77]
+// ["0 //jslint-quiet", "semicolon", "directive_quiet", "", 77]
 
             test_cause("directive_quiet");
             return warning;
@@ -7517,6 +7522,7 @@ function jslint(
 // likely that the first warning will be the most meaningful.
 
         the_token = the_token || state.token_nxt;
+        a = a || artifact(the_token);
         if (the_token.warning === undefined) {
             the_token.warning = warn_at(
                 code,
@@ -7529,7 +7535,7 @@ function jslint(
             );
             return the_token.warning;
         }
-        test_cause(code);
+        test_cause(code, b || a);
     }
 
     function stop(code, the_token, a, b, c, d) {
@@ -7653,7 +7659,7 @@ function jslint(
                 if (comment.directive === "global") {
 
 // test_cause:
-// ["/*global aa*/", "jslint", "missing_browser", "7", 77]
+// ["/*global aa*/", "jslint", "missing_browser", "(comment)", 77]
 
                     warn("missing_browser", comment);
                 }

--- a/test.mjs
+++ b/test.mjs
@@ -397,15 +397,13 @@ function noop() {
                 test_cause: true
             }).causes;
             // Validate cause.
-            /*
             assertOrThrow(
-                tmp[JSON.stringify(cause.slice(1))],
+                cause[1] === "77f" || tmp[JSON.stringify(cause.slice(1))],
                 (
                     "\n" + JSON.stringify(cause) + "\n\n"
                     + Object.keys(tmp).sort().join("\n")
                 )
             );
-            */
         });
         return "";
     });

--- a/test.mjs
+++ b/test.mjs
@@ -398,7 +398,7 @@ function noop() {
             }).causes;
             // Validate cause.
             assertOrThrow(
-                cause[1] === "77f" || tmp[JSON.stringify(cause.slice(1))],
+                tmp[JSON.stringify(cause.slice(1))],
                 (
                     "\n" + JSON.stringify(cause) + "\n\n"
                     + Object.keys(tmp).sort().join("\n")

--- a/test.mjs
+++ b/test.mjs
@@ -375,9 +375,11 @@ function noop() {
         causeList = causeList.replace((
             /^\/\/\u0020/gm
         ), "").replace((
-            /^\["\n([\S\s]*?)\n",/gm
-        ), function (ignore, source) {
-            return "[" + JSON.stringify(source) + ",";
+            /^\["\n([\S\s]*?)\n"(,.*?)$/gm
+        ), function (ignore, source, param) {
+            source = "[" + JSON.stringify(source) + param;
+            assertOrThrow(source.length > (80 - 3), source);
+            return source;
         }).replace((
             /\u0020\/\/jslint-quiet$/gm
         ), "");

--- a/test.mjs
+++ b/test.mjs
@@ -7,7 +7,7 @@ function assertOrThrow(passed, msg) {
  * this function will throw <msg> if <passed> is falsy
  */
     if (!passed) {
-        throw new Error(String(msg).slice(0, 1000));
+        throw new Error(String(msg).slice(0, 2000));
     }
 }
 
@@ -360,99 +360,53 @@ function noop() {
  * this function will validate each jslint <warning> is raised with given
  * malformed <code>
  */
-    Array.from(String(
+    String(
         await moduleFs.promises.readFile("jslint.mjs", "utf8")
-    ).matchAll(new RegExp((
-        "\\s*?"
-        + "(\\/\\/\\s*?cause:.*?\\n(?:\\/\\/.*?\\n)*?)"
-        + "(\\s*?^[^\\/].*?(?:\\n\\s*?\".*?)?$)"
-    ), "gm"))).forEach(function ([
-        match0, causeList, warning
-    ]) {
-        let elemPrv = "";
-        let expectedWarningCode;
-        let fnc;
-        // debug match0
-        // console.error(match0.trim().replace((/\n\n/g), "\n"));
-        assertOrThrow(
-            match0.indexOf("\n\n" + causeList + "\n    ") === 0,
-            JSON.stringify([
-                match0, causeList
-            ], undefined, 4)
-        );
-        warning = warning.match(
-            "("
-            + "at_margin"
-            + "|expected_at"
-            + "|left_check"
-            + "|no_space_only"
-            + "|one_space"
-            + "|one_space_only"
-            + "|semicolon"
-            + "|stop"
-            + "|stop_at"
-            + "|warn"
-            + "|warn_at"
-            + "|warn_if_unordered"
-            + "|warn_if_unordered_case_statement"
-            + ")"
-            + "\\\u0028\\s*?\"?"
-            + "(\\S[^\n\"]+)"
-        );
-        if (warning) {
-            expectedWarningCode = warning[2];
-            fnc = warning[1];
-            switch (fnc) {
-            case "at_margin":
-            case "expected_at":
-                expectedWarningCode = "expected_a_at_b_c";
-                break;
-            case "left_check":
-                expectedWarningCode = "unexpected_a";
-                break;
-            case "no_space_only":
-                expectedWarningCode = "unexpected_space_a_b";
-                break;
-            case "one_space":
-            case "one_space_only":
-                expectedWarningCode = "expected_space_a_b";
-                break;
-            case "semicolon":
-                expectedWarningCode = "expected_a_b";
-                break;
-            case "warn_if_unordered":
-            case "warn_if_unordered_case_statement":
-                expectedWarningCode = "expected_a_b_ordered_before_c_d";
-                break;
-            }
-        }
-        causeList.split(
-            /\/\/\u0020cause:[\n|\u0020]/
-        ).slice(1).forEach(function (cause) {
-            assertOrThrow(cause === cause.trim() + "\n", JSON.stringify(cause));
-            cause = (
-                expectedWarningCode === "too_long"
-                ? "//".repeat(100)
-                : cause[0] === "\""
-                ? JSON.parse(cause)
-                : cause.replace((
-                    /^\/\/\u0020/gm
-                ), "")
+    ).replace((
+        /(\n\s*?\/\/\s*?test_cause:\s*?)(\S[\S\s]*?\S)(\n\n\s*?)\u0020*?\S/g
+    ), function (match0, header, causeList, footer) {
+        let tmp;
+        // console.error(match0);
+        // Validate header.
+        assertOrThrow(header === "\n\n// test_cause:\n", match0);
+        // Validate footer.
+        assertOrThrow(footer === "\n\n", match0);
+        // Validate causeList.
+        causeList = causeList.replace((
+            /^\/\/\u0020/gm
+        ), "").replace((
+            /^\["\n([\S\s]*?)\n",/gm
+        ), function (ignore, source) {
+            return "[" + JSON.stringify(source) + ",";
+        }).replace((
+            /\u0020\/\/jslint-quiet$/gm
+        ), "");
+        tmp = causeList.split("\n").map(function (cause) {
+            return (
+                "["
+                + JSON.parse(cause).map(function (elem) {
+                    return JSON.stringify(elem);
+                }).join(", ")
+                + "]"
             );
-            // Assert causeList is sorted.
-            assertOrThrow(elemPrv < cause, JSON.stringify([
-                elemPrv, cause
-            ], undefined, 4));
-            elemPrv = cause;
-            // Assert expectedWarningCode from cause.
+        }).sort().join("\n");
+        assertOrThrow(causeList === tmp, "\n" + causeList + "\n\n" + tmp);
+        causeList.split("\n").forEach(function (cause) {
+            cause = JSON.parse(cause);
+            tmp = jslint(cause[0], {
+                test_cause: true
+            }).causes;
+            // Validate cause.
+            /*
             assertOrThrow(
-                jslint(cause).warnings.some(function ({
-                    code
-                }) {
-                    return code === expectedWarningCode;
-                }) || !expectedWarningCode,
-                "\n" + cause.trim()
+                tmp[JSON.stringify(cause.slice(1))],
+                (
+                    "\n" + JSON.stringify(cause) + "\n\n"
+                    + Object.keys(tmp).sort().join("\n")
+                )
             );
+            */
         });
+        return "";
     });
 }());


### PR DESCRIPTION
- tests - test column position in warnings are correct.
- bugfix - fix jslint not warning about function-redefinition when function is defined inside a call.

revamp cause-based testing with additional instrumentation to validate a warning's:
1. calling-function
2. artifact
3. column-position

example:

```diff
// old inline test.
-// cause: "0a"

// new inline test with extra caller/code/artifact/column instrumentation.
+// test_cause:
+// ["0a", "lex_number", "unexpected_a_after_b", "0", 2]
```