### PR TITLE
- jslint - add new beta-warning if functions are unordered.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
       - beta
       - master
       - sandbox
+  workflow_dispatch:
+    branches:
+      - alpha
+      - beta
+      - master
+      - sandbox
 # shCiBase - start
 jobs:
   build:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -2,6 +2,7 @@
 name: on-pull-request
 on:
   - pull_request
+  - workflow_dispatch
 # shCiBase - start
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 # v2021.7.1-beta
 - bugfix - fix jslint not warning about function-redefinition when function is defined inside a call.
 - bugfix - fix website crashing when linting pure json-object.
+- jslint - add new beta-warning if functions are unordered.
 - jslint - add new warning disallowing string-literal as property-name, e.g. {`aa`:0}.
 - jslint - comment out shebang in jslint.mjs so older ios devices can use website.
 - tests - revamp cause-based testing with more robust instrumentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 - jslint - require regexp to use open-form.
 - jslint - simplify comments/docs by removing unnecessary grammar-article "the".
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
-- jslint-refactor - migrate recursive-loops to for/while loops.
 - merge function.html and help.html into README.md
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - vim - add vim plugin.
@@ -25,7 +24,8 @@
 - jslint - add new beta-warning if functions are unordered.
 - jslint - add new warning disallowing string-literal as property-name, e.g. {`aa`:0}.
 - jslint - comment out shebang in jslint.mjs so older ios devices can use website.
-- tests - revamp cause-based testing with more robust instrumentation.
+- jslint-revamp - rearrange functions in jslint.mjs to comply with ordered-functions beta-warning.
+- jslint-revamp - revamp cause-based testing with more robust instrumentation.
 - tests - test artifact and column-position in warnings are correct.
 
 # v2021.6.30

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -91,7 +91,7 @@
 
 // WARNING: JSLint will hurt your feelings.
 
-/*jslint node*/
+/*jslint beta, node*/
 
 /*property
     causes,
@@ -109,7 +109,7 @@
     free, freeze, from, froms, fud, function_list, function_stack, functions,
     getset, global, global_dict, id, identifier, import, import_list, inc,
     indent2, index, indexOf, init, initial, isArray, isNaN, is_equal, is_weird,
-    join, jslint, json, keys, label, last_statement, lbp, led, length, level,
+    join, jslint, json, keys, label, statement_prv, lbp, led, length, level,
     line, line_list, line_offset, line_source, lines, live, long, loop, m, main,
     map, margin, match, message, meta, mode_force, mode_json, mode_module,
     mode_noop, mode_property, mode_shebang, mode_stop, module, name, names,
@@ -170,21 +170,1273 @@ function identity(val) {
     return val;
 }
 
-function noop() {
+function jslint(
+    source = "",                // A text to analyze.
+    option_dict = empty(),      // An object whose keys correspond to option
+                                // ... names.
+    global_list = []            // An array of strings containing global
+                                // ... variables that the file is allowed
+                                // ... readonly access.
+) {
 
-// This function will do nothing.
+// The jslint function itself.
 
-    return;
+    let allowed_option = {
+
+// These are the options that are recognized in the option object or that may
+// appear in a /*jslint*/ directive. Most options will have a boolean value,
+// usually true. Some options will also predefine some number of global
+// variables.
+
+        beta: true,             // Enable experimental warnings.
+        bitwise: true,          // Allow bitwise operators.
+        browser: [              // Assume browser environment.
+            "CharacterData",
+            "DOMException",
+            "DocumentType",
+            "Element",
+            "Event",
+            "FileReader",
+            "FontFace",
+            "FormData",
+            "IntersectionObserver",
+            "MutationObserver",
+            "Storage",
+            "TextDecoder",
+            "TextEncoder",
+            "URL",
+            "Worker",
+            "XMLHttpRequest",
+            "clearInterval",
+            "clearTimeout",
+            "document",
+            "fetch",
+            "localStorage",
+            "location",
+            "navigator",
+            "screen",
+            "sessionStorage",
+            "setInterval",
+            "setTimeout",
+            "window"
+        ],
+        convert: true,          // Allow conversion operators.
+        couch: [                // Assume CouchDb environment.
+            "emit",
+            "getRow",
+            "isArray",
+            "log",
+            "provides",
+            "registerType",
+            "require",
+            "send",
+            "start",
+            "sum",
+            "toJSON"
+        ],
+        debug: true,            // Include jslint stack-trace in warnings.
+        devel: [                // Allow console.log() and friends.
+            "alert", "confirm", "console", "prompt"
+        ],
+        eval: true,             // Allow eval().
+        for: true,              // Allow for-statement.
+        getset: true,           // Allow get() and set().
+        indent2: true,          // Allow 2-space indent.
+        long: true,             // Allow long lines.
+        name: true,             // Allow weird property names.
+        node: [                 // Assume Node.js environment.
+            "Buffer",
+            "TextDecoder",
+            "TextEncoder",
+            "URL",
+            "URLSearchParams",
+            "__dirname",
+            "__filename",
+            "clearImmediate",
+            "clearInterval",
+            "clearTimeout",
+            "console",
+            "exports",
+            "module",
+            "process",
+            "require",
+            "setImmediate",
+            "setInterval",
+            "setTimeout"
+        ],
+        single: true,           // Allow single-quote strings.
+        test_cause: true,       // Test jslint's causes.
+        test_internal_error: true,      // Test jslint's internal-error
+                                        // ... handling-ability.
+        this: true,             // Allow 'this'.
+        unordered: true,        // Allow unordered cases, params, properties,
+                                // ... and variables.
+        variable: true,         // Allow unordered const and let declarations
+                                // ... that are not at top of function-scope.
+        white: true             // Allow messy whitespace.
+    };
+    let catch_list = [];        // The array containing all catch-blocks.
+    let catch_stack = [         // The stack of catch-blocks.
+        {
+            context: empty()
+        }
+    ];
+    let cause_dict = empty();   // The object of test-causes.
+    let directive_list = [];    // The directive comments.
+    let export_dict = empty();  // The exported names and values.
+    let function_list = [];     // The array containing all functions.
+    let function_stack = [];    // The stack of functions.
+    let global_dict = empty();  // The object containing the global
+                                // ... declarations.
+    let import_list = [];       // The array collecting all import-from strings.
+    let line_list = String(     // The array containing source lines.
+        "\n" + source
+    ).split(
+        // rx_crlf
+        /\n|\r\n?/
+    ).map(function (line_source) {
+        return {
+            line_source
+        };
+    });
+    let mode_stop = false;      // true if JSLint cannot finish.
+    let property_dict = empty();        // The object containing the tallied
+                                        // ... property names.
+    let standard = [            // These are the globals that are provided by
+                                // ... the language standard.
+// node --input-type=module -e '
+// /*jslint beta node*/
+// import https from "https";
+// (async function () {
+//     var dict;
+//     var result = "";
+//     await new Promise(function (resolve) {
+//         https.get((
+//             "https://developer.mozilla.org"
+//             + "/en-US/docs/Web/JavaScript/Reference/Global_Objects"
+//         ), function (res) {
+//             res.on("data", function (chunk) {
+//                 result += chunk;
+//             }).on("end", resolve).setEncoding("utf8");
+//         });
+//     });
+//     dict = {
+//         import: true
+//     };
+//     result.replace(new RegExp((
+//         "href=\"\\/en-US\\/docs\\/Web\\/JavaScript\\/Reference"
+//         + "\\/Global_Objects\\/.*?<code>(\\w+).*?<\\/code>"
+//     ), "g"), function (ignore, key) {
+//         switch (globalThis.hasOwnProperty(key) && key) {
+//         case "escape":
+//         case "unescape":
+//         case "uneval":
+//         case false:
+//             break;
+//         default:
+//             dict[key] = true;
+//         }
+//     });
+//     console.log(JSON.stringify(Object.keys(dict).sort(), undefined, 4));
+// }());
+// '
+        "Array",
+        "ArrayBuffer",
+        "Atomics",
+        "BigInt",
+        "BigInt64Array",
+        "BigUint64Array",
+        "Boolean",
+        "DataView",
+        "Date",
+        "Error",
+        "EvalError",
+        "Float32Array",
+        "Float64Array",
+        "Function",
+        "Infinity",
+        "Int16Array",
+        "Int32Array",
+        "Int8Array",
+        "Intl",
+        "JSON",
+        "Map",
+        "Math",
+        "NaN",
+        "Number",
+        "Object",
+        "Promise",
+        "Proxy",
+        "RangeError",
+        "ReferenceError",
+        "Reflect",
+        "RegExp",
+        "Set",
+        "SharedArrayBuffer",
+        "String",
+        "Symbol",
+        "SyntaxError",
+        "TypeError",
+        "URIError",
+        "Uint16Array",
+        "Uint32Array",
+        "Uint8Array",
+        "Uint8ClampedArray",
+        "WeakMap",
+        "WeakSet",
+        "WebAssembly",
+        "decodeURI",
+        "decodeURIComponent",
+        "encodeURI",
+        "encodeURIComponent",
+        "eval",
+        "globalThis",
+        "import",
+        "isFinite",
+        "isNaN",
+        "parseFloat",
+        "parseInt",
+        "undefined"
+    ];
+    let state = empty();        // jslint state-object to be passed between
+                                // jslint functions.
+    let syntax_dict = empty();  // The object containing the parser.
+    let tenure = empty();       // The predefined property registry.
+    let token_global = {        // The global object; the outermost context.
+        async: 0,
+        body: true,
+        context: empty(),
+        finally: 0,
+        from: 0,
+        id: "(global)",
+        level: 0,
+        line: jslint_fudge,
+        live: [],
+        loop: 0,
+        switch: 0,
+        thru: 0,
+        try: 0
+    };
+    let token_list = [];        // The array of tokens.
+    let warning_list = [];      // The array collecting all generated warnings.
+
+// Error reportage functions:
+
+    function artifact(the_token) {
+
+// Return a string representing an artifact.
+
+        the_token = the_token || state.token_nxt;
+        return (
+            (the_token.id === "(string)" || the_token.id === "(number)")
+            ? String(the_token.value)
+            : the_token.id
+        );
+    }
+
+    function is_equal(aa, bb) {
+        let aa_value;
+        let bb_value;
+
+// test_cause:
+// ["0&&0", "is_equal", "", "", 0]
+
+        test_cause("");
+
+// Probably deadcode.
+// if (aa === bb) {
+//     return true;
+// }
+
+        assert_or_throw(!(aa === bb), `Expected !(aa === bb).`);
+        if (Array.isArray(aa)) {
+            return (
+                Array.isArray(bb)
+                && aa.length === bb.length
+                && aa.every(function (value, index) {
+
+// test_cause:
+// ["`${0}`&&`${0}`", "is_equal", "recurse_isArray", "", 0]
+
+                    test_cause("recurse_isArray");
+                    return is_equal(value, bb[index]);
+                })
+            );
+        }
+
+// Probably deadcode.
+// if (Array.isArray(bb)) {
+//     return false;
+// }
+
+        assert_or_throw(!Array.isArray(bb), `Expected !Array.isArray(bb).`);
+        if (aa.id === "(number)" && bb.id === "(number)") {
+            return aa.value === bb.value;
+        }
+        if (aa.id === "(string)") {
+            aa_value = aa.value;
+        } else if (aa.id === "`" && aa.constant) {
+            aa_value = aa.value[0];
+        }
+        if (bb.id === "(string)") {
+            bb_value = bb.value;
+        } else if (bb.id === "`" && bb.constant) {
+            bb_value = bb.value[0];
+        }
+        if (typeof aa_value === "string") {
+            return aa_value === bb_value;
+        }
+        if (is_weird(aa) || is_weird(bb)) {
+
+// test_cause:
+// ["aa(/./)||{}", "is_equal", "false", "", 0]
+
+            test_cause("false");
+            return false;
+        }
+        if (aa.arity === bb.arity && aa.id === bb.id) {
+            if (aa.id === ".") {
+
+// test_cause:
+// ["aa.bb&&aa.bb", "is_equal", "recurse_arity_id", "", 0]
+
+                test_cause("recurse_arity_id");
+                return (
+                    is_equal(aa.expression, bb.expression)
+                    && is_equal(aa.name, bb.name)
+                );
+            }
+            if (aa.arity === "unary") {
+
+// test_cause:
+// ["+0&&+0", "is_equal", "recurse_unary", "", 0]
+
+                test_cause("recurse_unary");
+                return is_equal(aa.expression, bb.expression);
+            }
+            if (aa.arity === "binary") {
+
+// test_cause:
+// ["aa[0]&&aa[0]", "is_equal", "recurse_binary", "", 0]
+
+                test_cause("recurse_binary");
+                return (
+                    aa.id !== "("
+                    && is_equal(aa.expression[0], bb.expression[0])
+                    && is_equal(aa.expression[1], bb.expression[1])
+                );
+            }
+            if (aa.arity === "ternary") {
+
+// test_cause:
+// ["aa=(``?``:``)&&(``?``:``)", "is_equal", "recurse_ternary", "", 0]
+
+                test_cause("recurse_ternary");
+                return (
+                    is_equal(aa.expression[0], bb.expression[0])
+                    && is_equal(aa.expression[1], bb.expression[1])
+                    && is_equal(aa.expression[2], bb.expression[2])
+                );
+            }
+
+// Probably deadcode.
+// if (aa.arity === "function" || aa.arity === "regexp") {
+//     return false;
+// }
+
+            assert_or_throw(
+                !(aa.arity === "function" || aa.arity === "regexp"),
+                `Expected !(aa.arity === "function" || aa.arity === "regexp").`
+            );
+
+// test_cause:
+// ["undefined&&undefined", "is_equal", "true", "", 0]
+
+            test_cause("true");
+            return true;
+        }
+
+// test_cause:
+// ["null&&undefined", "is_equal", "false", "", 0]
+
+        test_cause("false");
+        return false;
+    }
+
+    function is_weird(thing) {
+        switch (thing.id) {
+        case "(regexp)":
+            return true;
+        case "=>":
+            return true;
+        case "[":
+            return thing.arity === "unary";
+        case "function":
+            return true;
+        case "{":
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    function stop(code, the_token, a, b, c, d) {
+
+// Similar to warn and stop_at. If the token already had a warning, that
+// warning will be replaced with this new one. It is likely that the stopping
+// warning will be the more meaningful.
+
+        the_token = the_token || state.token_nxt;
+        delete the_token.warning;
+        throw warn(code, the_token, a, b, c, d);
+    }
+
+    function stop_at(code, line, column, a, b, c, d) {
+
+// Same as warn_at, except that it stops the analysis.
+
+        throw warn_at(code, line, column, a, b, c, d);
+    }
+
+    function test_cause(code, aa, column) {
+
+// This function will instrument <cause> to <cause_dict> for test-purposes.
+
+        if (option_dict.test_cause) {
+            cause_dict[JSON.stringify([
+                String(new Error().stack).replace((
+                    /^\u0020{4}at\u0020(?:file|stop|stop_at|test_cause|warn|warn_at)\b.*?\n/gm
+                ), "").match(
+                    /\n\u0020{4}at\u0020((?:Object\.\w+?_)?\w+?)\u0020/
+                )[1].replace((
+                    /^Object\./
+                ), ""),
+                code,
+                String(
+                    (aa === undefined || aa === token_global)
+                    ? ""
+                    : aa
+                ),
+                column || 0
+            ])] = true;
+        }
+    }
+
+    function warn(code, the_token, a, b, c, d) {
+
+// Same as warn_at, except the warning will be associated with a specific token.
+// If there is already a warning on this token, suppress the new one. It is
+// likely that the first warning will be the most meaningful.
+
+        let the_warning;
+        the_token = the_token || state.token_nxt;
+        the_warning = warn_at(
+            code,
+            the_token.line,
+            (the_token.from || 0) + jslint_fudge,
+            a || artifact(the_token),
+            b,
+            c,
+            d
+        );
+        if (the_token.warning === undefined) {
+            the_token.warning = the_warning;
+        } else {
+            warning_list.pop();
+        }
+        return the_warning;
+    }
+
+    function warn_at(code, line, column, a, b, c, d) {
+
+// Report an error at some line and column of the program. The warning object
+// resembles an exception.
+
+        let mm;
+        let warning = Object.assign(empty(), {
+            a,
+            b,
+            c,
+            code,
+
+// Fudge column numbers in warning message.
+
+            column: column || jslint_fudge,
+            d,
+            line,
+            line_source: "",
+            name: "JSLintError"
+        }, line_list[line]);
+        warning.column = Math.max(
+            Math.min(warning.column, warning.line_source.length),
+            jslint_fudge
+        );
+        test_cause(code, b || a, warning.column);
+        switch (code) {
+
+// The bundle contains the raw text messages that are generated by jslint. It
+// seems that they are all error messages and warnings. There are no "Atta
+// boy!" or "You are so awesome!" messages. There is no positive reinforcement
+// or encouragement. This relentless negativity can undermine self-esteem and
+// wound the inner child. But if you accept it as sound advice rather than as
+// personal criticism, it can make your programs better.
+
+        case "and":
+            mm = `The '&&' subexpression should be wrapped in parens.`;
+            break;
+        case "bad_assignment_a":
+            mm = `Bad assignment to '${a}'.`;
+            break;
+        case "bad_directive_a":
+            mm = `Bad directive '${a}'.`;
+            break;
+        case "bad_get":
+            mm = `A get function takes no parameters.`;
+            break;
+        case "bad_module_name_a":
+            mm = `Bad module name '${a}'.`;
+            break;
+        case "bad_option_a":
+            mm = `Bad option '${a}'.`;
+            break;
+        case "bad_set":
+            mm = `A set function takes one parameter.`;
+            break;
+        case "duplicate_a":
+            mm = `Duplicate '${a}'.`;
+            break;
+        case "empty_block":
+            mm = `Empty block.`;
+            break;
+        case "expected_a":
+            mm = `Expected '${a}'.`;
+            break;
+        case "expected_a_at_b_c":
+            mm = `Expected '${a}' at column ${b}, not column ${c}.`;
+            break;
+        case "expected_a_b":
+            mm = `Expected '${a}' and instead saw '${b}'.`;
+            break;
+        case "expected_a_b_before_c_d":
+            mm = `Expected ${a} '${b}' to be ordered before ${c} '${d}'.`;
+            break;
+        case "expected_a_b_from_c_d":
+            mm = (
+                `Expected '${a}' to match '${b}' from line ${c}`
+                + ` and instead saw '${d}'.`
+            );
+            break;
+        case "expected_a_before_b":
+            mm = `Expected '${a}' before '${b}'.`;
+            break;
+        case "expected_digits_after_a":
+            mm = `Expected digits after '${a}'.`;
+            break;
+        case "expected_four_digits":
+            mm = `Expected four digits after '\\u'.`;
+            break;
+        case "expected_identifier_a":
+            mm = `Expected an identifier and instead saw '${a}'.`;
+            break;
+        case "expected_line_break_a_b":
+            mm = `Expected a line break between '${a}' and '${b}'.`;
+            break;
+        case "expected_regexp_factor_a":
+            mm = `Expected a regexp factor and instead saw '${a}'.`;
+            break;
+        case "expected_space_a_b":
+            mm = `Expected one space between '${a}' and '${b}'.`;
+            break;
+        case "expected_statements_a":
+            mm = `Expected statements before '${a}'.`;
+            break;
+        case "expected_string_a":
+            mm = `Expected a string and instead saw '${a}'.`;
+            break;
+        case "expected_type_string_a":
+            mm = `Expected a type string and instead saw '${a}'.`;
+            break;
+        case "freeze_exports":
+            mm = (
+                `Expected 'Object.freeze('. All export values should be frozen.`
+            );
+            break;
+        case "function_in_loop":
+            mm = `Don't create functions within a loop.`;
+            break;
+        case "infix_in":
+            mm = (
+                `Unexpected 'in'. Compare with undefined,`
+                + ` or use the hasOwnProperty method instead.`
+            );
+            break;
+        case "label_a":
+            mm = `'${a}' is a statement label.`;
+            break;
+        case "misplaced_a":
+            mm = `Place '${a}' at the outermost level.`;
+            break;
+        case "misplaced_directive_a":
+            mm = `Place the '/*${a}*/' directive before the first statement.`;
+            break;
+        case "missing_await_statement":
+            mm = `Expected await statement in async function.`;
+            break;
+        case "missing_browser":
+            mm = `/*global*/ requires the Assume a browser option.`;
+            break;
+        case "missing_m":
+            mm = `Expected 'm' flag on a multiline regular expression.`;
+            break;
+        case "naked_block":
+            mm = `Naked block.`;
+            break;
+        case "nested_comment":
+            mm = `Nested comment.`;
+            break;
+        case "not_label_a":
+            mm = `'${a}' is not a label.`;
+            break;
+        case "number_isNaN":
+            mm = `Use Number.isNaN function to compare with NaN.`;
+            break;
+        case "out_of_scope_a":
+            mm = `'${a}' is out of scope.`;
+            break;
+        case "redefinition_a_b":
+            mm = `Redefinition of '${a}' from line ${b}.`;
+            break;
+        case "required_a_optional_b":
+            mm = `Required parameter '${a}' after optional parameter '${b}'.`;
+            break;
+        case "reserved_a":
+            mm = `Reserved name '${a}'.`;
+            break;
+        case "subscript_a":
+            mm = `['${a}'] is better written in dot notation.`;
+            break;
+        case "todo_comment":
+            mm = `Unexpected TODO comment.`;
+            break;
+        case "too_long":
+            mm = `Line is longer than 80 characters.`;
+            break;
+        case "too_many_digits":
+            mm = `Too many digits.`;
+            break;
+        case "unclosed_comment":
+            mm = `Unclosed comment.`;
+            break;
+        case "unclosed_disable":
+            mm = (
+                `Directive '/*jslint-disable*/' was not closed`
+                + ` with '/*jslint-enable*/'.`
+            );
+            break;
+        case "unclosed_mega":
+            mm = `Unclosed mega literal.`;
+            break;
+        case "unclosed_string":
+            mm = `Unclosed string.`;
+            break;
+        case "undeclared_a":
+            mm = `Undeclared '${a}'.`;
+            break;
+        case "unexpected_a":
+            mm = `Unexpected '${a}'.`;
+            break;
+        case "unexpected_a_after_b":
+            mm = `Unexpected '${a}' after '${b}'.`;
+            break;
+        case "unexpected_a_before_b":
+            mm = `Unexpected '${a}' before '${b}'.`;
+            break;
+        case "unexpected_at_top_level_a":
+            mm = `Expected '${a}' to be in a function.`;
+            break;
+        case "unexpected_char_a":
+            mm = `Unexpected character '${a}'.`;
+            break;
+        case "unexpected_comment":
+            mm = `Unexpected comment.`;
+            break;
+        case "unexpected_directive_a":
+            mm = `When using modules, don't use directive '/\u002a${a}'.`;
+            break;
+        case "unexpected_expression_a":
+            mm = `Unexpected expression '${a}' in statement position.`;
+            break;
+        case "unexpected_label_a":
+            mm = `Unexpected label '${a}'.`;
+            break;
+        case "unexpected_parens":
+            mm = `Don't wrap function literals in parens.`;
+            break;
+        case "unexpected_space_a_b":
+            mm = `Unexpected space between '${a}' and '${b}'.`;
+            break;
+        case "unexpected_statement_a":
+            mm = `Unexpected statement '${a}' in expression position.`;
+            break;
+        case "unexpected_trailing_space":
+            mm = `Unexpected trailing space.`;
+            break;
+        case "unexpected_typeof_a":
+            mm = (
+                `Unexpected 'typeof'. Use '===' to compare directly with ${a}.`
+            );
+            break;
+        case "uninitialized_a":
+            mm = `Uninitialized '${a}'.`;
+            break;
+        case "unopened_enable":
+            mm = (
+                `Directive '/*jslint-enable*/' was not opened`
+                + ` with '/*jslint-disable*/'.`
+            );
+            break;
+        case "unreachable_a":
+            mm = `Unreachable '${a}'.`;
+            break;
+        case "unregistered_property_a":
+            mm = `Unregistered property name '${a}'.`;
+            break;
+        case "unused_a":
+            mm = `Unused '${a}'.`;
+            break;
+        case "use_double":
+            mm = `Use double quotes, not single quotes.`;
+            break;
+        case "use_open":
+            mm = (
+                `Wrap a ternary expression in parens,`
+                + ` with a line break after the left paren.`
+            );
+            break;
+        case "use_spaces":
+            mm = `Use spaces, not tabs.`;
+            break;
+        case "var_on_top":
+            mm = `Move variable declaration to top of function or script.`;
+            break;
+        case "var_switch":
+            mm = `Don't declare variables in a switch.`;
+            break;
+        case "weird_condition_a":
+            mm = `Weird condition '${a}'.`;
+            break;
+        case "weird_expression_a":
+            mm = `Weird expression '${a}'.`;
+            break;
+        case "weird_loop":
+            mm = `Weird loop.`;
+            break;
+        case "weird_property_a":
+            mm = `Weird property name '${a}'.`;
+            break;
+        case "weird_relation_a":
+            mm = `Weird relation '${a}'.`;
+            break;
+        case "wrap_condition":
+            mm = `Wrap the condition in parens.`;
+            break;
+        case "wrap_immediate":
+            mm = (
+                `Wrap an immediate function invocation in parentheses to assist`
+                + ` the reader in understanding that the expression is the`
+                + ` result of a function, and not the function itself.`
+            );
+            break;
+        case "wrap_parameter":
+            mm = `Wrap the parameter in parens.`;
+            break;
+        case "wrap_regexp":
+            mm = `Wrap this regexp in parens to avoid confusion.`;
+            break;
+        case "wrap_unary":
+            mm = `Wrap the unary expression in parens.`;
+            break;
+        }
+
+// Validate mm.
+
+        assert_or_throw(mm, code);
+        warning.message = mm;
+
+// Include stack_trace for jslint to debug itself for errors.
+
+        if (option_dict.debug) {
+            warning.stack_trace = new Error().stack;
+        }
+        if (warning.directive_quiet) {
+
+// test_cause:
+// ["0 //jslint-quiet", "semicolon", "directive_quiet", "", 0]
+
+            test_cause("directive_quiet");
+            return warning;
+        }
+        warning_list.push(warning);
+        return warning;
+    }
+
+    try {
+
+// tokenize takes a source and produces from it an array of token objects.
+// JavaScript is notoriously difficult to tokenize because of the horrible
+// interactions between automatic semicolon insertion, regular expression
+// literals, and now megastring literals. JSLint benefits from eliminating
+// automatic semicolon insertion and nested megastring literals, which allows
+// full tokenization to precede parsing.
+
+        option_dict = Object.assign(empty(), option_dict);
+        populate(global_list, global_dict, false);
+        populate(standard, global_dict, false);
+        Object.keys(option_dict).forEach(function (name) {
+            const allowed = allowed_option[name];
+            if (option_dict[name] === true && Array.isArray(allowed)) {
+                populate(allowed, global_dict, false);
+            }
+        });
+
+        Object.assign(state, {
+            allowed_option,
+            artifact,
+            catch_list,
+            catch_stack,
+            directive_list,
+            export_dict,
+            function_list,
+            function_stack,
+            global_dict,
+            import_list,
+            is_equal,
+            is_weird,
+            line_list,
+            mode_json: false,           // true if parsing JSON.
+            mode_module: false,         // true if import or export was used.
+            mode_property: false,       // true if directive /*property*/ is
+                                        // used.
+            mode_shebang: false,        // true if #! is seen on the first line.
+            option_dict,
+            property_dict,
+            source,
+            stop,
+            stop_at,
+            syntax_dict,
+            tenure,
+            test_cause,
+            token_global,
+            token_list,
+            token_nxt: token_global,
+            warn,
+            warn_at,
+            warning_list
+        });
+
+// PHASE 1. Split <source> by newlines into <line_list>.
+
+        jslint_phase1_split(state);
+        assert_or_throw(catch_stack.length === 1, `catch_stack.length === 1.`);
+        assert_or_throw(
+            function_stack.length === 0,
+            `function_stack.length === 0.`
+        );
+
+// PHASE 2. Lex <line_list> into <token_list>.
+
+        jslint_phase2_lex(state);
+        assert_or_throw(catch_stack.length === 1, `catch_stack.length === 1.`);
+        assert_or_throw(
+            function_stack.length === 0,
+            `function_stack.length === 0.`
+        );
+
+// PHASE 3. Parse <token_list> into <token_tree> using the Pratt-parser.
+
+        jslint_phase3_parse(state);
+        assert_or_throw(catch_stack.length === 1, `catch_stack.length === 1.`);
+        assert_or_throw(
+            function_stack.length === 0,
+            `function_stack.length === 0.`
+        );
+
+// PHASE 4. Walk <token_tree>, traversing all nodes of the tree. It is a
+//          recursive traversal. Each node may be processed on the way down
+//          (preaction) and on the way up (postaction).
+
+        if (!state.mode_json) {
+            jslint_phase4_walk(state);
+        }
+        assert_or_throw(catch_stack.length === 1, `catch_stack.length === 1.`);
+        assert_or_throw(
+            function_stack.length === 0,
+            `function_stack.length === 0.`
+        );
+
+// PHASE 5. Check whitespace between tokens in <token_list>.
+
+        if (!state.mode_json && warning_list.length === 0) {
+            jslint_phase5_whitage(state);
+        }
+        assert_or_throw(catch_stack.length === 1, `catch_stack.length === 1.`);
+        assert_or_throw(
+            function_stack.length === 0,
+            `function_stack.length === 0.`
+        );
+
+        if (!option_dict.browser) {
+            directive_list.forEach(function (comment) {
+                if (comment.directive === "global") {
+
+// test_cause:
+// ["/*global aa*/", "jslint", "missing_browser", "(comment)", 1]
+
+                    warn("missing_browser", comment);
+                }
+            });
+        }
+        if (option_dict.test_internal_error) {
+            assert_or_throw(undefined, "test_internal_error");
+        }
+    } catch (err) {
+        mode_stop = true;
+        err.message = "[JSLint was unable to finish]\n" + err.message;
+        err.mode_stop = true;
+        if (err.name !== "JSLintError") {
+            Object.assign(err, {
+                column: jslint_fudge,
+                line: jslint_fudge,
+                line_source: "",
+                stack_trace: err.stack
+            });
+        }
+        if (warning_list.indexOf(err) === -1) {
+            warning_list.push(err);
+        }
+    }
+
+// Sort warning_list by mode_stop first, line, column respectively.
+
+    warning_list.sort(function (aa, bb) {
+        return (
+            Boolean(bb.mode_stop) - Boolean(aa.mode_stop)
+            || aa.line - bb.line
+            || aa.column - bb.column
+        );
+
+// Update each warning with formatted_message ready-for-use by jslint_cli.
+
+    }).map(function ({
+        column,
+        line,
+        line_source,
+        message,
+        stack_trace = ""
+    }, ii, list) {
+        list[ii].formatted_message = String(
+            String(ii + 1).padStart(2, " ")
+            + ". \u001b[31m" + message + "\u001b[39m"
+            + " \u001b[90m\/\/ line " + line + ", column " + column
+            + "\u001b[39m\n"
+            + ("    " + line_source.trim()).slice(0, 72) + "\n"
+            + stack_trace
+        ).trimRight();
+    });
+
+    return {
+        causes: cause_dict,
+        directives: directive_list,
+        edition: jslint_edition,
+        exports: export_dict,
+        froms: import_list,
+        functions: function_list,
+        global: token_global,
+        id: "(JSLint)",
+        json: state.mode_json,
+        lines: line_list,
+        module: state.mode_module === true,
+        ok: warning_list.length === 0 && !mode_stop,
+        option: option_dict,
+        property: property_dict,
+        shebang: (
+            state.mode_shebang
+            ? line_list[jslint_fudge].line_source
+            : undefined
+        ),
+        stop: mode_stop,
+        tokens: token_list,
+        tree: state.token_tree,
+        warnings: warning_list
+    };
 }
 
-function populate(array, object = empty(), value = true) {
+async function jslint_cli({
+    cjs_module,
+    cjs_require,
+    console_error,
+    file,
+    mode_force,
+    mode_noop,
+    option,
+    process_exit,
+    source
+}) {
 
-// Augment an object by taking property names from an array of strings.
+// This function will run jslint from nodejs-cli.
 
-    array.forEach(function (name) {
-        object[name] = value;
+    let data;
+    let exit_code = 0;
+    let module_fs;
+    let module_path;
+    let module_url;
+
+    function jslint_from_file({
+        code,
+        file,
+        line_offset = 0,
+        option = empty(),
+        warnings = []
+    }) {
+        option = Object.assign(empty(), option, {
+            file
+        });
+        switch ((
+            /\.\w+?$|$/m
+        ).exec(file)[0]) {
+        case ".html":
+
+// Recursively jslint embedded "<script>\n...\n</script>".
+
+            code.replace((
+                /^<script>\n([\S\s]*?\n)<\/script>$/gm
+            ), function (ignore, match1, ii) {
+                jslint_from_file({
+                    code: match1,
+                    file: file + ".<script>.js",
+                    line_offset: string_line_count(code.slice(0, ii)) + 1,
+                    option: Object.assign(empty(), {
+                        browser: true
+                    }, option)
+                });
+                return "";
+            });
+            return;
+        case ".md":
+
+// Recursively jslint embedded "```javascript\n...\n```".
+
+            code.replace((
+                /^```(?:javascript|js)\n([\S\s]*?\n)```$/gm
+            ), function (ignore, match1, ii) {
+                jslint_from_file({
+                    code: match1,
+                    file: file + ".<```javascript>.js",
+                    line_offset: string_line_count(code.slice(0, ii)) + 1,
+                    option
+                });
+                return "";
+            });
+            return;
+        case ".sh":
+
+// Recursively jslint embedded "node -e '\n...\n'".
+
+            code.replace((
+                /\bnode\u0020.*?-e\u0020'\n([\S\s]*?\n)'/gm
+            ), function (ignore, match1, ii) {
+                jslint_from_file({
+                    code: match1,
+                    file: file + ".<node -e>.js",
+                    line_offset: string_line_count(code.slice(0, ii)) + 1,
+                    option: Object.assign(empty(), {
+                        beta: Boolean(
+                            process.env.JSLINT_BETA
+                            && !(
+                                /0|false|null|undefined/
+                            ).test(process.env.JSLINT_BETA)
+                        ),
+                        node: true
+                    }, option)
+                });
+                return "";
+            });
+            return;
+        default:
+            warnings = jslint(
+                "\n".repeat(line_offset) + code,
+                option
+            ).warnings;
+        }
+
+// Print only first 10 warnings to stderr.
+
+        if (warnings.length > 0) {
+            exit_code = 1;
+            console_error(
+                "\u001b[1mjslint " + file + "\u001b[22m\n"
+                + warnings.slice(0, 10).map(function ({
+                    formatted_message
+                }) {
+                    return formatted_message;
+                }).join("\n")
+            );
+        }
+    }
+
+    function string_line_count(code) {
+
+// This function will count number of newlines in <code>.
+
+        let cnt;
+        let ii;
+
+// https://jsperf.com/regexp-counting-2/8
+
+        cnt = 0;
+        ii = 0;
+        while (true) {
+            ii = code.indexOf("\n", ii) + 1;
+            if (ii === 0) {
+                break;
+            }
+            cnt += 1;
+        }
+        return cnt;
+    }
+
+// Feature-detect nodejs.
+
+    if (!(
+        typeof process === "object"
+        && process
+        && process.versions
+        && typeof process.versions.node === "string"
+        && !mode_noop
+    )) {
+        return exit_code;
+    }
+    console_error = console_error || console.error;
+    module_fs = await import("fs");
+    module_path = await import("path");
+    module_url = await import("url");
+    process_exit = process_exit || process.exit;
+    if (!(
+
+// Feature-detect nodejs-cjs-cli.
+
+        (cjs_module && cjs_require)
+        ? cjs_module === cjs_require.main
+
+// Feature-detect nodejs-esm-cli.
+
+        : (
+            process.execArgv.indexOf("--eval") === -1
+            && process.execArgv.indexOf("-e") === -1
+            && (
+                (
+                    /[\/|\\]jslint(?:\.[cm]?js)?$/m
+                ).test(process.argv[1])
+                || mode_force
+            )
+            && module_url.fileURLToPath(jslint_import_meta_url)
+            === module_path.resolve(process.argv[1])
+        )
+    ) && !mode_force) {
+        return exit_code;
+    }
+
+// Normalize file relative to process.cwd().
+
+    file = file || process.argv[2];
+    if (!file) {
+        return;
+    }
+    file = module_path.resolve(file) + "/";
+    if (file.startsWith(process.cwd() + "/")) {
+        file = file.replace(process.cwd() + "/", "").slice(0, -1) || ".";
+    }
+    file = file.replace((
+        /\\/g
+    ), "/").replace((
+        /\/$/g
+    ), "");
+    if (source) {
+        jslint_from_file({
+            code: source,
+            file,
+            option
+        });
+        process_exit(exit_code);
+        return exit_code;
+    }
+
+// jslint_cli - jslint directory.
+
+    try {
+        data = await module_fs.promises.readdir(file, "utf8");
+    } catch (ignore) {}
+    if (data) {
+        await Promise.all(data.map(async function (file2) {
+            let code;
+            let time_start = Date.now();
+            file2 = file + "/" + file2;
+            switch ((
+                /\.\w+?$|$/m
+            ).exec(file2)[0]) {
+            case ".cjs":
+            case ".html":
+            case ".js":
+            case ".json":
+            case ".md":
+            case ".mjs":
+            case ".sh":
+                break;
+            default:
+                return;
+            }
+            try {
+                code = await module_fs.promises.readFile(file2, "utf8");
+            } catch (ignore) {
+                return;
+            }
+            if (!(
+                !(
+                    /\b(?:lock|min|raw|rollup)\b/
+                ).test(file2) && code && code.length < 1048576
+            )) {
+                return;
+            }
+            jslint_from_file({
+                code,
+                file: file2,
+                option
+            });
+            console_error(
+                "jslint - " + (Date.now() - time_start) + "ms - " + file2
+            );
+        }));
+        process_exit(exit_code);
+        return exit_code;
+    }
+
+// jslint_cli - jslint file.
+
+    try {
+        data = await module_fs.promises.readFile(file, "utf8");
+    } catch (err) {
+        console_error(err);
+        exit_code = 1;
+        process_exit(exit_code);
+        return exit_code;
+    }
+    jslint_from_file({
+        code: data,
+        file,
+        option
     });
-    return object;
+    process_exit(exit_code);
+    return exit_code;
 }
 
 function jslint_phase1_split() {
@@ -296,203 +1548,6 @@ function jslint_phase2_lex(state) {
         return char;
     }
 
-    function char_before() {
-
-// Back up one character by moving a character from the end of the snippet to
-// the front of the line_source.
-
-        char = snippet.slice(-1);
-        line_source = char + line_source;
-        column -= char.length;
-
-// Remove last character from snippet.
-
-        snippet = snippet.slice(0, -1);
-        return char;
-    }
-
-    function read_digits(rx, quiet) {
-        let digits = line_source.match(rx)[0];
-        let length = digits.length;
-        if (!quiet && length === 0) {
-
-// test_cause:
-// ["0x", "read_digits", "expected_digits_after_a", "0x", 2]
-
-            warn_at("expected_digits_after_a", line, column, snippet);
-        }
-        column += length;
-        line_source = line_source.slice(length);
-        snippet += digits;
-        char_after();
-        return length;
-    }
-
-    function read_line() {
-
-// Put the next line of source in line_source. If the line contains tabs,
-// replace them with spaces and give a warning. Also warn if the line contains
-// unsafe characters or is too damn long.
-
-        if (
-            !option_dict.long
-            && line_whole.length > 80
-            && line_disable === undefined
-            && !state.mode_json
-            && token_1
-            && !mode_regexp
-        ) {
-
-// test_cause:
-// ["/////////////////////////////////////////////////////////////////////////////////", "read_line", "too_long", "", 1] //jslint-quiet
-
-            warn_at("too_long", line);
-        }
-        column = 0;
-        line += 1;
-        mode_regexp = false;
-        line_source = undefined;
-        line_whole = "";
-        if (line_list[line] === undefined) {
-            return line_source;
-        }
-        line_source = line_list[line].line_source;
-        line_whole = line_source;
-
-// Scan each line for following ignore-directives:
-// "/*jslint-disable*/"
-// "/*jslint-enable*/"
-// "//jslint-quiet"
-
-        if (line_source === "/*jslint-disable*/") {
-
-// test_cause:
-// ["/*jslint-disable*/", "read_line", "jslint_disable", "", 0]
-
-            test_cause("jslint_disable");
-            line_disable = line;
-        } else if (line_source === "/*jslint-enable*/") {
-            if (line_disable === undefined) {
-
-// test_cause:
-// ["/*jslint-enable*/", "read_line", "unopened_enable", "", 1]
-
-                stop_at("unopened_enable", line);
-            }
-            line_disable = undefined;
-        } else if (line_source.endsWith(" //jslint-quiet")) {
-
-// test_cause:
-// ["0 //jslint-quiet", "read_line", "jslint_quiet", "", 0]
-
-            test_cause("jslint_quiet");
-            line_list[line].directive_quiet = true;
-        }
-        if (line_disable !== undefined) {
-
-// test_cause:
-// ["/*jslint-disable*/\n0", "read_line", "line_disable", "", 0]
-
-            test_cause("line_disable");
-            line_source = "";
-        }
-        if (line_source.indexOf("\t") >= 0) {
-            if (!option_dict.white) {
-
-// test_cause:
-// ["\t", "read_line", "use_spaces", "", 1]
-
-                warn_at("use_spaces", line, line_source.indexOf("\t") + 1);
-            }
-            line_source = line_source.replace((
-                // rx_tab
-                /\t/g
-            ), " ");
-        }
-        if (!option_dict.white && line_source.endsWith(" ")) {
-
-// test_cause:
-// [" ", "read_line", "unexpected_trailing_space", "", 1]
-
-            warn_at("unexpected_trailing_space", line, line_source.length - 1);
-        }
-        return line_source;
-    }
-
-    function token_create(id, value, identifier) {
-
-// Create the token object and append it to token_list.
-
-        let the_token = {
-            from,
-            id,
-            identifier: Boolean(identifier),
-            line,
-            nr: token_list.length,
-            thru: column
-        };
-        token_list.push(the_token);
-
-// Directives must appear before the first statement.
-
-        if (id !== "(comment)" && id !== ";") {
-            mode_directive = false;
-        }
-
-// If the token is to have a value, give it one.
-
-        if (value !== undefined) {
-            the_token.value = value;
-        }
-
-// If this token is an identifier that touches a preceding number, or
-// a "/", comment, or regular expression literal that touches a preceding
-// comment or regular expression literal, then give a missing space warning.
-// This warning is not suppressed by option_dict.white.
-
-        if (
-            token_prv.line === line
-            && token_prv.thru === from
-            && (id === "(comment)" || id === "(regexp)" || id === "/")
-            && (token_prv.id === "(comment)" || token_prv.id === "(regexp)")
-        ) {
-
-// test_cause:
-// ["/**//**/", "token_create", "expected_space_a_b", "(comment)", 5]
-
-            warn(
-                "expected_space_a_b",
-                the_token,
-                artifact(token_prv),
-                artifact(the_token)
-            );
-        }
-        if (token_prv.id === "." && id === "(number)") {
-
-// test_cause:
-// [".0", "token_create", "expected_a_before_b", ".", 1]
-
-            warn("expected_a_before_b", token_prv, "0", ".");
-        }
-        if (token_prv_expr.id === "." && the_token.identifier) {
-            the_token.dot = true;
-        }
-
-// The previous token is used to detect adjacency problems.
-
-        token_prv = the_token;
-
-// The token_prv_expr token is a previous token that was not a comment.
-// The token_prv_expr token
-// is used to disambiguate "/", which can mean division or regular expression
-// literal.
-
-        if (token_prv.id !== "(comment)") {
-            token_prv_expr = token_prv;
-        }
-        return the_token;
-    }
-
     function char_after_escape(extra) {
 
 // Validate char after escape "\\".
@@ -570,6 +1625,21 @@ function jslint_phase2_lex(state) {
 
             warn_at("unexpected_a_before_b", line, column, "\\", char);
         }
+    }
+
+    function char_before() {
+
+// Back up one character by moving a character from the end of the snippet to
+// the front of the line_source.
+
+        char = snippet.slice(-1);
+        line_source = char + line_source;
+        column -= char.length;
+
+// Remove last character from snippet.
+
+        snippet = snippet.slice(0, -1);
+        return char;
     }
 
     function lex_comment() {
@@ -1540,6 +2610,188 @@ function jslint_phase2_lex(state) {
         return token_create(snippet);
     }
 
+    function read_digits(rx, quiet) {
+        let digits = line_source.match(rx)[0];
+        let length = digits.length;
+        if (!quiet && length === 0) {
+
+// test_cause:
+// ["0x", "read_digits", "expected_digits_after_a", "0x", 2]
+
+            warn_at("expected_digits_after_a", line, column, snippet);
+        }
+        column += length;
+        line_source = line_source.slice(length);
+        snippet += digits;
+        char_after();
+        return length;
+    }
+
+    function read_line() {
+
+// Put the next line of source in line_source. If the line contains tabs,
+// replace them with spaces and give a warning. Also warn if the line contains
+// unsafe characters or is too damn long.
+
+        if (
+            !option_dict.long
+            && line_whole.length > 80
+            && line_disable === undefined
+            && !state.mode_json
+            && token_1
+            && !mode_regexp
+        ) {
+
+// test_cause:
+// ["/////////////////////////////////////////////////////////////////////////////////", "read_line", "too_long", "", 1] //jslint-quiet
+
+            warn_at("too_long", line);
+        }
+        column = 0;
+        line += 1;
+        mode_regexp = false;
+        line_source = undefined;
+        line_whole = "";
+        if (line_list[line] === undefined) {
+            return line_source;
+        }
+        line_source = line_list[line].line_source;
+        line_whole = line_source;
+
+// Scan each line for following ignore-directives:
+// "/*jslint-disable*/"
+// "/*jslint-enable*/"
+// "//jslint-quiet"
+
+        if (line_source === "/*jslint-disable*/") {
+
+// test_cause:
+// ["/*jslint-disable*/", "read_line", "jslint_disable", "", 0]
+
+            test_cause("jslint_disable");
+            line_disable = line;
+        } else if (line_source === "/*jslint-enable*/") {
+            if (line_disable === undefined) {
+
+// test_cause:
+// ["/*jslint-enable*/", "read_line", "unopened_enable", "", 1]
+
+                stop_at("unopened_enable", line);
+            }
+            line_disable = undefined;
+        } else if (line_source.endsWith(" //jslint-quiet")) {
+
+// test_cause:
+// ["0 //jslint-quiet", "read_line", "jslint_quiet", "", 0]
+
+            test_cause("jslint_quiet");
+            line_list[line].directive_quiet = true;
+        }
+        if (line_disable !== undefined) {
+
+// test_cause:
+// ["/*jslint-disable*/\n0", "read_line", "line_disable", "", 0]
+
+            test_cause("line_disable");
+            line_source = "";
+        }
+        if (line_source.indexOf("\t") >= 0) {
+            if (!option_dict.white) {
+
+// test_cause:
+// ["\t", "read_line", "use_spaces", "", 1]
+
+                warn_at("use_spaces", line, line_source.indexOf("\t") + 1);
+            }
+            line_source = line_source.replace((
+                // rx_tab
+                /\t/g
+            ), " ");
+        }
+        if (!option_dict.white && line_source.endsWith(" ")) {
+
+// test_cause:
+// [" ", "read_line", "unexpected_trailing_space", "", 1]
+
+            warn_at("unexpected_trailing_space", line, line_source.length - 1);
+        }
+        return line_source;
+    }
+
+    function token_create(id, value, identifier) {
+
+// Create the token object and append it to token_list.
+
+        let the_token = {
+            from,
+            id,
+            identifier: Boolean(identifier),
+            line,
+            nr: token_list.length,
+            thru: column
+        };
+        token_list.push(the_token);
+
+// Directives must appear before the first statement.
+
+        if (id !== "(comment)" && id !== ";") {
+            mode_directive = false;
+        }
+
+// If the token is to have a value, give it one.
+
+        if (value !== undefined) {
+            the_token.value = value;
+        }
+
+// If this token is an identifier that touches a preceding number, or
+// a "/", comment, or regular expression literal that touches a preceding
+// comment or regular expression literal, then give a missing space warning.
+// This warning is not suppressed by option_dict.white.
+
+        if (
+            token_prv.line === line
+            && token_prv.thru === from
+            && (id === "(comment)" || id === "(regexp)" || id === "/")
+            && (token_prv.id === "(comment)" || token_prv.id === "(regexp)")
+        ) {
+
+// test_cause:
+// ["/**//**/", "token_create", "expected_space_a_b", "(comment)", 5]
+
+            warn(
+                "expected_space_a_b",
+                the_token,
+                artifact(token_prv),
+                artifact(the_token)
+            );
+        }
+        if (token_prv.id === "." && id === "(number)") {
+
+// test_cause:
+// [".0", "token_create", "expected_a_before_b", ".", 1]
+
+            warn("expected_a_before_b", token_prv, "0", ".");
+        }
+        if (token_prv_expr.id === "." && the_token.identifier) {
+            the_token.dot = true;
+        }
+
+// The previous token is used to detect adjacency problems.
+
+        token_prv = the_token;
+
+// The token_prv_expr token is a previous token that was not a comment.
+// The token_prv_expr token
+// is used to disambiguate "/", which can mean division or regular expression
+// literal.
+
+        if (token_prv.id !== "(comment)") {
+            token_prv_expr = token_prv;
+        }
+        return the_token;
+    }
+
 // Scan first line for "#!" and ignore it.
 
     if (line_list[jslint_fudge].line_source.startsWith("#!")) {
@@ -1598,7 +2850,6 @@ function jslint_phase3_parse(state) {
         warn_at
     } = state;
     let catchage = catch_stack[0];      // The current catch-block.
-    let function_level_list = [];
     let functionage = token_global;     // The current function.
     let mode_var;               // "var" if using var; "let" if using let.
     let rx_identifier = (
@@ -1612,69 +2863,6 @@ function jslint_phase3_parse(state) {
                                         // ... the parse.
     let token_nxt = token_global;       // The next token to be examined in
                                         // ... <token_list>.
-
-    function check_ordered(type, token_list) {
-
-// This function will warn if <token_list> is unordered.
-
-        token_list.reduce(function (aa, token) {
-            const bb = artifact(token);
-            if (!option_dict.unordered && aa > bb) {
-                warn("expected_a_b_before_c_d", token, type, bb, type, aa);
-            }
-            return bb;
-        }, "");
-    }
-
-    function check_ordered_case(case_list) {
-
-// This function will warn if <case_list> is unordered.
-
-        case_list.filter(identity).map(function (token) {
-            switch (token.identifier || token.id) {
-            case "(number)":
-                return {
-                    order: 1,
-                    token,
-                    type: "number",
-                    value: Number(artifact(token))
-                };
-            case "(string)":
-                return {
-                    order: 2,
-                    token,
-                    type: "string",
-                    value: artifact(token)
-                };
-            case true:
-                return {
-                    order: 3,
-                    token,
-                    type: "identifier",
-                    value: artifact(token)
-                };
-            }
-        }).reduce(function (aa, bb) {
-            if (
-                !option_dict.unordered
-                && aa && bb
-                && (
-                    aa.order > bb.order
-                    || (aa.order === bb.order && aa.value > bb.value)
-                )
-            ) {
-                warn(
-                    "expected_a_b_before_c_d",
-                    bb.token,
-                    `case-${bb.type}`,
-                    bb.value,
-                    `case-${aa.type}`,
-                    aa.value
-                );
-            }
-            return bb;
-        });
-    }
 
     function advance(id, match) {
 
@@ -1739,183 +2927,219 @@ function jslint_phase3_parse(state) {
         }
     }
 
-    function lookahead() {
+    function assignment(id) {
 
-// Look ahead one token without advancing, skipping comments.
+// Create an assignment operator. The one true assignment is different because
+// its left side, when it is a variable, is not treated as an expression.
+// That case is special because that is when a variable gets initialized. The
+// other assignment operators can modify, but they cannot initialize.
 
-        let cadet;
-        let ii = token_ii;
-        while (true) {
-            cadet = token_list[ii];
-            if (cadet.id !== "(comment)") {
-                return cadet;
+        const the_symbol = symbol(id, 20);
+        the_symbol.led = function (left) {
+            const the_token = token_now;
+            let right;
+            the_token.arity = "assignment";
+            right = parse_expression(20 - 1);
+            if (id === "=" && left.arity === "variable") {
+                the_token.names = left;
+                the_token.expression = right;
+            } else {
+                the_token.expression = [left, right];
             }
-            ii += 1;
-        }
+            if (
+                right.arity === "assignment"
+                || right.arity === "preassign"
+                || right.arity === "postassign"
+            ) {
+                warn("unexpected_a", right);
+            }
+            check_mutation(left);
+            return the_token;
+        };
+        return the_symbol;
     }
 
-// Now we parse JavaScript.
+    function block(special) {
 
-    function enroll(name, role, readonly) {
+// Parse a block, a sequence of statements wrapped in braces.
+//  special "body"      The block is a function body.
+//          "ignore"    No warning on an empty block.
+//          "naked"     No advance.
+//          undefined   An ordinary block.
 
-// Enroll a name into the current function context. The role can be exception,
-// function, label, parameter, or variable. We look for variable redefinition
-// because it causes confusion.
+        let stmts;
+        let the_block;
+        if (special !== "naked") {
+            advance("{");
+        }
+        the_block = token_now;
+        if (special !== "body") {
+            functionage.statement_prv = the_block;
+        }
+        the_block.arity = "statement";
+        the_block.body = special === "body";
 
-        const id = name.id;
-        let earlier;
+// Top level function bodies may include the "use strict" pragma.
 
-// Reserved words may not be enrolled.
-
-        if (syntax_dict[id] !== undefined && id !== "ignore") {
+        if (
+            special === "body"
+            && function_stack.length === 1
+            && token_nxt.value === "use strict"
+        ) {
+            token_nxt.statement = true;
+            advance("(string)");
+            advance(";");
+        }
+        stmts = parse_statements();
+        the_block.block = stmts;
+        if (stmts.length === 0) {
+            if (!option_dict.devel && special !== "ignore") {
 
 // test_cause:
-// ["let undefined", "enroll", "reserved_a", "undefined", 5]
+// ["function aa(){}", "block", "empty_block", "{", 14]
 
-            warn("reserved_a", name);
+                warn("empty_block", the_block);
+            }
+            the_block.disrupt = false;
         } else {
+            the_block.disrupt = stmts[stmts.length - 1].disrupt;
+        }
+        advance("}");
+        return the_block;
+    }
 
-// Has the name been enrolled in this context?
+    function check_left(left, right) {
 
-            earlier = functionage.context[id] || catchage.context[id];
-            if (earlier) {
+// Warn if the left is not one of these:
+//      ?.
+//      ?:
+//      e()
+//      e.b
+//      e[b]
+//      identifier
+
+        const id = left.id;
+        if (
+            !left.identifier
+            && (
+                left.arity !== "ternary"
+                || (
+                    !check_left(left.expression[1])
+                    && !check_left(left.expression[2])
+                )
+            )
+            && (
+                left.arity !== "binary"
+                || (id !== "." && id !== "?." && id !== "(" && id !== "[")
+            )
+        ) {
+            warn("unexpected_a", right || token_nxt);
+            return false;
+        }
+        return true;
+    }
+
+    function check_mutation(the_thing) {
+
+// The only expressions that may be assigned to are
+//      e.b
+//      e[b]
+//      v
+//      [destructure]
+//      {destructure}
+
+        if (
+            the_thing.arity !== "variable"
+            && the_thing.id !== "."
+            && the_thing.id !== "["
+            && the_thing.id !== "{"
+        ) {
 
 // test_cause:
-// ["let aa;let aa", "enroll", "redefinition_a_b", "1", 12]
+// ["0=0", "check_mutation", "bad_assignment_a", "0", 1]
 
-                warn("redefinition_a_b", name, name.id, earlier.line);
+            warn("bad_assignment_a", the_thing);
+            return false;
+        }
+        return true;
+    }
 
-// Has the name been enrolled in an outer context?
+    function check_not_top_level(thing) {
 
-            } else {
-                function_stack.forEach(function (value) {
-                    const item = value.context[id];
-                    if (item !== undefined) {
-                        earlier = item;
-                    }
-                });
-                if (earlier) {
-                    if (id === "ignore") {
-                        if (earlier.role === "variable") {
+// Some features should not be at the outermost level.
 
-// test_cause:
-// ["let ignore;function aa(ignore){}", "enroll", "unexpected_a", "ignore", 24]
-
-                            warn("unexpected_a", name);
-                        }
-                    } else {
-                        if (
-                            (
-                                role !== "exception"
-                                || earlier.role !== "exception"
-                            )
-                            && role !== "parameter" && role !== "function"
-                        ) {
+        if (functionage === token_global) {
 
 // test_cause:
 // ["
-// function aa(){try{aa();}catch(aa){aa();}}
-// ", "enroll", "redefinition_a_b", "1", 31]
-// ["function aa(){var aa;}", "enroll", "redefinition_a_b", "1", 19]
+// while(0){}
+// ", "check_not_top_level", "unexpected_at_top_level_a", "while", 1]
 
-                            warn(
-                                "redefinition_a_b",
-                                name,
-                                name.id,
-                                earlier.line
-                            );
-                        }
-                    }
-                }
-
-// Enroll it.
-
-                Object.assign(name, {
-                    dead: true,
-                    init: false,
-                    parent: (
-                        role === "exception"
-                        ? catchage
-                        : functionage
-                    ),
-                    role,
-                    used: 0,
-                    writable: !readonly
-                });
-                name.parent.context[id] = name;
-            }
+            warn("unexpected_at_top_level_a", thing);
         }
     }
 
-    function parse_expression(rbp, initial) {
+    function check_ordered(type, token_list) {
 
-// This is the heart of JSLINT, the Pratt parser. In addition to parsing, it
-// is looking for ad hoc lint patterns. We add .fud to Pratt's model, which is
-// like .nud except that it is only used on the first token of a statement.
-// Having .fud makes it much easier to define statement-oriented languages like
-// JavaScript. I retained Pratt's nomenclature.
-// They are elements of the parsing method called Top Down Operator Precedence.
+// This function will warn if <token_list> is unordered.
 
-// .nud     Null denotation
-// .fud     First null denotation
-// .led     Left denotation
-//  lbp     Left binding power
-//  rbp     Right binding power
-
-// It processes a nud (variable, constant, prefix operator). It will then
-// process leds (infix operators) until the bind powers cause it to stop. It
-// returns the expression's parse tree.
-
-        let left;
-        let the_symbol;
-
-// Statements will have already advanced, so advance now only if the token is
-// not the first of a statement.
-
-        if (!initial) {
-            advance();
-        }
-        the_symbol = syntax_dict[token_now.id];
-        if (the_symbol !== undefined && the_symbol.nud !== undefined) {
-
-// test_cause:
-// ["0", "parse_expression", "symbol", "", 0]
-
-            test_cause("symbol");
-            left = the_symbol.nud();
-        } else if (token_now.identifier) {
-
-// test_cause:
-// ["aa", "parse_expression", "identifier", "", 0]
-
-            test_cause("identifier");
-            left = token_now;
-            left.arity = "variable";
-        } else {
-
-// test_cause:
-// ["!", "parse_expression", "unexpected_a", "(end)", 1]
-// ["/./", "parse_expression", "unexpected_a", "/", 1]
-// ["let aa=`${}`;", "parse_expression", "unexpected_a", "}", 11]
-
-            return stop("unexpected_a", token_now);
-        }
-
-// Parse/loop through each symbol in expression.
-
-        while (true) {
-            the_symbol = syntax_dict[token_nxt.id];
-            if (
-                the_symbol === undefined
-                || the_symbol.led === undefined
-                || the_symbol.lbp <= rbp
-            ) {
-                break;
+        token_list.reduce(function (aa, token) {
+            const bb = artifact(token);
+            if (!option_dict.unordered && aa > bb) {
+                warn("expected_a_b_before_c_d", token, type, bb, type, aa);
             }
-            advance();
-            left = the_symbol.led(left);
-        }
-        return left;
+            return bb;
+        }, "");
+    }
+
+    function check_ordered_case(case_list) {
+
+// This function will warn if <case_list> is unordered.
+
+        case_list.filter(identity).map(function (token) {
+            switch (token.identifier || token.id) {
+            case "(number)":
+                return {
+                    order: 1,
+                    token,
+                    type: "number",
+                    value: Number(artifact(token))
+                };
+            case "(string)":
+                return {
+                    order: 2,
+                    token,
+                    type: "string",
+                    value: artifact(token)
+                };
+            case true:
+                return {
+                    order: 3,
+                    token,
+                    type: "identifier",
+                    value: artifact(token)
+                };
+            }
+        }).reduce(function (aa, bb) {
+            if (
+                !option_dict.unordered
+                && aa && bb
+                && (
+                    aa.order > bb.order
+                    || (aa.order === bb.order && aa.value > bb.value)
+                )
+            ) {
+                warn(
+                    "expected_a_b_before_c_d",
+                    bb.token,
+                    `case-${bb.type}`,
+                    bb.value,
+                    `case-${aa.type}`,
+                    aa.value
+                );
+            }
+            return bb;
+        });
     }
 
     function condition() {
@@ -2017,321 +3241,6 @@ function jslint_phase3_parse(state) {
         return the_value;
     }
 
-    function semicolon() {
-
-// Try to match a semicolon.
-
-        if (token_nxt.id === ";") {
-            advance(";");
-        } else {
-
-// test_cause:
-// ["0", "semicolon", "expected_a_b", "(end)", 1]
-
-            warn_at(
-                "expected_a_b",
-                token_now.line,
-                token_now.thru + 1,
-                ";",
-                artifact()
-            );
-        }
-        anon = "anonymous";
-    }
-
-    function parse_statement() {
-
-// Parse a statement. Any statement may have a label, but only four statements
-// have use for one. A statement can be one of the standard statements, or
-// an assignment expression, or an invocation expression.
-
-        let first;
-        let the_label;
-        let the_statement;
-        let the_symbol;
-        advance();
-        if (token_now.identifier && token_nxt.id === ":") {
-            the_label = token_now;
-            if (the_label.id === "ignore") {
-
-// test_cause:
-// ["ignore:", "parse_statement", "unexpected_a", "ignore", 1]
-
-                warn("unexpected_a", the_label);
-            }
-            advance(":");
-            if (
-                token_nxt.id === "do"
-                || token_nxt.id === "for"
-                || token_nxt.id === "switch"
-                || token_nxt.id === "while"
-            ) {
-                enroll(the_label, "label", true);
-                the_label.init = true;
-                the_label.dead = false;
-                the_statement = parse_statement();
-                functionage.last_statement = the_statement;
-                the_statement.label = the_label;
-                the_statement.statement = true;
-                return the_statement;
-            }
-            advance();
-
-// test_cause:
-// ["aa:", "parse_statement", "unexpected_label_a", "aa", 1]
-
-            warn("unexpected_label_a", the_label);
-        }
-
-// Parse the statement.
-
-        first = token_now;
-        first.statement = true;
-        the_symbol = syntax_dict[first.id];
-        if (
-            the_symbol !== undefined
-            && the_symbol.fud !== undefined
-
-// Bugfix - Fixes issues #316, #317 - dynamic-import().
-
-            && !(the_symbol.id === "import" && token_nxt.id === "(")
-        ) {
-            the_symbol.disrupt = false;
-            the_symbol.statement = true;
-            token_now.arity = "statement";
-            the_statement = the_symbol.fud();
-            functionage.last_statement = the_statement;
-        } else {
-
-// It is an expression statement.
-
-            the_statement = parse_expression(0, true);
-            functionage.last_statement = the_statement;
-            if (the_statement.wrapped && the_statement.id !== "(") {
-
-// test_cause:
-// ["(0)", "parse_statement", "unexpected_a", "(", 1]
-
-                warn("unexpected_a", first);
-            }
-            semicolon();
-        }
-        if (the_label !== undefined) {
-            the_label.dead = true;
-        }
-        return the_statement;
-    }
-
-    function parse_statements() {
-
-// Parse a list of statements. Give a warning if an unreachable statement
-// follows a disruptive statement.
-
-        const statement_list = [];
-        let a_statement;
-        let disrupt = false;
-
-// Parse/loop each statement until a statement-terminator is reached.
-
-        while (true) {
-            switch (token_nxt.id) {
-            case "(end)":
-            case "case":
-            case "default":
-            case "else":
-            case "}":
-
-// test_cause:
-// [";", "parse_statements", "closer", "", 0]
-// ["case", "parse_statements", "closer", "", 0]
-// ["default", "parse_statements", "closer", "", 0]
-// ["else", "parse_statements", "closer", "", 0]
-// ["}", "parse_statements", "closer", "", 0]
-
-                test_cause("closer");
-                return statement_list;
-            }
-            a_statement = parse_statement();
-            statement_list.push(a_statement);
-            if (disrupt) {
-
-// test_cause:
-// ["while(0){break;0;}", "parse_statements", "unreachable_a", "0", 16]
-
-                warn("unreachable_a", a_statement);
-            }
-            disrupt = a_statement.disrupt;
-        }
-    }
-
-    function check_not_top_level(thing) {
-
-// Some features should not be at the outermost level.
-
-        if (functionage === token_global) {
-
-// test_cause:
-// ["
-// while(0){}
-// ", "check_not_top_level", "unexpected_at_top_level_a", "while", 1]
-
-            warn("unexpected_at_top_level_a", thing);
-        }
-    }
-
-    function block(special) {
-
-// Parse a block, a sequence of statements wrapped in braces.
-//  special "body"      The block is a function body.
-//          "ignore"    No warning on an empty block.
-//          "naked"     No advance.
-//          undefined   An ordinary block.
-
-        let stmts;
-        let the_block;
-        if (special !== "naked") {
-            advance("{");
-        }
-        the_block = token_now;
-        if (special !== "body") {
-            functionage.last_statement = the_block;
-        }
-        the_block.arity = "statement";
-        the_block.body = special === "body";
-
-// Top level function bodies may include the "use strict" pragma.
-
-        if (
-            special === "body"
-            && function_stack.length === 1
-            && token_nxt.value === "use strict"
-        ) {
-            token_nxt.statement = true;
-            advance("(string)");
-            advance(";");
-        }
-        stmts = parse_statements();
-        the_block.block = stmts;
-        if (stmts.length === 0) {
-            if (!option_dict.devel && special !== "ignore") {
-
-// test_cause:
-// ["function aa(){}", "block", "empty_block", "{", 14]
-
-                warn("empty_block", the_block);
-            }
-            the_block.disrupt = false;
-        } else {
-            the_block.disrupt = stmts[stmts.length - 1].disrupt;
-        }
-        advance("}");
-        return the_block;
-    }
-
-    function check_mutation(the_thing) {
-
-// The only expressions that may be assigned to are
-//      e.b
-//      e[b]
-//      v
-//      [destructure]
-//      {destructure}
-
-        if (
-            the_thing.arity !== "variable"
-            && the_thing.id !== "."
-            && the_thing.id !== "["
-            && the_thing.id !== "{"
-        ) {
-
-// test_cause:
-// ["0=0", "check_mutation", "bad_assignment_a", "0", 1]
-
-            warn("bad_assignment_a", the_thing);
-            return false;
-        }
-        return true;
-    }
-
-    function check_left(left, right) {
-
-// Warn if the left is not one of these:
-//      ?.
-//      ?:
-//      e()
-//      e.b
-//      e[b]
-//      identifier
-
-        const id = left.id;
-        if (
-            !left.identifier
-            && (
-                left.arity !== "ternary"
-                || (
-                    !check_left(left.expression[1])
-                    && !check_left(left.expression[2])
-                )
-            )
-            && (
-                left.arity !== "binary"
-                || (id !== "." && id !== "?." && id !== "(" && id !== "[")
-            )
-        ) {
-            warn("unexpected_a", right || token_nxt);
-            return false;
-        }
-        return true;
-    }
-
-// These functions are used to specify the grammar of our language:
-
-    function symbol(id, bp) {
-
-// Create a symbol if it does not already exist in the language's syntax.
-
-        let the_symbol = syntax_dict[id];
-        if (the_symbol === undefined) {
-            the_symbol = empty();
-            the_symbol.id = id;
-            the_symbol.lbp = bp || 0;
-            syntax_dict[id] = the_symbol;
-        }
-        return the_symbol;
-    }
-
-    function assignment(id) {
-
-// Create an assignment operator. The one true assignment is different because
-// its left side, when it is a variable, is not treated as an expression.
-// That case is special because that is when a variable gets initialized. The
-// other assignment operators can modify, but they cannot initialize.
-
-        const the_symbol = symbol(id, 20);
-        the_symbol.led = function (left) {
-            const the_token = token_now;
-            let right;
-            the_token.arity = "assignment";
-            right = parse_expression(20 - 1);
-            if (id === "=" && left.arity === "variable") {
-                the_token.names = left;
-                the_token.expression = right;
-            } else {
-                the_token.expression = [left, right];
-            }
-            if (
-                right.arity === "assignment"
-                || right.arity === "pre"
-                || right.arity === "post"
-            ) {
-                warn("unexpected_a", right);
-            }
-            check_mutation(left);
-            return the_token;
-        };
-        return the_symbol;
-    }
-
     function constant(id, type, value) {
 
 // Create a constant symbol.
@@ -2354,7 +3263,182 @@ function jslint_phase3_parse(state) {
         return the_symbol;
     }
 
-    function infix(id, bp, f) {
+    function constant_Function() {
+        if (!option_dict.eval) {
+
+// test_cause:
+// ["Function", "constant_Function", "unexpected_a", "Function", 1]
+
+            warn("unexpected_a", token_now);
+        } else if (token_nxt.id !== "(") {
+
+// test_cause:
+// ["
+// /*jslint eval*/
+// Function
+// ", "constant_Function", "expected_a_before_b", "(end)", 1]
+
+            warn("expected_a_before_b", token_nxt, "(", artifact());
+        }
+        return token_now;
+    }
+
+    function constant_arguments() {
+
+// test_cause:
+// ["arguments", "constant_arguments", "unexpected_a", "arguments", 1]
+
+        warn("unexpected_a", token_now);
+        return token_now;
+    }
+
+    function constant_eval() {
+        if (!option_dict.eval) {
+
+// test_cause:
+// ["eval", "constant_eval", "unexpected_a", "eval", 1]
+
+            warn("unexpected_a", token_now);
+        } else if (token_nxt.id !== "(") {
+
+// test_cause:
+// ["/*jslint eval*/\neval", "constant_eval", "expected_a_before_b", "(end)", 1]
+
+            warn("expected_a_before_b", token_nxt, "(", artifact());
+        }
+        return token_now;
+    }
+
+    function constant_ignore() {
+
+// test_cause:
+// ["ignore", "constant_ignore", "unexpected_a", "ignore", 1]
+
+        warn("unexpected_a", token_now);
+        return token_now;
+    }
+
+    function constant_isInfinite() {
+
+// test_cause:
+// ["isFinite", "constant_isInfinite", "expected_a_b", "isFinite", 1]
+
+        warn("expected_a_b", token_now, "Number.isFinite", "isFinite");
+        return token_now;
+    }
+
+    function constant_isNaN() {
+
+// test_cause:
+// ["isNaN(0)", "constant_isNaN", "number_isNaN", "isNaN", 1]
+
+        warn("number_isNaN", token_now);
+        return token_now;
+    }
+
+    function constant_this() {
+        if (!option_dict.this) {
+
+// test_cause:
+// ["this", "constant_this", "unexpected_a", "this", 1]
+
+            warn("unexpected_a", token_now);
+        }
+        return token_now;
+    }
+
+    function enroll(name, role, readonly) {
+
+// Enroll a name into the current function context. The role can be exception,
+// function, label, parameter, or variable. We look for variable redefinition
+// because it causes confusion.
+
+        const id = name.id;
+        let earlier;
+
+// Reserved words may not be enrolled.
+
+        if (syntax_dict[id] !== undefined && id !== "ignore") {
+
+// test_cause:
+// ["let undefined", "enroll", "reserved_a", "undefined", 5]
+
+            warn("reserved_a", name);
+        } else {
+
+// Has the name been enrolled in this context?
+
+            earlier = functionage.context[id] || catchage.context[id];
+            if (earlier) {
+
+// test_cause:
+// ["let aa;let aa", "enroll", "redefinition_a_b", "1", 12]
+
+                warn("redefinition_a_b", name, name.id, earlier.line);
+
+// Has the name been enrolled in an outer context?
+
+            } else {
+                function_stack.forEach(function (value) {
+                    const item = value.context[id];
+                    if (item !== undefined) {
+                        earlier = item;
+                    }
+                });
+                if (earlier) {
+                    if (id === "ignore") {
+                        if (earlier.role === "variable") {
+
+// test_cause:
+// ["let ignore;function aa(ignore){}", "enroll", "unexpected_a", "ignore", 24]
+
+                            warn("unexpected_a", name);
+                        }
+                    } else {
+                        if (
+                            (
+                                role !== "exception"
+                                || earlier.role !== "exception"
+                            )
+                            && role !== "parameter" && role !== "function"
+                        ) {
+
+// test_cause:
+// ["
+// function aa(){try{aa();}catch(aa){aa();}}
+// ", "enroll", "redefinition_a_b", "1", 31]
+// ["function aa(){var aa;}", "enroll", "redefinition_a_b", "1", 19]
+
+                            warn(
+                                "redefinition_a_b",
+                                name,
+                                name.id,
+                                earlier.line
+                            );
+                        }
+                    }
+                }
+
+// Enroll it.
+
+                Object.assign(name, {
+                    dead: true,
+                    init: false,
+                    parent: (
+                        role === "exception"
+                        ? catchage
+                        : functionage
+                    ),
+                    role,
+                    used: 0,
+                    writable: !readonly
+                });
+                name.parent.context[id] = name;
+            }
+        }
+    }
+
+    function infix(bp, id, f) {
 
 // Create an infix operator.
 
@@ -2371,327 +3455,97 @@ function jslint_phase3_parse(state) {
         return the_symbol;
     }
 
-    function infixr(id, bp) {
-
-// Create a right associative infix operator.
-
-        const the_symbol = symbol(id, bp);
-        the_symbol.led = function parse_infixr_led(left) {
-            const the_token = token_now;
-
-// test_cause:
-// ["0**0", "parse_infixr_led", "led", "", 0]
-
-            test_cause("led");
-            the_token.arity = "binary";
-            the_token.expression = [left, parse_expression(bp - 1)];
-            return the_token;
-        };
-        return the_symbol;
-    }
-
-    function post(id) {
-
-// Create one of the post operators.
-
-        const the_symbol = symbol(id, 150);
-        the_symbol.led = function (left) {
-            token_now.expression = left;
-            token_now.arity = "post";
-            check_mutation(token_now.expression);
-            return token_now;
-        };
-        return the_symbol;
-    }
-
-    function pre(id) {
-
-// Create one of the pre operators.
-
-        const the_symbol = symbol(id);
-        the_symbol.nud = function () {
-            const the_token = token_now;
-            the_token.arity = "pre";
-            the_token.expression = parse_expression(150);
-            check_mutation(the_token.expression);
-            return the_token;
-        };
-        return the_symbol;
-    }
-
-    function prefix(id, f) {
-
-// Create a prefix operator.
-
-        const the_symbol = symbol(id);
-        the_symbol.nud = function () {
-            const the_token = token_now;
-            the_token.arity = "unary";
-            if (typeof f === "function") {
-                return f();
-            }
-            the_token.expression = parse_expression(150);
-            return the_token;
-        };
-        return the_symbol;
-    }
-
-    function stmt(id, fud) {
-
-// Create a statement.
-
-        const the_symbol = symbol(id);
-        the_symbol.fud = fud;
-        return the_symbol;
-    }
-
-    function survey(name) {
-        let id = name.id;
-
-// Tally the property name. If it is a string, only tally strings that conform
-// to the identifier rules.
-
-        if (id === "(string)") {
-            id = name.value;
-            if (!rx_identifier.test(id)) {
-                return id;
-            }
-        } else if (id === "`") {
-            if (name.value.length === 1) {
-                id = name.value[0].value;
-                if (!rx_identifier.test(id)) {
-                    return id;
-                }
-            }
-        } else if (!name.identifier) {
+    function infix_dot(left) {
+        const the_token = token_now;
+        let name;
+        name = token_nxt;
+        if (
+            (
+                left.id !== "(string)"
+                || (name.id !== "indexOf" && name.id !== "repeat")
+            )
+            && (
+                left.id !== "["
+                || (
+                    name.id !== "concat"
+                    && name.id !== "forEach"
+                    && name.id !== "join"
+                    && name.id !== "map"
+                )
+            )
+            && (left.id !== "+" || name.id !== "slice")
+            && (
+                left.id !== "(regexp)"
+                || (name.id !== "exec" && name.id !== "test")
+            )
+        ) {
 
 // test_cause:
-// ["let aa={0:0}", "survey", "expected_identifier_a", "0", 9]
+// ["\"\".aa", "check_left", "unexpected_a", ".", 3]
 
-            return stop("expected_identifier_a", name);
+            check_left(left, the_token);
+        }
+        if (!name.identifier) {
+
+// test_cause:
+// ["aa.0", "infix_dot", "expected_identifier_a", "0", 4]
+
+            stop("expected_identifier_a");
+        }
+        advance();
+        survey(name);
+
+// The property name is not an expression.
+
+        the_token.name = name;
+        the_token.expression = left;
+        return the_token;
+    }
+
+    function infix_fart_unwrapped(left) {
+
+// test_cause:
+// ["aa=>0", "infix_fart_unwrapped", "wrap_parameter", "aa", 1]
+
+        return stop("wrap_parameter", left);
+    }
+
+    function infix_grave(left) {
+        const the_tick = prefix_tick();
+
+// test_cause:
+// ["0``", "check_left", "unexpected_a", "`", 2]
+
+        check_left(left, the_tick);
+        the_tick.expression = [left].concat(the_tick.expression);
+        return the_tick;
+    }
+
+    function infix_lbracket(left) {
+        const the_token = token_now;
+        let name;
+        let the_subscript = parse_expression(0);
+        if (the_subscript.id === "(string)" || the_subscript.id === "`") {
+            name = survey(the_subscript);
+            if (rx_identifier.test(name)) {
+
+// test_cause:
+// ["aa[`aa`]", "infix_lbracket", "subscript_a", "aa", 4]
+
+                warn("subscript_a", the_subscript, name);
+            }
         }
 
-// If we have seen this name before, increment its count.
-
-        if (typeof property_dict[id] === "number") {
-            property_dict[id] += 1;
-
-// If this is the first time seeing this property name, and if there is a
-// tenure list, then it must be on the list. Otherwise, it must conform to
-// the rules for good property names.
-
-        } else {
-            if (state.mode_property) {
-                if (tenure[id] !== true) {
-
 // test_cause:
-// ["/*property aa*/\naa.bb", "survey", "unregistered_property_a", "bb", 4]
+// ["0[0]", "check_left", "unexpected_a", "[", 2]
 
-                    warn("unregistered_property_a", name);
-                }
-            } else if (
-                !option_dict.name
-                && name.identifier
-                && (
-                    // rx_weird_property
-                    /^_|\$|Sync$|_$/m
-                ).test(id)
-            ) {
-
-// test_cause:
-// ["aa.$", "survey", "weird_property_a", "$", 4]
-// ["aa._", "survey", "weird_property_a", "_", 4]
-// ["aa._aa", "survey", "weird_property_a", "_aa", 4]
-// ["aa.aaSync", "survey", "weird_property_a", "aaSync", 4]
-// ["aa.aa_", "survey", "weird_property_a", "aa_", 4]
-
-                warn("weird_property_a", name);
-            }
-            property_dict[id] = 1;
-        }
-        return id;
+        check_left(left, the_token);
+        the_token.expression = [left, the_subscript];
+        advance("]");
+        return the_token;
     }
 
-    function ternary(id1, id2) {
-
-// Create a ternary operator.
-
-        const the_symbol = symbol(id1, 30);
-        the_symbol.led = function parse_ternary_led(left) {
-            const the_token = token_now;
-            let second;
-            second = parse_expression(20);
-            advance(id2);
-            token_now.arity = "ternary";
-            the_token.arity = "ternary";
-            the_token.expression = [left, second, parse_expression(10)];
-            if (token_nxt.id !== ")") {
-
-// test_cause:
-// ["0?0:0", "parse_ternary_led", "use_open", "?", 2]
-
-                warn("use_open", the_token);
-            }
-            return the_token;
-        };
-        return the_symbol;
-    }
-
-// Begin defining the language.
-
-    symbol("}");
-    symbol(")");
-    symbol("]");
-    symbol(",");
-    symbol(";");
-    symbol(":");
-    symbol("*/");
-    symbol("async");
-    symbol("await");
-    symbol("case");
-    symbol("catch");
-    symbol("class");
-    symbol("default");
-    symbol("else");
-    symbol("enum");
-    symbol("finally");
-    symbol("implements");
-    symbol("interface");
-    symbol("package");
-    symbol("private");
-    symbol("protected");
-    symbol("public");
-    symbol("static");
-    symbol("super");
-    symbol("void");
-    symbol("yield");
-
-    constant("(number)", "number");
-    constant("(regexp)", "regexp");
-    constant("(string)", "string");
-    constant("arguments", "object", function const_arguments() {
-
-// test_cause:
-// ["arguments", "const_arguments", "unexpected_a", "arguments", 1]
-
-        warn("unexpected_a", token_now);
-        return token_now;
-    });
-    constant("eval", "function", function const_eval() {
-        if (!option_dict.eval) {
-
-// test_cause:
-// ["eval", "const_eval", "unexpected_a", "eval", 1]
-
-            warn("unexpected_a", token_now);
-        } else if (token_nxt.id !== "(") {
-
-// test_cause:
-// ["/*jslint eval*/\neval", "const_eval", "expected_a_before_b", "(end)", 1]
-
-            warn("expected_a_before_b", token_nxt, "(", artifact());
-        }
-        return token_now;
-    });
-    constant("false", "boolean", false);
-    constant("Function", "function", function const_Function() {
-        if (!option_dict.eval) {
-
-// test_cause:
-// ["Function", "const_Function", "unexpected_a", "Function", 1]
-
-            warn("unexpected_a", token_now);
-        } else if (token_nxt.id !== "(") {
-
-// test_cause:
-// ["
-// /*jslint eval*/
-// Function
-// ", "const_Function", "expected_a_before_b", "(end)", 1]
-
-            warn("expected_a_before_b", token_nxt, "(", artifact());
-        }
-        return token_now;
-    });
-    constant("ignore", "undefined", function const_ignore() {
-
-// test_cause:
-// ["ignore", "const_ignore", "unexpected_a", "ignore", 1]
-
-        warn("unexpected_a", token_now);
-        return token_now;
-    });
-    constant("Infinity", "number", Infinity);
-    constant("isFinite", "function", function const_isInfinite() {
-
-// test_cause:
-// ["isFinite", "const_isInfinite", "expected_a_b", "isFinite", 1]
-
-        warn("expected_a_b", token_now, "Number.isFinite", "isFinite");
-        return token_now;
-    });
-    constant("isNaN", "function", function const_isNaN() {
-
-// test_cause:
-// ["isNaN(0)", "const_isNaN", "number_isNaN", "isNaN", 1]
-
-        warn("number_isNaN", token_now);
-        return token_now;
-    });
-    constant("NaN", "number", NaN);
-    constant("null", "null", null);
-    constant("this", "object", function const_this() {
-        if (!option_dict.this) {
-
-// test_cause:
-// ["this", "const_this", "unexpected_a", "this", 1]
-
-            warn("unexpected_a", token_now);
-        }
-        return token_now;
-    });
-    constant("true", "boolean", true);
-    constant("undefined", "undefined");
-
-    assignment("=");
-    assignment("+=");
-    assignment("-=");
-    assignment("*=");
-    assignment("/=");
-    assignment("%=");
-    assignment("&=");
-    assignment("|=");
-    assignment("^=");
-    assignment("<<=");
-    assignment(">>=");
-    assignment(">>>=");
-
-    infix("??", 35);
-    infix("||", 40);
-    infix("&&", 50);
-    infix("|", 70);
-    infix("^", 80);
-    infix("&", 90);
-    infix("==", 100);
-    infix("===", 100);
-    infix("!=", 100);
-    infix("!==", 100);
-    infix("<", 110);
-    infix(">", 110);
-    infix("<=", 110);
-    infix(">=", 110);
-    infix("in", 110);
-    infix("instanceof", 110);
-    infix("<<", 120);
-    infix(">>", 120);
-    infix(">>>", 120);
-    infix("+", 130);
-    infix("-", 130);
-    infix("*", 140);
-    infix("/", 140);
-    infix("%", 140);
-    infixr("**", 150);
-    infix("(", 160, function infix_lparen(left) {
+    function infix_lparen(left) {
         const the_paren = token_now;
         let ellipsis;
         let the_argument;
@@ -2755,54 +3609,9 @@ function jslint_phase3_parse(state) {
             the_paren.free = false;
         }
         return the_paren;
-    });
-    infix(".", 170, function infix_dot(left) {
-        const the_token = token_now;
-        let name;
-        name = token_nxt;
-        if (
-            (
-                left.id !== "(string)"
-                || (name.id !== "indexOf" && name.id !== "repeat")
-            )
-            && (
-                left.id !== "["
-                || (
-                    name.id !== "concat"
-                    && name.id !== "forEach"
-                    && name.id !== "join"
-                    && name.id !== "map"
-                )
-            )
-            && (left.id !== "+" || name.id !== "slice")
-            && (
-                left.id !== "(regexp)"
-                || (name.id !== "exec" && name.id !== "test")
-            )
-        ) {
+    }
 
-// test_cause:
-// ["\"\".aa", "check_left", "unexpected_a", ".", 3]
-
-            check_left(left, the_token);
-        }
-        if (!name.identifier) {
-
-// test_cause:
-// ["aa.0", "infix_dot", "expected_identifier_a", "0", 4]
-
-            stop("expected_identifier_a");
-        }
-        advance();
-        survey(name);
-
-// The property name is not an expression.
-
-        the_token.name = name;
-        the_token.expression = left;
-        return the_token;
-    });
-    infix("?.", 170, function infix_option_chain(left) {
+    function infix_option_chain(left) {
         const the_token = token_now;
         let name;
         name = token_nxt;
@@ -2854,166 +3663,710 @@ function jslint_phase3_parse(state) {
         the_token.name = name;
         the_token.expression = left;
         return the_token;
-    });
-    infix("[", 170, function infix_lbracket(left) {
-        const the_token = token_now;
-        let name;
-        let the_subscript = parse_expression(0);
-        if (the_subscript.id === "(string)" || the_subscript.id === "`") {
-            name = survey(the_subscript);
-            if (rx_identifier.test(name)) {
-
-// test_cause:
-// ["aa[`aa`]", "infix_lbracket", "subscript_a", "aa", 4]
-
-                warn("subscript_a", the_subscript, name);
-            }
-        }
-
-// test_cause:
-// ["0[0]", "check_left", "unexpected_a", "[", 2]
-
-        check_left(left, the_token);
-        the_token.expression = [left, the_subscript];
-        advance("]");
-        return the_token;
-    });
-    infix("=>", 170, function infix_fart_unwrapped(left) {
-
-// test_cause:
-// ["aa=>0", "infix_fart_unwrapped", "wrap_parameter", "aa", 1]
-
-        return stop("wrap_parameter", left);
-    });
-
-    function parse_tick() {
-        const the_tick = token_now;
-        the_tick.value = [];
-        the_tick.expression = [];
-        if (token_nxt.id !== "`") {
-
-// Parse/loop through each token in `${...}`.
-
-            while (true) {
-                advance("(string)");
-                the_tick.value.push(token_now);
-                if (token_nxt.id !== "${") {
-                    break;
-                }
-                advance("${");
-
-// test_cause:
-// ["let aa=`${}`;", "parse_tick", "${", "", 0]
-
-                test_cause("${");
-                the_tick.expression.push(parse_expression(0));
-                advance("}");
-            }
-        }
-        advance("`");
-        return the_tick;
     }
 
-    infix("`", 160, function infix_grave(left) {
-        const the_tick = parse_tick();
+    function infixr(bp, id) {
+
+// Create a right associative infix operator.
+
+        const the_symbol = symbol(id, bp);
+        the_symbol.led = function parse_infixr_led(left) {
+            const the_token = token_now;
 
 // test_cause:
-// ["0``", "check_left", "unexpected_a", "`", 2]
+// ["0**0", "parse_infixr_led", "led", "", 0]
 
-        check_left(left, the_tick);
-        the_tick.expression = [left].concat(the_tick.expression);
-        return the_tick;
-    });
+            test_cause("led");
+            the_token.arity = "binary";
+            the_token.expression = [left, parse_expression(bp - 1)];
+            return the_token;
+        };
+        return the_symbol;
+    }
 
-    post("++");
-    post("--");
-    pre("++");
-    pre("--");
+    function lookahead() {
 
-    prefix("+");
-    prefix("-");
-    prefix("~");
-    prefix("!");
-    prefix("!!");
-    prefix("[", function prefix_lbracket() {
-        const the_token = token_now;
-        let element;
-        let ellipsis;
-        the_token.expression = [];
-        if (token_nxt.id !== "]") {
+// Look ahead one token without advancing, skipping comments.
 
-// Parse/loop through each element in [...].
+        let cadet;
+        let ii = token_ii;
+        while (true) {
+            cadet = token_list[ii];
+            if (cadet.id !== "(comment)") {
+                return cadet;
+            }
+            ii += 1;
+        }
+    }
 
-            while (true) {
-                ellipsis = false;
-                if (token_nxt.id === "...") {
-                    ellipsis = true;
-                    advance("...");
-                }
-                element = parse_expression(10);
-                if (ellipsis) {
-                    element.ellipsis = true;
-                }
-                the_token.expression.push(element);
-                if (token_nxt.id !== ",") {
-                    break;
-                }
-                advance(",");
-                if (token_nxt.id === "]") {
+    function parse_expression(rbp, initial) {
+
+// This is the heart of JSLINT, the Pratt parser. In addition to parsing, it
+// is looking for ad hoc lint patterns. We add .fud to Pratt's model, which is
+// like .nud except that it is only used on the first token of a statement.
+// Having .fud makes it much easier to define statement-oriented languages like
+// JavaScript. I retained Pratt's nomenclature.
+// They are elements of the parsing method called Top Down Operator Precedence.
+
+// .nud     Null denotation
+// .fud     First null denotation
+// .led     Left denotation
+//  lbp     Left binding power
+//  rbp     Right binding power
+
+// It processes a nud (variable, constant, prefix operator). It will then
+// process leds (infix operators) until the bind powers cause it to stop. It
+// returns the expression's parse tree.
+
+        let left;
+        let the_symbol;
+
+// Statements will have already advanced, so advance now only if the token is
+// not the first of a statement.
+
+        if (!initial) {
+            advance();
+        }
+        the_symbol = syntax_dict[token_now.id];
+        if (the_symbol !== undefined && the_symbol.nud !== undefined) {
 
 // test_cause:
-// ["let aa=[0,]", "prefix_lbracket", "unexpected_a", ",", 10]
+// ["0", "parse_expression", "symbol", "", 0]
 
-                    warn("unexpected_a", token_now);
-                    break;
+            test_cause("symbol");
+            left = the_symbol.nud();
+        } else if (token_now.identifier) {
+
+// test_cause:
+// ["aa", "parse_expression", "identifier", "", 0]
+
+            test_cause("identifier");
+            left = token_now;
+            left.arity = "variable";
+        } else {
+
+// test_cause:
+// ["!", "parse_expression", "unexpected_a", "(end)", 1]
+// ["/./", "parse_expression", "unexpected_a", "/", 1]
+// ["let aa=`${}`;", "parse_expression", "unexpected_a", "}", 11]
+
+            return stop("unexpected_a", token_now);
+        }
+
+// Parse/loop through each symbol in expression.
+
+        while (true) {
+            the_symbol = syntax_dict[token_nxt.id];
+            if (
+                the_symbol === undefined
+                || the_symbol.led === undefined
+                || the_symbol.lbp <= rbp
+            ) {
+                break;
+            }
+            advance();
+            left = the_symbol.led(left);
+        }
+        return left;
+    }
+
+    function parse_fart(pl) {
+        let the_fart;
+        advance("=>");
+        the_fart = token_now;
+        the_fart.arity = "binary";
+        the_fart.name = "=>";
+        the_fart.level = functionage.level + 1;
+        function_list.push(the_fart);
+        if (functionage.loop > 0) {
+
+// test_cause:
+// ["while(0){aa.map(()=>0);}", "parse_fart", "function_in_loop", "=>", 19]
+
+            warn("function_in_loop", the_fart);
+        }
+
+// Give the function properties storing its names and for observing the depth
+// of loops and switches.
+
+        the_fart.context = empty();
+        the_fart.finally = 0;
+        the_fart.loop = 0;
+        the_fart.switch = 0;
+        the_fart.try = 0;
+
+// Push the current function context and establish a new one.
+
+        function_stack.push(functionage);
+        functionage = the_fart;
+        the_fart.parameters = pl[0];
+        the_fart.signature = pl[1];
+        the_fart.parameters.forEach(function (name) {
+
+// test_cause:
+// ["(aa)=>{}", "parse_fart", "parameter", "", 0]
+
+            test_cause("parameter");
+            enroll(name, "parameter", true);
+        });
+        if (token_nxt.id === "{") {
+
+// test_cause:
+// ["()=>{}", "parse_fart", "expected_a_b", "=>", 3]
+
+            warn("expected_a_b", the_fart, "function", "=>");
+            the_fart.block = block("body");
+        } else {
+            the_fart.expression = parse_expression(0);
+        }
+        functionage = function_stack.pop();
+        return the_fart;
+    }
+
+    function parse_json() {
+        let container;
+        let is_dup;
+        let name;
+        let negative;
+        switch (token_nxt.id) {
+        case "(number)":
+            if (!rx_json_number.test(token_nxt.value)) {
+
+// test_cause:
+// ["[0x0]", "parse_json", "unexpected_a", "0x0", 2]
+
+                warn("unexpected_a");
+            }
+            advance();
+            return token_now;
+        case "(string)":
+            if (token_nxt.quote !== "\"") {
+
+// test_cause:
+// ["['']", "parse_json", "unexpected_a", "'", 2]
+
+                warn("unexpected_a", token_nxt, token_nxt.quote);
+            }
+            advance();
+            return token_now;
+        case "-":
+            negative = token_nxt;
+            negative.arity = "unary";
+            advance("-");
+            advance("(number)");
+            if (!rx_json_number.test(token_now.value)) {
+
+// test_cause:
+// ["[-0x0]", "parse_json", "unexpected_a", "0x0", 3]
+
+                warn("unexpected_a", token_now);
+            }
+            negative.expression = token_now;
+            return negative;
+        case "[":
+
+// test_cause:
+// ["[]", "parse_json", "bracket", "", 0]
+
+            test_cause("bracket");
+            container = token_nxt;
+            container.expression = [];
+            advance("[");
+            if (token_nxt.id !== "]") {
+                while (true) {
+
+// Recurse parse_json().
+
+                    container.expression.push(parse_json());
+                    if (token_nxt.id !== ",") {
+
+// test_cause:
+// ["[0,0]", "parse_json", "comma", "", 0]
+
+                        test_cause("comma");
+                        break;
+                    }
+                    advance(",");
                 }
             }
+            advance("]", container);
+            return container;
+        case "false":
+        case "null":
+        case "true":
+
+// test_cause:
+// ["[false]", "parse_json", "advance", "", 0]
+// ["[null]", "parse_json", "advance", "", 0]
+// ["[true]", "parse_json", "advance", "", 0]
+
+            test_cause("advance");
+            advance();
+            return token_now;
+        case "{":
+
+// test_cause:
+// ["{}", "parse_json", "brace", "", 0]
+
+            test_cause("brace");
+            container = token_nxt;
+
+// Explicit empty-object required to detect "__proto__".
+
+            is_dup = empty();
+            container.expression = [];
+            advance("{");
+            if (token_nxt.id !== "}") {
+
+// JSON
+// Parse/loop through each property in {...}.
+
+                while (true) {
+                    if (token_nxt.quote !== "\"") {
+
+// test_cause:
+// ["{0:0}", "parse_json", "unexpected_a", "0", 2]
+
+                        warn(
+                            "unexpected_a",
+                            token_nxt,
+                            token_nxt.quote
+                        );
+                    }
+                    name = token_nxt;
+                    advance("(string)");
+                    if (is_dup[token_now.value] !== undefined) {
+
+// test_cause:
+// ["{\"aa\":0,\"aa\":0}", "parse_json", "duplicate_a", "aa", 9]
+
+                        warn("duplicate_a", token_now);
+                    } else if (token_now.value === "__proto__") {
+
+// test_cause:
+// ["{\"__proto__\":0}", "parse_json", "weird_property_a", "__proto__", 2]
+
+                        warn("weird_property_a", token_now);
+                    } else {
+                        is_dup[token_now.value] = token_now;
+                    }
+                    advance(":");
+                    container.expression.push(
+
+// Recurse parse_json().
+
+                        Object.assign(parse_json(), {
+                            label: name
+                        })
+                    );
+                    if (token_nxt.id !== ",") {
+                        break;
+                    }
+                    advance(",");
+                }
+            }
+            advance("}", container);
+            return container;
+        default:
+
+// test_cause:
+// ["[undefined]", "parse_json", "unexpected_a", "undefined", 2]
+
+            stop("unexpected_a");
         }
-        advance("]");
-        return the_token;
-    });
-    prefix("/=", function prefix_assign_divide() {
+    }
+
+    function parse_statement() {
+
+// Parse a statement. Any statement may have a label, but only four statements
+// have use for one. A statement can be one of the standard statements, or
+// an assignment expression, or an invocation expression.
+
+        let first;
+        let the_label;
+        let the_statement;
+        let the_symbol;
+        advance();
+        if (token_now.identifier && token_nxt.id === ":") {
+            the_label = token_now;
+            if (the_label.id === "ignore") {
+
+// test_cause:
+// ["ignore:", "parse_statement", "unexpected_a", "ignore", 1]
+
+                warn("unexpected_a", the_label);
+            }
+            advance(":");
+            if (
+                token_nxt.id === "do"
+                || token_nxt.id === "for"
+                || token_nxt.id === "switch"
+                || token_nxt.id === "while"
+            ) {
+                enroll(the_label, "label", true);
+                the_label.dead = false;
+                the_label.init = true;
+                the_statement = parse_statement();
+                functionage.statement_prv = the_statement;
+                the_statement.label = the_label;
+                the_statement.statement = true;
+                return the_statement;
+            }
+            advance();
+
+// test_cause:
+// ["aa:", "parse_statement", "unexpected_label_a", "aa", 1]
+
+            warn("unexpected_label_a", the_label);
+        }
+
+// Parse the statement.
+
+        first = token_now;
+        first.statement = true;
+        the_symbol = syntax_dict[first.id];
+        if (
+            the_symbol !== undefined
+            && the_symbol.fud !== undefined
+
+// Bugfix - Fixes issues #316, #317 - dynamic-import().
+
+            && !(the_symbol.id === "import" && token_nxt.id === "(")
+        ) {
+            the_symbol.disrupt = false;
+            the_symbol.statement = true;
+            token_now.arity = "statement";
+            the_statement = the_symbol.fud();
+            functionage.statement_prv = the_statement;
+        } else {
+
+// It is an expression statement.
+
+            the_statement = parse_expression(0, true);
+            functionage.statement_prv = the_statement;
+            if (the_statement.wrapped && the_statement.id !== "(") {
+
+// test_cause:
+// ["(0)", "parse_statement", "unexpected_a", "(", 1]
+
+                warn("unexpected_a", first);
+            }
+            semicolon();
+        }
+        if (the_label !== undefined) {
+            the_label.dead = true;
+        }
+        return the_statement;
+    }
+
+    function parse_statements() {
+
+// Parse a list of statements. Give a warning if an unreachable statement
+// follows a disruptive statement.
+
+        const statement_list = [];
+        let a_statement;
+        let disrupt = false;
+
+// Parse/loop each statement until a statement-terminator is reached.
+
+        while (true) {
+            switch (token_nxt.id) {
+            case "(end)":
+            case "case":
+            case "default":
+            case "else":
+            case "}":
+
+// test_cause:
+// [";", "parse_statements", "closer", "", 0]
+// ["case", "parse_statements", "closer", "", 0]
+// ["default", "parse_statements", "closer", "", 0]
+// ["else", "parse_statements", "closer", "", 0]
+// ["}", "parse_statements", "closer", "", 0]
+
+                test_cause("closer");
+                return statement_list;
+            }
+            a_statement = parse_statement();
+            statement_list.push(a_statement);
+            if (disrupt) {
+
+// test_cause:
+// ["while(0){break;0;}", "parse_statements", "unreachable_a", "0", 16]
+
+                warn("unreachable_a", a_statement);
+            }
+            disrupt = a_statement.disrupt;
+        }
+    }
+
+    function postassign(id) {
+
+// Create one of the postassign operators.
+
+        const the_symbol = symbol(id, 150);
+        the_symbol.led = function (left) {
+            token_now.expression = left;
+            token_now.arity = "postassign";
+            check_mutation(token_now.expression);
+            return token_now;
+        };
+        return the_symbol;
+    }
+
+    function preassign(id) {
+
+// Create one of the preassign operators.
+
+        const the_symbol = symbol(id);
+        the_symbol.nud = function () {
+            const the_token = token_now;
+            the_token.arity = "preassign";
+            the_token.expression = parse_expression(150);
+            check_mutation(the_token.expression);
+            return the_token;
+        };
+        return the_symbol;
+    }
+
+    function prefix(id, f) {
+
+// Create a prefix operator.
+
+        const the_symbol = symbol(id);
+        the_symbol.nud = function () {
+            const the_token = token_now;
+            the_token.arity = "unary";
+            if (typeof f === "function") {
+                return f();
+            }
+            the_token.expression = parse_expression(150);
+            return the_token;
+        };
+        return the_symbol;
+    }
+
+    function prefix_assign_divide() {
 
 // test_cause:
 // ["/=", "prefix_assign_divide", "expected_a_b", "/=", 1]
 
         stop("expected_a_b", token_now, "/\\=", "/=");
-    });
-    prefix("=>", function prefix_fart() {
+    }
+
+    function prefix_async() {
+        let the_async;
+        let the_function;
+        the_async = token_now;
+        advance("function");
+        the_function = Object.assign(token_now, {
+            arity: the_async.arity,
+            async: 1
+        });
+        prefix_function();
+        if (the_function.async === 1) {
+
+// test_cause:
+// ["
+// async function aa(){}
+// ", "prefix_async", "missing_await_statement", "function", 7]
+
+            warn("missing_await_statement", the_function);
+        }
+        return the_function;
+    }
+
+    function prefix_await() {
+        const the_await = token_now;
+        if (functionage.async === 0) {
+
+// test_cause:
+// ["await", "prefix_await", "unexpected_a", "await", 1]
+// ["function aa(){aa=await 0;}", "prefix_await", "unexpected_a", "await", 18]
+// ["function aa(){await 0;}", "prefix_await", "unexpected_a", "await", 15]
+
+            warn("unexpected_a", the_await);
+        } else {
+            functionage.async += 1;
+        }
+        if (the_await.arity === "statement") {
+            the_await.block = parse_expression();
+            semicolon();
+        } else {
+            the_await.expression = parse_expression();
+        }
+        return the_await;
+    }
+
+    function prefix_fart() {
 
 // test_cause:
 // ["=>0", "prefix_fart", "expected_a_before_b", "=>", 1]
 
         return stop("expected_a_before_b", token_now, "()", "=>");
-    });
-    prefix("new", function prefix_new() {
-        const the_new = token_now;
-        let right;
-        right = parse_expression(160);
-        if (token_nxt.id !== "(") {
+    }
+
+    function prefix_function(the_function) {
+        let name = the_function && the_function.name;
+        if (the_function === undefined) {
+            the_function = token_now;
+
+// A function statement must have a name that will be in the parent's scope.
+
+            if (the_function.arity === "statement") {
+                if (!token_nxt.identifier) {
 
 // test_cause:
-// ["new aa", "prefix_new", "expected_a_before_b", "(end)", 1]
+// ["function(){}", "prefix_function", "expected_identifier_a", "(", 9]
+// ["function*aa(){}", "prefix_function", "expected_identifier_a", "*", 9]
 
-            warn("expected_a_before_b", token_nxt, "()", artifact());
+                    return stop("expected_identifier_a");
+                }
+                name = token_nxt;
+                enroll(name, "variable", true);
+                the_function.name = Object.assign(name, {
+                    calls: empty(),
+
+// Bugfix - Fixes issue #272 - function hoisting not allowed.
+
+                    dead: false,
+                    init: true
+                });
+                advance();
+            } else if (name === undefined) {
+
+// A function expression may have an optional name.
+
+                the_function.name = anon;
+                if (token_nxt.identifier) {
+                    name = token_nxt;
+                    the_function.name = name;
+                    advance();
+                }
+            }
         }
-        the_new.expression = right;
-        return the_new;
-    });
-    prefix("typeof");
-    prefix("void", function prefix_void() {
-        const the_void = token_now;
+        the_function.level = functionage.level + 1;
+
+//  Probably deadcode.
+//  if (mode_mega) {
+//      warn("unexpected_a", the_function);
+//  }
+//  assert_or_throw(!mode_mega, `Expected !mode_mega.`);
+
+// Don't create functions in loops. It is inefficient, and it can lead to
+// scoping errors.
+
+        if (functionage.loop > 0) {
 
 // test_cause:
-// ["void 0", "prefix_void", "unexpected_a", "void", 1]
-// ["void", "prefix_void", "unexpected_a", "void", 1]
+// ["
+// while(0){aa.map(function(){});}
+// ", "prefix_function", "function_in_loop", "function", 17]
 
-        warn("unexpected_a", the_void);
-        the_void.expression = parse_expression(0);
-        return the_void;
-    });
+            warn("function_in_loop", the_function);
+        }
 
-    function parse_function_arg() {
+// Give the function properties for storing its names and for observing the
+// depth of loops and switches.
+
+        Object.assign(the_function, {
+            async: the_function.async || 0,
+            context: empty(),
+            finally: 0,
+            loop: 0,
+            statement_prv: undefined,
+            switch: 0,
+            try: 0
+        });
+        if (the_function.arity !== "statement" && typeof name === "object") {
+
+// test_cause:
+// ["let aa=function bb(){return;};", "prefix_function", "expression", "", 0]
+
+            test_cause("expression");
+            enroll(name, "function", true);
+            name.dead = false;
+            name.init = true;
+            name.used = 1;
+        }
+
+// Bugfix - fix function-redefinitions not warned inside function-calls.
+// Push the current function context and establish a new one.
+
+        function_stack.push(functionage);
+        function_list.push(the_function);
+        functionage = the_function;
+
+// Parse the parameter list.
+
+        advance("(");
+
+// test_cause:
+// ["function aa(){}", "prefix_function", "opener", "", 0]
+
+        test_cause("opener");
+        token_now.free = false;
+        token_now.arity = "function";
+        [functionage.parameters, functionage.signature] = prefix_function_arg();
+        functionage.parameters.forEach(function enroll_parameter(name) {
+            if (name.identifier) {
+                enroll(name, "parameter", false);
+            } else {
+                name.names.forEach(enroll_parameter);
+            }
+        });
+
+// The function's body is a block.
+
+        the_function.block = block("body");
+        if (
+            the_function.arity === "statement"
+            && token_nxt.line === token_now.line
+        ) {
+
+// test_cause:
+// ["function aa(){}0", "prefix_function", "unexpected_a", "0", 16]
+
+            return stop("unexpected_a");
+        }
+        if (
+            token_nxt.id === "."
+            || token_nxt.id === "?."
+            || token_nxt.id === "["
+        ) {
+
+// test_cause:
+// ["function aa(){}\n.aa", "prefix_function", "unexpected_a", ".", 1]
+// ["function aa(){}\n?.aa", "prefix_function", "unexpected_a", "?.", 1]
+// ["function aa(){}\n[]", "prefix_function", "unexpected_a", "[", 1]
+
+            warn("unexpected_a");
+        }
+
+// Check functions are ordered.
+
+        check_ordered(
+            "function",
+            function_list.slice(
+                function_list.indexOf(the_function) + 1
+            ).map(function ({
+                level,
+                name
+            }) {
+                return (level === the_function.level + 1) && name;
+            }).filter(function (name) {
+                return option_dict.beta && name && name.id;
+            })
+        );
+
+// Restore the previous context.
+
+        functionage = function_stack.pop();
+        return the_function;
+    }
+
+    function prefix_function_arg() {
         const list = [];
         const signature = ["("];
         let optional;
@@ -3216,319 +4569,7 @@ function jslint_phase3_parse(state) {
         return [list, signature.join("")];
     }
 
-    function parse_function(the_function) {
-        let name = the_function && the_function.name;
-        if (the_function === undefined) {
-            the_function = token_now;
-
-// A function statement must have a name that will be in the parent's scope.
-
-            if (the_function.arity === "statement") {
-                if (!token_nxt.identifier) {
-
-// test_cause:
-// ["function(){}", "parse_function", "expected_identifier_a", "(", 9]
-// ["function*aa(){}", "parse_function", "expected_identifier_a", "*", 9]
-
-                    return stop("expected_identifier_a");
-                }
-                name = token_nxt;
-                enroll(name, "variable", true);
-                the_function.name = Object.assign(name, {
-                    calls: empty(),
-
-// Bugfix - Fixes issue #272 - function hoisting not allowed.
-
-                    dead: false,
-                    init: true
-                });
-                advance();
-            } else if (name === undefined) {
-
-// A function expression may have an optional name.
-
-                the_function.name = anon;
-                if (token_nxt.identifier) {
-                    name = token_nxt;
-                    the_function.name = name;
-                    advance();
-                }
-            }
-        }
-        the_function.level = functionage.level + 1;
-
-//  Probably deadcode.
-//  if (mode_mega) {
-//      warn("unexpected_a", the_function);
-//  }
-//  assert_or_throw(!mode_mega, `Expected !mode_mega.`);
-
-// Don't create functions in loops. It is inefficient, and it can lead to
-// scoping errors.
-
-        if (functionage.loop > 0) {
-
-// test_cause:
-// ["
-// while(0){aa.map(function(){});}
-// ", "parse_function", "function_in_loop", "function", 17]
-
-            warn("function_in_loop", the_function);
-        }
-
-// Give the function properties for storing its names and for observing the
-// depth of loops and switches.
-
-        Object.assign(the_function, {
-            async: the_function.async || 0,
-            context: empty(),
-            finally: 0,
-            loop: 0,
-            switch: 0,
-            try: 0
-        });
-        if (the_function.arity !== "statement" && typeof name === "object") {
-
-// test_cause:
-// ["let aa=function bb(){return;};", "parse_function", "expression", "", 0]
-
-            test_cause("expression");
-            enroll(name, "function", true);
-            name.dead = false;
-            name.init = true;
-            name.used = 1;
-        }
-
-// Bugfix - fix function-redefinitions not warned inside function-calls.
-// Push the current function context and establish a new one.
-
-        function_stack.push(functionage);
-        function_list.push(the_function);
-        function_level_list[the_function.level] = (
-            function_level_list[the_function.level] || []
-        );
-        function_level_list[the_function.level].push(the_function);
-        functionage = the_function;
-
-// Parse the parameter list.
-
-        advance("(");
-
-// test_cause:
-// ["function aa(){}", "parse_function", "opener", "", 0]
-
-        test_cause("opener");
-        token_now.free = false;
-        token_now.arity = "function";
-        [functionage.parameters, functionage.signature] = parse_function_arg();
-        functionage.parameters.forEach(function enroll_parameter(name) {
-            if (name.identifier) {
-                enroll(name, "parameter", false);
-            } else {
-                name.names.forEach(enroll_parameter);
-            }
-        });
-
-// The function's body is a block.
-
-        the_function.block = block("body");
-        if (
-            the_function.arity === "statement"
-            && token_nxt.line === token_now.line
-        ) {
-
-// test_cause:
-// ["function aa(){}0", "parse_function", "unexpected_a", "0", 16]
-
-            return stop("unexpected_a");
-        }
-        if (
-            token_nxt.id === "."
-            || token_nxt.id === "?."
-            || token_nxt.id === "["
-        ) {
-
-// test_cause:
-// ["function aa(){}\n.aa", "parse_function", "unexpected_a", ".", 1]
-// ["function aa(){}\n?.aa", "parse_function", "unexpected_a", "?.", 1]
-// ["function aa(){}\n[]", "parse_function", "unexpected_a", "[", 1]
-
-            warn("unexpected_a");
-        }
-
-// Restore the previous context.
-
-        functionage = function_stack.pop();
-        return the_function;
-    }
-
-    function parse_async() {
-        let the_async;
-        let the_function;
-        the_async = token_now;
-        advance("function");
-        the_function = Object.assign(token_now, {
-            arity: the_async.arity,
-            async: 1
-        });
-        parse_function();
-        if (the_function.async === 1) {
-
-// test_cause:
-// ["
-// async function aa(){}
-// ", "parse_async", "missing_await_statement", "function", 7]
-
-            warn("missing_await_statement", the_function);
-        }
-        return the_function;
-    }
-
-    function parse_await() {
-        const the_await = token_now;
-        if (functionage.async === 0) {
-
-// test_cause:
-// ["await", "parse_await", "unexpected_a", "await", 1]
-// ["function aa(){aa=await 0;}", "parse_await", "unexpected_a", "await", 18]
-// ["function aa(){await 0;}", "parse_await", "unexpected_a", "await", 15]
-
-            warn("unexpected_a", the_await);
-        } else {
-            functionage.async += 1;
-        }
-        if (the_await.arity === "statement") {
-            the_await.block = parse_expression();
-            semicolon();
-        } else {
-            the_await.expression = parse_expression();
-        }
-        return the_await;
-    }
-
-    prefix("async", parse_async);
-    prefix("await", parse_await);
-    prefix("function", parse_function);
-
-    function parse_fart(pl) {
-        let the_fart;
-        advance("=>");
-        the_fart = token_now;
-        the_fart.arity = "binary";
-        the_fart.name = "=>";
-        the_fart.level = functionage.level + 1;
-        function_list.push(the_fart);
-        if (functionage.loop > 0) {
-
-// test_cause:
-// ["while(0){aa.map(()=>0);}", "parse_fart", "function_in_loop", "=>", 19]
-
-            warn("function_in_loop", the_fart);
-        }
-
-// Give the function properties storing its names and for observing the depth
-// of loops and switches.
-
-        the_fart.context = empty();
-        the_fart.finally = 0;
-        the_fart.loop = 0;
-        the_fart.switch = 0;
-        the_fart.try = 0;
-
-// Push the current function context and establish a new one.
-
-        function_stack.push(functionage);
-        functionage = the_fart;
-        the_fart.parameters = pl[0];
-        the_fart.signature = pl[1];
-        the_fart.parameters.forEach(function (name) {
-
-// test_cause:
-// ["(aa)=>{}", "parse_fart", "parameter", "", 0]
-
-            test_cause("parameter");
-            enroll(name, "parameter", true);
-        });
-        if (token_nxt.id === "{") {
-
-// test_cause:
-// ["()=>{}", "parse_fart", "expected_a_b", "=>", 3]
-
-            warn("expected_a_b", the_fart, "function", "=>");
-            the_fart.block = block("body");
-        } else {
-            the_fart.expression = parse_expression(0);
-        }
-        functionage = function_stack.pop();
-        return the_fart;
-    }
-
-    prefix("(", function prefix_lparen() {
-        const cadet = lookahead().id;
-        const the_paren = token_now;
-        let the_value;
-
-// We can distinguish between a parameter list for => and a wrapped expression
-// with one token of lookahead.
-
-        if (
-            token_nxt.id === ")"
-            || token_nxt.id === "..."
-            || (token_nxt.identifier && (cadet === "," || cadet === "="))
-        ) {
-
-// test_cause:
-// ["()=>0", "prefix_lparen", "fart", "", 0]
-
-            test_cause("fart");
-            the_paren.free = false;
-            return parse_fart(parse_function_arg());
-        }
-
-// test_cause:
-// ["(0)", "prefix_lparen", "expr", "", 0]
-
-        test_cause("expr");
-        the_paren.free = true;
-        the_value = parse_expression(0);
-        if (the_value.wrapped === true) {
-
-// test_cause:
-// ["((0))", "prefix_lparen", "unexpected_a", "(", 1]
-
-            warn("unexpected_a", the_paren);
-        }
-        the_value.wrapped = true;
-        advance(")", the_paren);
-        if (token_nxt.id === "=>") {
-            if (the_value.arity !== "variable") {
-                if (the_value.id === "{" || the_value.id === "[") {
-
-// test_cause:
-// ["([])=>0", "prefix_lparen", "expected_a_before_b", "(", 1]
-// ["({})=>0", "prefix_lparen", "expected_a_before_b", "(", 1]
-
-                    warn("expected_a_before_b", the_paren, "function", "(");
-
-// test_cause:
-// ["([])=>0", "prefix_lparen", "expected_a_b", "=>", 5]
-// ["({})=>0", "prefix_lparen", "expected_a_b", "=>", 5]
-
-                    return stop("expected_a_b", token_nxt, "{", "=>");
-                }
-
-// test_cause:
-// ["(0)=>0", "prefix_lparen", "expected_identifier_a", "0", 2]
-
-                return stop("expected_identifier_a", the_value);
-            }
-            the_paren.expression = [the_value];
-            return parse_fart([the_paren.expression, "(" + the_value.id + ")"]);
-        }
-        return the_value;
-    });
-    prefix("`", parse_tick);
-    prefix("{", function prefix_lbrace() {
+    function prefix_lbrace() {
         const seen = empty();
         const the_brace = token_now;
         let extra;
@@ -3570,6 +4611,13 @@ function jslint_phase3_parse(state) {
                     }
                     seen[id] = false;
                     seen[full] = true;
+                } else if (name.id === "`") {
+
+// test_cause:
+// ["aa={`aa`:0}", "prefix_lbrace", "unexpected_a", "`", 5]
+
+                    stop("unexpected_a", name);
+
                 } else {
                     id = survey(name);
                     if (typeof seen[id] === "boolean") {
@@ -3599,7 +4647,7 @@ function jslint_phase3_parse(state) {
 // ["aa={get aa(){}}", "prefix_lbrace", "paren", "", 0]
 
                         test_cause("paren");
-                        value = parse_function({
+                        value = prefix_function({
                             arity: "unary",
                             from: name.from,
                             id: "function",
@@ -3683,28 +4731,198 @@ function jslint_phase3_parse(state) {
         );
         advance("}");
         return the_brace;
-    });
+    }
 
-    stmt(";", function stmt_semicolon() {
+    function prefix_lbracket() {
+        const the_token = token_now;
+        let element;
+        let ellipsis;
+        the_token.expression = [];
+        if (token_nxt.id !== "]") {
+
+// Parse/loop through each element in [...].
+
+            while (true) {
+                ellipsis = false;
+                if (token_nxt.id === "...") {
+                    ellipsis = true;
+                    advance("...");
+                }
+                element = parse_expression(10);
+                if (ellipsis) {
+                    element.ellipsis = true;
+                }
+                the_token.expression.push(element);
+                if (token_nxt.id !== ",") {
+                    break;
+                }
+                advance(",");
+                if (token_nxt.id === "]") {
 
 // test_cause:
-// [";", "stmt_semicolon", "unexpected_a", ";", 1]
+// ["let aa=[0,]", "prefix_lbracket", "unexpected_a", ",", 10]
 
-        warn("unexpected_a", token_now);
-        return token_now;
-    });
-    stmt("{", function stmt_lbrace() {
+                    warn("unexpected_a", token_now);
+                    break;
+                }
+            }
+        }
+        advance("]");
+        return the_token;
+    }
+
+    function prefix_lparen() {
+        const cadet = lookahead().id;
+        const the_paren = token_now;
+        let the_value;
+
+// We can distinguish between a parameter list for => and a wrapped expression
+// with one token of lookahead.
+
+        if (
+            token_nxt.id === ")"
+            || token_nxt.id === "..."
+            || (token_nxt.identifier && (cadet === "," || cadet === "="))
+        ) {
 
 // test_cause:
-// [";{}", "stmt_lbrace", "naked_block", "{", 2]
-// ["class aa{}", "stmt_lbrace", "naked_block", "{", 9]
+// ["()=>0", "prefix_lparen", "fart", "", 0]
 
-        warn("naked_block", token_now);
-        return block("naked");
-    });
-    stmt("async", parse_async);
-    stmt("await", parse_await);
-    stmt("break", function stmt_break() {
+            test_cause("fart");
+            the_paren.free = false;
+            return parse_fart(prefix_function_arg());
+        }
+
+// test_cause:
+// ["(0)", "prefix_lparen", "expr", "", 0]
+
+        test_cause("expr");
+        the_paren.free = true;
+        the_value = parse_expression(0);
+        if (the_value.wrapped === true) {
+
+// test_cause:
+// ["((0))", "prefix_lparen", "unexpected_a", "(", 1]
+
+            warn("unexpected_a", the_paren);
+        }
+        the_value.wrapped = true;
+        advance(")", the_paren);
+        if (token_nxt.id === "=>") {
+            if (the_value.arity !== "variable") {
+                if (the_value.id === "{" || the_value.id === "[") {
+
+// test_cause:
+// ["([])=>0", "prefix_lparen", "expected_a_before_b", "(", 1]
+// ["({})=>0", "prefix_lparen", "expected_a_before_b", "(", 1]
+
+                    warn("expected_a_before_b", the_paren, "function", "(");
+
+// test_cause:
+// ["([])=>0", "prefix_lparen", "expected_a_b", "=>", 5]
+// ["({})=>0", "prefix_lparen", "expected_a_b", "=>", 5]
+
+                    return stop("expected_a_b", token_nxt, "{", "=>");
+                }
+
+// test_cause:
+// ["(0)=>0", "prefix_lparen", "expected_identifier_a", "0", 2]
+
+                return stop("expected_identifier_a", the_value);
+            }
+            the_paren.expression = [the_value];
+            return parse_fart([the_paren.expression, "(" + the_value.id + ")"]);
+        }
+        return the_value;
+    }
+
+    function prefix_new() {
+        const the_new = token_now;
+        let right;
+        right = parse_expression(160);
+        if (token_nxt.id !== "(") {
+
+// test_cause:
+// ["new aa", "prefix_new", "expected_a_before_b", "(end)", 1]
+
+            warn("expected_a_before_b", token_nxt, "()", artifact());
+        }
+        the_new.expression = right;
+        return the_new;
+    }
+
+    function prefix_tick() {
+        const the_tick = token_now;
+        the_tick.value = [];
+        the_tick.expression = [];
+        if (token_nxt.id !== "`") {
+
+// Parse/loop through each token in `${...}`.
+
+            while (true) {
+                advance("(string)");
+                the_tick.value.push(token_now);
+                if (token_nxt.id !== "${") {
+                    break;
+                }
+                advance("${");
+
+// test_cause:
+// ["let aa=`${}`;", "prefix_tick", "${", "", 0]
+
+                test_cause("${");
+                the_tick.expression.push(parse_expression(0));
+                advance("}");
+            }
+        }
+        advance("`");
+        return the_tick;
+    }
+
+    function prefix_void() {
+        const the_void = token_now;
+
+// test_cause:
+// ["void 0", "prefix_void", "unexpected_a", "void", 1]
+// ["void", "prefix_void", "unexpected_a", "void", 1]
+
+        warn("unexpected_a", the_void);
+        the_void.expression = parse_expression(0);
+        return the_void;
+    }
+
+    function semicolon() {
+
+// Try to match a semicolon.
+
+        if (token_nxt.id === ";") {
+            advance(";");
+        } else {
+
+// test_cause:
+// ["0", "semicolon", "expected_a_b", "(end)", 1]
+
+            warn_at(
+                "expected_a_b",
+                token_now.line,
+                token_now.thru + 1,
+                ";",
+                artifact()
+            );
+        }
+        anon = "anonymous";
+    }
+
+    function stmt(id, fud) {
+
+// Create a statement.
+
+        const the_symbol = symbol(id);
+        the_symbol.fud = fud;
+        return the_symbol;
+    }
+
+    function stmt_break() {
         const the_break = token_now;
         let the_label;
         if (
@@ -3746,286 +4964,17 @@ function jslint_phase3_parse(state) {
         }
         advance(";");
         return the_break;
-    });
-
-    function parse_var() {
-        let ellipsis;
-        let mode_const;
-        let name;
-        let the_brace;
-        let the_bracket;
-        let the_variable = token_now;
-        let variable_prv;
-        mode_const = the_variable.id === "const";
-        the_variable.names = [];
-
-// A program may use var or let, but not both.
-
-        if (!mode_const) {
-            if (mode_var === undefined) {
-                mode_var = the_variable.id;
-            } else if (the_variable.id !== mode_var) {
-
-// test_cause:
-// ["let aa;var aa", "parse_var", "expected_a_b", "var", 8]
-
-                warn("expected_a_b", the_variable, mode_var, the_variable.id);
-            }
-        }
-
-// We don't expect to see variables created in switch statements.
-
-        if (functionage.switch > 0) {
-
-// test_cause:
-// ["switch(0){case 0:var aa}", "parse_var", "var_switch", "var", 18]
-
-            warn("var_switch", the_variable);
-        }
-        switch (
-            Boolean(functionage.last_statement)
-            && functionage.last_statement.id
-        ) {
-        case "const":
-        case "let":
-        case "var":
-
-// test_cause:
-// ["const aa=0;const bb=0;", "parse_var", "last_var", "const", 0]
-// ["let aa=0;let bb=0;", "parse_var", "last_var", "let", 0]
-// ["var aa=0;var bb=0;", "parse_var", "last_var", "var", 0]
-
-            test_cause("last_var", functionage.last_statement.id);
-            variable_prv = functionage.last_statement;
-            break;
-        case "import":
-
-// test_cause:
-// ["import aa from \"aa\";\nlet bb=0;", "parse_var", "last_import", "", 0]
-
-            test_cause("last_import");
-            break;
-        case false:
-            break;
-        default:
-            if (
-                (option_dict.beta && !option_dict.variable)
-                || the_variable.id === "var"
-            ) {
-
-// test_cause:
-// ["
-// /*jslint beta*/
-// console.log();let aa=0;
-// ", "parse_var", "var_on_top", "let", 15]
-// ["console.log();var aa=0;", "parse_var", "var_on_top", "var", 15]
-// ["try{aa();}catch(aa){var aa=0;}", "parse_var", "var_on_top", "var", 21]
-// ["while(0){var aa;}", "parse_var", "var_on_top", "var", 10]
-
-                warn("var_on_top", token_now);
-            }
-        }
-        while (true) {
-            if (token_nxt.id === "{") {
-                if (the_variable.id === "var") {
-
-// test_cause:
-// ["var{aa}=0", "parse_var", "unexpected_a", "var", 1]
-
-                    warn("unexpected_a", the_variable);
-                }
-                the_brace = token_nxt;
-                advance("{");
-                while (true) {
-                    name = token_nxt;
-                    if (!name.identifier) {
-
-// test_cause:
-// ["let {0}", "parse_var", "expected_identifier_a", "0", 6]
-
-                        return stop("expected_identifier_a");
-                    }
-                    survey(name);
-                    advance();
-                    if (token_nxt.id === ":") {
-                        advance(":");
-                        if (!token_nxt.identifier) {
-
-// test_cause:
-// ["let {aa:0}", "parse_var", "expected_identifier_a", "0", 9]
-// ["let {aa:{aa}}", "parse_var", "expected_identifier_a", "{", 9]
-
-                            return stop("expected_identifier_a");
-                        }
-                        token_nxt.label = name;
-                        the_variable.names.push(token_nxt);
-                        enroll(token_nxt, "variable", mode_const);
-                        advance();
-                        the_brace.open = true;
-                    } else {
-                        the_variable.names.push(name);
-                        enroll(name, "variable", mode_const);
-                    }
-                    name.dead = false;
-                    name.init = true;
-                    if (token_nxt.id === "=") {
-
-// test_cause:
-// ["let {aa=0}", "parse_var", "assign", "", 0]
-
-                        test_cause("assign");
-                        advance("=");
-                        name.expression = parse_expression();
-                        the_brace.open = true;
-                    }
-                    if (token_nxt.id !== ",") {
-                        break;
-                    }
-                    advance(",");
-                }
-
-// test_cause:
-// ["let{bb,aa}", "check_ordered", "expected_a_b_before_c_d", "aa", 8]
-
-                check_ordered(the_variable.id, the_variable.names);
-                advance("}");
-                advance("=");
-                the_variable.expression = parse_expression(0);
-            } else if (token_nxt.id === "[") {
-                if (the_variable.id === "var") {
-
-// test_cause:
-// ["var[aa]=0", "parse_var", "unexpected_a", "var", 1]
-
-                    warn("unexpected_a", the_variable);
-                }
-                the_bracket = token_nxt;
-                advance("[");
-                while (true) {
-                    ellipsis = false;
-                    if (token_nxt.id === "...") {
-                        ellipsis = true;
-                        advance("...");
-                    }
-                    if (!token_nxt.identifier) {
-
-// test_cause:
-// ["let[]", "parse_var", "expected_identifier_a", "]", 5]
-
-                        return stop("expected_identifier_a");
-                    }
-                    name = token_nxt;
-                    advance();
-                    the_variable.names.push(name);
-                    enroll(name, "variable", mode_const);
-                    name.dead = false;
-                    name.init = true;
-                    if (ellipsis) {
-                        name.ellipsis = true;
-                        break;
-                    }
-                    if (token_nxt.id === "=") {
-                        advance("=");
-                        name.expression = parse_expression();
-                        the_bracket.open = true;
-                    }
-                    if (token_nxt.id !== ",") {
-                        break;
-                    }
-                    advance(",");
-                }
-                advance("]");
-                advance("=");
-                the_variable.expression = parse_expression(0);
-            } else if (token_nxt.identifier) {
-                name = token_nxt;
-                advance();
-                if (name.id === "ignore") {
-
-// test_cause:
-// ["
-// let ignore;function aa(ignore) {}
-// ", "parse_var", "unexpected_a", "ignore", 5]
-
-                    warn("unexpected_a", name);
-                }
-                enroll(name, "variable", mode_const);
-                if (token_nxt.id === "=" || mode_const) {
-                    advance("=");
-                    name.dead = false;
-                    name.init = true;
-                    name.expression = parse_expression(0);
-                }
-                the_variable.names.push(name);
-            } else {
-
-// test_cause:
-// ["let 0", "parse_var", "expected_identifier_a", "0", 5]
-// ["var{aa:{aa}}", "parse_var", "expected_identifier_a", "{", 8]
-
-                return stop("expected_identifier_a");
-            }
-            if (token_nxt.id !== ",") {
-                break;
-            }
-
-// test_cause:
-// ["let aa,bb;", "parse_var", "expected_a_b", ",", 7]
-
-            warn("expected_a_b", token_nxt, ";", ",");
-            advance(",");
-        }
-
-// Warn if variable declarations are unordered.
-
-        if (
-            option_dict.beta
-            && !option_dict.unordered
-            && !option_dict.variable
-            && variable_prv
-            && (
-                variable_prv.id + " " + variable_prv.names[0].id
-                > the_variable.id + " " + the_variable.names[0].id
-            )
-        ) {
-
-// test_cause:
-// ["
-// /*jslint beta*/
-// const bb=0;const aa=0;
-// ", "parse_var", "expected_a_b_before_c_d", "aa", 12]
-// ["
-// /*jslint beta*/
-// let bb;let aa;
-// ", "parse_var", "expected_a_b_before_c_d", "aa", 8]
-// ["
-// /*jslint beta*/
-// var bb;var aa;
-// ", "parse_var", "expected_a_b_before_c_d", "aa", 8]
-
-            warn(
-                "expected_a_b_before_c_d",
-                the_variable,
-                the_variable.id,
-                the_variable.names[0].id,
-                variable_prv.id,
-                variable_prv.names[0].id
-            );
-        }
-        semicolon();
-        return the_variable;
     }
 
-    stmt("const", parse_var);
-    stmt("continue", function parse_continue() {
+    function stmt_continue() {
         const the_continue = token_now;
         if (functionage.loop < 1 || functionage.finally > 0) {
 
 // test_cause:
-// ["continue", "parse_continue", "unexpected_a", "continue", 1]
+// ["continue", "stmt_continue", "unexpected_a", "continue", 1]
 // ["
 // function aa(){while(0){try{}finally{continue}}}
-// ", "parse_continue", "unexpected_a", "continue", 37]
+// ", "stmt_continue", "unexpected_a", "continue", 37]
 
             warn("unexpected_a", the_continue);
         }
@@ -4034,8 +4983,9 @@ function jslint_phase3_parse(state) {
         warn("unexpected_a", the_continue);
         advance(";");
         return the_continue;
-    });
-    stmt("debugger", function stmt_debugger() {
+    }
+
+    function stmt_debugger() {
         const the_debug = token_now;
         if (!option_dict.devel) {
 
@@ -4046,8 +4996,9 @@ function jslint_phase3_parse(state) {
         }
         semicolon();
         return the_debug;
-    });
-    stmt("delete", function stmt_delete() {
+    }
+
+    function stmt_delete() {
         const the_token = token_now;
         const the_value = parse_expression(0);
         if (
@@ -4063,8 +5014,9 @@ function jslint_phase3_parse(state) {
         the_token.expression = the_value;
         semicolon();
         return the_token;
-    });
-    stmt("do", function stmt_do() {
+    }
+
+    function stmt_do() {
         const the_do = token_now;
         check_not_top_level(the_do);
         functionage.loop += 1;
@@ -4081,8 +5033,9 @@ function jslint_phase3_parse(state) {
         }
         functionage.loop -= 1;
         return the_do;
-    });
-    stmt("export", function stmt_export() {
+    }
+
+    function stmt_export() {
         const the_export = token_now;
         let the_id;
         let the_name;
@@ -4217,8 +5170,9 @@ function jslint_phase3_parse(state) {
         }
         state.mode_module = true;
         return the_export;
-    });
-    stmt("for", function stmt_for() {
+    }
+
+    function stmt_for() {
         const the_for = token_now;
         let first;
         if (!option_dict.for) {
@@ -4290,9 +5244,9 @@ function jslint_phase3_parse(state) {
         }
         functionage.loop -= 1;
         return the_for;
-    });
-    stmt("function", parse_function);
-    stmt("if", function stmt_if() {
+    }
+
+    function stmt_if() {
         const the_if = token_now;
         let the_else;
         the_if.expression = condition();
@@ -4329,8 +5283,9 @@ function jslint_phase3_parse(state) {
             }
         }
         return the_if;
-    });
-    stmt("import", function stmt_import() {
+    }
+
+    function stmt_import() {
         const the_import = token_now;
         let name;
         let names;
@@ -4409,9 +5364,19 @@ function jslint_phase3_parse(state) {
         import_list.push(token_now.value);
         semicolon();
         return the_import;
-    });
-    stmt("let", parse_var);
-    stmt("return", function stmt_return() {
+    }
+
+    function stmt_lbrace() {
+
+// test_cause:
+// [";{}", "stmt_lbrace", "naked_block", "{", 2]
+// ["class aa{}", "stmt_lbrace", "naked_block", "{", 9]
+
+        warn("naked_block", token_now);
+        return block("naked");
+    }
+
+    function stmt_return() {
         const the_return = token_now;
         check_not_top_level(the_return);
         if (functionage.finally > 0) {
@@ -4429,8 +5394,18 @@ function jslint_phase3_parse(state) {
         }
         advance(";");
         return the_return;
-    });
-    stmt("switch", function stmt_switch() {
+    }
+
+    function stmt_semicolon() {
+
+// test_cause:
+// [";", "stmt_semicolon", "unexpected_a", ";", 1]
+
+        warn("unexpected_a", token_now);
+        return token_now;
+    }
+
+    function stmt_switch() {
         const the_cases = [];
         const the_switch = token_now;
         let dups = [];
@@ -4598,8 +5573,9 @@ function jslint_phase3_parse(state) {
         functionage.switch -= 1;
         the_switch.disrupt = the_disrupt;
         return the_switch;
-    });
-    stmt("throw", function stmt_throw() {
+    }
+
+    function stmt_throw() {
         const the_throw = token_now;
         the_throw.disrupt = true;
         the_throw.expression = parse_expression(10);
@@ -4612,8 +5588,9 @@ function jslint_phase3_parse(state) {
             warn("unexpected_a", the_throw);
         }
         return the_throw;
-    });
-    stmt("try", function stmt_try() {
+    }
+
+    function stmt_try() {
         const the_try = token_now;
         let ignored;
         let the_catch;
@@ -4683,9 +5660,277 @@ function jslint_phase3_parse(state) {
         the_try.disrupt = the_disrupt;
         functionage.try -= 1;
         return the_try;
-    });
-    stmt("var", parse_var);
-    stmt("while", function stmt_while() {
+    }
+
+    function stmt_var() {
+        let ellipsis;
+        let mode_const;
+        let name;
+        let the_brace;
+        let the_bracket;
+        let the_variable = token_now;
+        let variable_prv;
+        mode_const = the_variable.id === "const";
+        the_variable.names = [];
+
+// A program may use var or let, but not both.
+
+        if (!mode_const) {
+            if (mode_var === undefined) {
+                mode_var = the_variable.id;
+            } else if (the_variable.id !== mode_var) {
+
+// test_cause:
+// ["let aa;var aa", "stmt_var", "expected_a_b", "var", 8]
+
+                warn("expected_a_b", the_variable, mode_var, the_variable.id);
+            }
+        }
+
+// We don't expect to see variables created in switch statements.
+
+        if (functionage.switch > 0) {
+
+// test_cause:
+// ["switch(0){case 0:var aa}", "stmt_var", "var_switch", "var", 18]
+
+            warn("var_switch", the_variable);
+        }
+        switch (
+            Boolean(functionage.statement_prv)
+            && functionage.statement_prv.id
+        ) {
+        case "const":
+        case "let":
+        case "var":
+
+// test_cause:
+// ["const aa=0;const bb=0;", "stmt_var", "var_prv", "const", 0]
+// ["let aa=0;let bb=0;", "stmt_var", "var_prv", "let", 0]
+// ["var aa=0;var bb=0;", "stmt_var", "var_prv", "var", 0]
+
+            test_cause("var_prv", functionage.statement_prv.id);
+            variable_prv = functionage.statement_prv;
+            break;
+        case "import":
+
+// test_cause:
+// ["import aa from \"aa\";\nlet bb=0;", "stmt_var", "import_prv", "", 0]
+
+            test_cause("import_prv");
+            break;
+        case false:
+            break;
+        default:
+            if (
+                (option_dict.beta && !option_dict.variable)
+                || the_variable.id === "var"
+            ) {
+
+// test_cause:
+// ["
+// /*jslint beta*/
+// console.log();let aa=0;
+// ", "stmt_var", "var_on_top", "let", 15]
+// ["console.log();var aa=0;", "stmt_var", "var_on_top", "var", 15]
+// ["try{aa();}catch(aa){var aa=0;}", "stmt_var", "var_on_top", "var", 21]
+// ["while(0){var aa;}", "stmt_var", "var_on_top", "var", 10]
+
+                warn("var_on_top", token_now);
+            }
+        }
+        while (true) {
+            if (token_nxt.id === "{") {
+                if (the_variable.id === "var") {
+
+// test_cause:
+// ["var{aa}=0", "stmt_var", "unexpected_a", "var", 1]
+
+                    warn("unexpected_a", the_variable);
+                }
+                the_brace = token_nxt;
+                advance("{");
+                while (true) {
+                    name = token_nxt;
+                    if (!name.identifier) {
+
+// test_cause:
+// ["let {0}", "stmt_var", "expected_identifier_a", "0", 6]
+
+                        return stop("expected_identifier_a");
+                    }
+                    survey(name);
+                    advance();
+                    if (token_nxt.id === ":") {
+                        advance(":");
+                        if (!token_nxt.identifier) {
+
+// test_cause:
+// ["let {aa:0}", "stmt_var", "expected_identifier_a", "0", 9]
+// ["let {aa:{aa}}", "stmt_var", "expected_identifier_a", "{", 9]
+
+                            return stop("expected_identifier_a");
+                        }
+                        token_nxt.label = name;
+                        the_variable.names.push(token_nxt);
+                        enroll(token_nxt, "variable", mode_const);
+                        advance();
+                        the_brace.open = true;
+                    } else {
+                        the_variable.names.push(name);
+                        enroll(name, "variable", mode_const);
+                    }
+                    name.dead = false;
+                    name.init = true;
+                    if (token_nxt.id === "=") {
+
+// test_cause:
+// ["let {aa=0}", "stmt_var", "assign", "", 0]
+
+                        test_cause("assign");
+                        advance("=");
+                        name.expression = parse_expression();
+                        the_brace.open = true;
+                    }
+                    if (token_nxt.id !== ",") {
+                        break;
+                    }
+                    advance(",");
+                }
+
+// test_cause:
+// ["let{bb,aa}", "check_ordered", "expected_a_b_before_c_d", "aa", 8]
+
+                check_ordered(the_variable.id, the_variable.names);
+                advance("}");
+                advance("=");
+                the_variable.expression = parse_expression(0);
+            } else if (token_nxt.id === "[") {
+                if (the_variable.id === "var") {
+
+// test_cause:
+// ["var[aa]=0", "stmt_var", "unexpected_a", "var", 1]
+
+                    warn("unexpected_a", the_variable);
+                }
+                the_bracket = token_nxt;
+                advance("[");
+                while (true) {
+                    ellipsis = false;
+                    if (token_nxt.id === "...") {
+                        ellipsis = true;
+                        advance("...");
+                    }
+                    if (!token_nxt.identifier) {
+
+// test_cause:
+// ["let[]", "stmt_var", "expected_identifier_a", "]", 5]
+
+                        return stop("expected_identifier_a");
+                    }
+                    name = token_nxt;
+                    advance();
+                    the_variable.names.push(name);
+                    enroll(name, "variable", mode_const);
+                    name.dead = false;
+                    name.init = true;
+                    if (ellipsis) {
+                        name.ellipsis = true;
+                        break;
+                    }
+                    if (token_nxt.id === "=") {
+                        advance("=");
+                        name.expression = parse_expression();
+                        the_bracket.open = true;
+                    }
+                    if (token_nxt.id !== ",") {
+                        break;
+                    }
+                    advance(",");
+                }
+                advance("]");
+                advance("=");
+                the_variable.expression = parse_expression(0);
+            } else if (token_nxt.identifier) {
+                name = token_nxt;
+                advance();
+                if (name.id === "ignore") {
+
+// test_cause:
+// ["
+// let ignore;function aa(ignore) {}
+// ", "stmt_var", "unexpected_a", "ignore", 5]
+
+                    warn("unexpected_a", name);
+                }
+                enroll(name, "variable", mode_const);
+                if (token_nxt.id === "=" || mode_const) {
+                    advance("=");
+                    name.dead = false;
+                    name.init = true;
+                    name.expression = parse_expression(0);
+                }
+                the_variable.names.push(name);
+            } else {
+
+// test_cause:
+// ["let 0", "stmt_var", "expected_identifier_a", "0", 5]
+// ["var{aa:{aa}}", "stmt_var", "expected_identifier_a", "{", 8]
+
+                return stop("expected_identifier_a");
+            }
+            if (token_nxt.id !== ",") {
+                break;
+            }
+
+// test_cause:
+// ["let aa,bb;", "stmt_var", "expected_a_b", ",", 7]
+
+            warn("expected_a_b", token_nxt, ";", ",");
+            advance(",");
+        }
+
+// Warn if variable declarations are unordered.
+
+        if (
+            option_dict.beta
+            && !option_dict.unordered
+            && !option_dict.variable
+            && variable_prv
+            && (
+                variable_prv.id + " " + variable_prv.names[0].id
+                > the_variable.id + " " + the_variable.names[0].id
+            )
+        ) {
+
+// test_cause:
+// ["
+// /*jslint beta*/
+// const bb=0;const aa=0;
+// ", "stmt_var", "expected_a_b_before_c_d", "aa", 12]
+// ["
+// /*jslint beta*/
+// let bb;let aa;
+// ", "stmt_var", "expected_a_b_before_c_d", "aa", 8]
+// ["
+// /*jslint beta*/
+// var bb;var aa;
+// ", "stmt_var", "expected_a_b_before_c_d", "aa", 8]
+
+            warn(
+                "expected_a_b_before_c_d",
+                the_variable,
+                the_variable.id,
+                the_variable.names[0].id,
+                variable_prv.id,
+                variable_prv.names[0].id
+            );
+        }
+        semicolon();
+        return the_variable;
+    }
+
+    function stmt_while() {
         const the_while = token_now;
         check_not_top_level(the_while);
         functionage.loop += 1;
@@ -4700,173 +5945,263 @@ function jslint_phase3_parse(state) {
         }
         functionage.loop -= 1;
         return the_while;
-    });
-    stmt("with", function stmt_with() {
+    }
+
+    function stmt_with() {
 
 // test_cause:
 // ["with", "stmt_with", "unexpected_a", "with", 1]
 
         stop("unexpected_a", token_now);
-    });
+    }
 
+    function survey(name) {
+        let id = name.id;
+
+// Tally the property name. If it is a string, only tally strings that conform
+// to the identifier rules.
+
+        if (id === "(string)") {
+            id = name.value;
+            if (!rx_identifier.test(id)) {
+                return id;
+            }
+        } else if (id === "`") {
+            if (name.value.length === 1) {
+                id = name.value[0].value;
+                if (!rx_identifier.test(id)) {
+                    return id;
+                }
+            }
+        } else if (!name.identifier) {
+
+// test_cause:
+// ["let aa={0:0}", "survey", "expected_identifier_a", "0", 9]
+
+            return stop("expected_identifier_a", name);
+        }
+
+// If we have seen this name before, increment its count.
+
+        if (typeof property_dict[id] === "number") {
+            property_dict[id] += 1;
+
+// If this is the first time seeing this property name, and if there is a
+// tenure list, then it must be on the list. Otherwise, it must conform to
+// the rules for good property names.
+
+        } else {
+            if (state.mode_property) {
+                if (tenure[id] !== true) {
+
+// test_cause:
+// ["/*property aa*/\naa.bb", "survey", "unregistered_property_a", "bb", 4]
+
+                    warn("unregistered_property_a", name);
+                }
+            } else if (
+                !option_dict.name
+                && name.identifier
+                && (
+                    // rx_weird_property
+                    /^_|\$|Sync$|_$/m
+                ).test(id)
+            ) {
+
+// test_cause:
+// ["aa.$", "survey", "weird_property_a", "$", 4]
+// ["aa._", "survey", "weird_property_a", "_", 4]
+// ["aa._aa", "survey", "weird_property_a", "_aa", 4]
+// ["aa.aaSync", "survey", "weird_property_a", "aaSync", 4]
+// ["aa.aa_", "survey", "weird_property_a", "aa_", 4]
+
+                warn("weird_property_a", name);
+            }
+            property_dict[id] = 1;
+        }
+        return id;
+    }
+
+// These functions are used to specify the grammar of our language:
+
+    function symbol(id, bp) {
+
+// Create a symbol if it does not already exist in the language's syntax.
+
+        let the_symbol = syntax_dict[id];
+        if (the_symbol === undefined) {
+            the_symbol = empty();
+            the_symbol.id = id;
+            the_symbol.lbp = bp || 0;
+            syntax_dict[id] = the_symbol;
+        }
+        return the_symbol;
+    }
+
+    function ternary(id1, id2) {
+
+// Create a ternary operator.
+
+        const the_symbol = symbol(id1, 30);
+        the_symbol.led = function parse_ternary_led(left) {
+            const the_token = token_now;
+            let second;
+            second = parse_expression(20);
+            advance(id2);
+            token_now.arity = "ternary";
+            the_token.arity = "ternary";
+            the_token.expression = [left, second, parse_expression(10)];
+            if (token_nxt.id !== ")") {
+
+// test_cause:
+// ["0?0:0", "parse_ternary_led", "use_open", "?", 2]
+
+                warn("use_open", the_token);
+            }
+            return the_token;
+        };
+        return the_symbol;
+    }
+
+// Now we parse JavaScript.
+// Begin defining the language.
+
+    assignment("%=");
+    assignment("&=");
+    assignment("*=");
+    assignment("+=");
+    assignment("-=");
+    assignment("/=");
+    assignment("<<=");
+    assignment("=");
+    assignment(">>=");
+    assignment(">>>=");
+    assignment("^=");
+    assignment("|=");
+    constant("(number)", "number");
+    constant("(regexp)", "regexp");
+    constant("(string)", "string");
+    constant("Function", "function", constant_Function);
+    constant("Infinity", "number", Infinity);
+    constant("NaN", "number", NaN);
+    constant("arguments", "object", constant_arguments);
+    constant("eval", "function", constant_eval);
+    constant("false", "boolean", false);
+    constant("ignore", "undefined", constant_ignore);
+    constant("isFinite", "function", constant_isInfinite);
+    constant("isNaN", "function", constant_isNaN);
+    constant("null", "null", null);
+    constant("this", "object", constant_this);
+    constant("true", "boolean", true);
+    constant("undefined", "undefined");
+    infix(100, "!=");
+    infix(100, "!==");
+    infix(100, "==");
+    infix(100, "===");
+    infix(110, "<");
+    infix(110, "<=");
+    infix(110, ">");
+    infix(110, ">=");
+    infix(110, "in");
+    infix(110, "instanceof");
+    infix(120, "<<");
+    infix(120, ">>");
+    infix(120, ">>>");
+    infix(130, "+");
+    infix(130, "-");
+    infix(140, "%");
+    infix(140, "*");
+    infix(140, "/");
+    infix(160, "(", infix_lparen);
+    infix(160, "`", infix_grave);
+    infix(170, ".", infix_dot);
+    infix(170, "=>", infix_fart_unwrapped);
+    infix(170, "?.", infix_option_chain);
+    infix(170, "[", infix_lbracket);
+    infix(35, "??");
+    infix(40, "||");
+    infix(50, "&&");
+    infix(70, "|");
+    infix(80, "^");
+    infix(90, "&");
+    infixr(150, "**");
+    postassign("++");
+    postassign("--");
+    preassign("++");
+    preassign("--");
+    prefix("!!");
+    prefix("!");
+    prefix("(", prefix_lparen);
+    prefix("+");
+    prefix("-");
+    prefix("/=", prefix_assign_divide);
+    prefix("=>", prefix_fart);
+    prefix("[", prefix_lbracket);
+    prefix("`", prefix_tick);
+    prefix("async", prefix_async);
+    prefix("await", prefix_await);
+    prefix("function", prefix_function);
+    prefix("new", prefix_new);
+    prefix("typeof");
+    prefix("void", prefix_void);
+    prefix("{", prefix_lbrace);
+    prefix("~");
+    stmt(";", stmt_semicolon);
+    stmt("async", prefix_async);
+    stmt("await", prefix_await);
+    stmt("break", stmt_break);
+    stmt("const", stmt_var);
+    stmt("continue", stmt_continue);
+    stmt("debugger", stmt_debugger);
+    stmt("delete", stmt_delete);
+    stmt("do", stmt_do);
+    stmt("export", stmt_export);
+    stmt("for", stmt_for);
+    stmt("function", prefix_function);
+    stmt("if", stmt_if);
+    stmt("import", stmt_import);
+    stmt("let", stmt_var);
+    stmt("return", stmt_return);
+    stmt("switch", stmt_switch);
+    stmt("throw", stmt_throw);
+    stmt("try", stmt_try);
+    stmt("var", stmt_var);
+    stmt("while", stmt_while);
+    stmt("with", stmt_with);
+    stmt("{", stmt_lbrace);
+    symbol(")");
+    symbol("*/");
+    symbol(",");
+    symbol(":");
+    symbol(";");
+    symbol("]");
+    symbol("async");
+    symbol("await");
+    symbol("case");
+    symbol("catch");
+    symbol("class");
+    symbol("default");
+    symbol("else");
+    symbol("enum");
+    symbol("finally");
+    symbol("implements");
+    symbol("interface");
+    symbol("package");
+    symbol("private");
+    symbol("protected");
+    symbol("public");
+    symbol("static");
+    symbol("super");
+    symbol("void");
+    symbol("yield");
+    symbol("}");
     ternary("?", ":");
+
+// Init token_nxt.
 
     advance();
 
 // Parsing of JSON is simple:
-
-    function parse_json() {
-        let container;
-        let is_dup;
-        let name;
-        let negative;
-        switch (token_nxt.id) {
-        case "(number)":
-            if (!rx_json_number.test(token_nxt.value)) {
-
-// test_cause:
-// ["[0x0]", "parse_json", "unexpected_a", "0x0", 2]
-
-                warn("unexpected_a");
-            }
-            advance();
-            return token_now;
-        case "(string)":
-            if (token_nxt.quote !== "\"") {
-
-// test_cause:
-// ["['']", "parse_json", "unexpected_a", "'", 2]
-
-                warn("unexpected_a", token_nxt, token_nxt.quote);
-            }
-            advance();
-            return token_now;
-        case "-":
-            negative = token_nxt;
-            negative.arity = "unary";
-            advance("-");
-            advance("(number)");
-            if (!rx_json_number.test(token_now.value)) {
-
-// test_cause:
-// ["[-0x0]", "parse_json", "unexpected_a", "0x0", 3]
-
-                warn("unexpected_a", token_now);
-            }
-            negative.expression = token_now;
-            return negative;
-        case "[":
-
-// test_cause:
-// ["[]", "parse_json", "bracket", "", 0]
-
-            test_cause("bracket");
-            container = token_nxt;
-            container.expression = [];
-            advance("[");
-            if (token_nxt.id !== "]") {
-                while (true) {
-
-// Recurse parse_json().
-
-                    container.expression.push(parse_json());
-                    if (token_nxt.id !== ",") {
-
-// test_cause:
-// ["[0,0]", "parse_json", "comma", "", 0]
-
-                        test_cause("comma");
-                        break;
-                    }
-                    advance(",");
-                }
-            }
-            advance("]", container);
-            return container;
-        case "false":
-        case "null":
-        case "true":
-
-// test_cause:
-// ["[false]", "parse_json", "advance", "", 0]
-// ["[null]", "parse_json", "advance", "", 0]
-// ["[true]", "parse_json", "advance", "", 0]
-
-            test_cause("advance");
-            advance();
-            return token_now;
-        case "{":
-
-// test_cause:
-// ["{}", "parse_json", "brace", "", 0]
-
-            test_cause("brace");
-            container = token_nxt;
-
-// Explicit empty-object required to detect "__proto__".
-
-            is_dup = empty();
-            container.expression = [];
-            advance("{");
-            if (token_nxt.id !== "}") {
-
-// JSON
-// Parse/loop through each property in {...}.
-
-                while (true) {
-                    if (token_nxt.quote !== "\"") {
-
-// test_cause:
-// ["{0:0}", "parse_json", "unexpected_a", "0", 2]
-
-                        warn(
-                            "unexpected_a",
-                            token_nxt,
-                            token_nxt.quote
-                        );
-                    }
-                    name = token_nxt;
-                    advance("(string)");
-                    if (is_dup[token_now.value] !== undefined) {
-
-// test_cause:
-// ["{\"aa\":0,\"aa\":0}", "parse_json", "duplicate_a", "aa", 9]
-
-                        warn("duplicate_a", token_now);
-                    } else if (token_now.value === "__proto__") {
-
-// test_cause:
-// ["{\"__proto__\":0}", "parse_json", "weird_property_a", "__proto__", 2]
-
-                        warn("weird_property_a", token_now);
-                    } else {
-                        is_dup[token_now.value] = token_now;
-                    }
-                    advance(":");
-                    container.expression.push(
-
-// Recurse parse_json().
-
-                        Object.assign(parse_json(), {
-                            label: name
-                        })
-                    );
-                    if (token_nxt.id !== ",") {
-                        break;
-                    }
-                    advance(",");
-                }
-            }
-            advance("}", container);
-            return container;
-        default:
-
-// test_cause:
-// ["[undefined]", "parse_json", "unexpected_a", "undefined", 2]
-
-            stop("unexpected_a");
-        }
-    }
 
     if (state.mode_json) {
         state.token_tree = parse_json();
@@ -4881,32 +6216,29 @@ function jslint_phase3_parse(state) {
         if (token_nxt.id === ";") {
             advance(";");
         }
-    } else {
 
 // If we are not in a browser, then the file form of strict pragma may be used.
 
-        if (token_nxt.value === "use strict") {
-            advance("(string)");
-            advance(";");
-        }
+    } else if (token_nxt.value === "use strict") {
+        advance("(string)");
+        advance(";");
     }
     state.token_tree = parse_statements();
     advance("(end)");
 
-// Check functions are ordered.
+// Check global functions are ordered.
 
-    function_level_list.forEach(function (list) {
-        check_ordered(
-            "function",
-            Array.from(list || []).map(function ({
-                name
-            }) {
-                return name;
-            }).filter(function (name) {
-                return option_dict.beta && name && name.id;
-            })
-        );
-    });
+    check_ordered(
+        "function",
+        function_list.map(function ({
+            level,
+            name
+        }) {
+            return (level === 1) && name;
+        }).filter(function (name) {
+            return option_dict.beta && name && name.id;
+        })
+    );
 }
 
 function jslint_phase4_walk(state) {
@@ -5021,112 +6353,15 @@ function jslint_phase4_walk(state) {
         };
     }
 
-    function post_export_import(the_thing) {
-
-// Some features must be at the most outermost level.
-
-        if (blockage !== token_global) {
-
-// test_cause:
-// ["
-// if(0){import aa from "aa";}
-// ", "post_export_import", "misplaced_a", "import", 7]
-
-            warn("misplaced_a", the_thing);
-        }
-    }
-
-    function walk_expression(thing) {
-        if (thing) {
-            if (Array.isArray(thing)) {
-
-// test_cause:
-// ["(function(){}())", "walk_expression", "isArray", "", 0]
-// ["0&&0", "walk_expression", "isArray", "", 0]
-
-                test_cause("isArray");
-                thing.forEach(walk_expression);
-            } else {
-                preamble(thing);
-                walk_expression(thing.expression);
-                if (thing.id === "function") {
-
-// test_cause:
-// ["aa=function(){}", "walk_expression", "function", "", 0]
-
-                    test_cause("function");
-                    walk_statement(thing.block);
-                }
-                if (thing.arity === "pre" || thing.arity === "post") {
-
-// test_cause:
-// ["aa=++aa", "walk_expression", "unexpected_a", "++", 4]
-// ["aa=--aa", "walk_expression", "unexpected_a", "--", 4]
-
-                    warn("unexpected_a", thing);
-                } else if (
-                    thing.arity === "statement"
-                    || thing.arity === "assignment"
-                ) {
-
-// test_cause:
-// ["aa[aa=0]", "walk_expression", "unexpected_statement_a", "=", 6]
-
-                    warn("unexpected_statement_a", thing);
-                }
-
-// test_cause:
-// ["aa=0", "walk_expression", "default", "", 0]
-
-                test_cause("default");
-                postamble(thing);
+    function init_variable(name) {
+        const the_variable = lookup(name);
+        if (the_variable !== undefined) {
+            if (the_variable.writable) {
+                the_variable.init = true;
+                return;
             }
         }
-    }
-
-    function walk_statement(thing) {
-        if (thing) {
-            if (Array.isArray(thing)) {
-
-// test_cause:
-// ["+[]", "walk_statement", "isArray", "", 0]
-
-                test_cause("isArray");
-                thing.forEach(walk_statement);
-            } else {
-                preamble(thing);
-                walk_expression(thing.expression);
-                if (thing.arity === "binary") {
-                    if (thing.id !== "(") {
-
-// test_cause:
-// ["0&&0", "walk_statement", "unexpected_expression_a", "&&", 2]
-
-                        warn("unexpected_expression_a", thing);
-                    }
-                } else if (
-                    thing.arity !== "statement"
-                    && thing.arity !== "assignment"
-                    && thing.id !== "import"
-                ) {
-
-// test_cause:
-// ["!0", "walk_statement", "unexpected_expression_a", "!", 1]
-// ["+[]", "walk_statement", "unexpected_expression_a", "+", 1]
-// ["+new aa()", "walk_statement", "unexpected_expression_a", "+", 1]
-// ["0", "walk_statement", "unexpected_expression_a", "0", 1]
-// ["
-// async function aa(){await 0;}
-// ", "walk_statement", "unexpected_expression_a", "0", 27]
-// ["typeof 0", "walk_statement", "unexpected_expression_a", "typeof", 1]
-
-                    warn("unexpected_expression_a", thing);
-                }
-                walk_statement(thing.block);
-                walk_statement(thing.else);
-                postamble(thing);
-            }
-        }
+        warn("bad_assignment_a", name);
     }
 
     function lookup(thing) {
@@ -5210,367 +6445,7 @@ function jslint_phase4_walk(state) {
         }
     }
 
-    function subactivate(name) {
-        name.init = true;
-        name.dead = false;
-        blockage.live.push(name);
-    }
-
-    function pre_function(thing) {
-
-// test_cause:
-// ["()=>0", "pre_function", "", "", 0]
-// ["(function (){}())", "pre_function", "", "", 0]
-// ["function aa(){}", "pre_function", "", "", 0]
-
-        test_cause("");
-        if (thing.arity === "statement" && blockage.body !== true) {
-
-// test_cause:
-// ["if(0){function aa(){}\n}", "pre_function", "unexpected_a", "function", 7]
-
-            warn("unexpected_a", thing);
-        }
-        function_stack.push(functionage);
-        block_stack.push(blockage);
-        functionage = thing;
-        blockage = thing;
-        thing.live = [];
-        if (typeof thing.name === "object") {
-            thing.name.dead = false;
-            thing.name.init = true;
-        }
-        if (thing.extra === "get") {
-            if (thing.parameters.length !== 0) {
-
-// test_cause:
-// ["
-// /*jslint getset*/
-// aa={get aa(aa){}}
-// ", "pre_function", "bad_get", "function", 9]
-
-                warn("bad_get", thing);
-            }
-        } else if (thing.extra === "set") {
-            if (thing.parameters.length !== 1) {
-
-// test_cause:
-// ["
-// /*jslint getset*/
-// aa={set aa(){}}
-// ", "pre_function", "bad_set", "function", 9]
-
-                warn("bad_set", thing);
-            }
-        }
-        thing.parameters.forEach(function (name) {
-            walk_expression(name.expression);
-            if (name.id === "{" || name.id === "[") {
-                name.names.forEach(subactivate);
-            } else {
-                name.dead = false;
-                name.init = true;
-            }
-        });
-    }
-
-    function pre_bitwise(thing) {
-
-// These are the bitwise operators.
-
-        switch (!option_dict.bitwise && thing.id) {
-        case "&":
-        case "&=":
-        case "<<":
-        case "<<=":
-        case ">>":
-        case ">>=":
-        case ">>>":
-        case ">>>=":
-        case "^":
-        case "^=":
-        case "|":
-        case "|=":
-        case "~":
-
-// test_cause:
-// ["0&0", "pre_bitwise", "unexpected_a", "&", 2]
-// ["0&=0", "pre_bitwise", "unexpected_a", "&=", 2]
-// ["0<<0", "pre_bitwise", "unexpected_a", "<<", 2]
-// ["0<<=0", "pre_bitwise", "unexpected_a", "<<=", 2]
-// ["0>>0", "pre_bitwise", "unexpected_a", ">>", 2]
-// ["0>>=0", "pre_bitwise", "unexpected_a", ">>=", 2]
-// ["0>>>0", "pre_bitwise", "unexpected_a", ">>>", 2]
-// ["0>>>=0", "pre_bitwise", "unexpected_a", ">>>=", 2]
-// ["0^0", "pre_bitwise", "unexpected_a", "^", 2]
-// ["0^=0", "pre_bitwise", "unexpected_a", "^=", 2]
-// ["0|0", "pre_bitwise", "unexpected_a", "|", 2]
-// ["0|=0", "pre_bitwise", "unexpected_a", "|=", 2]
-// ["~0", "pre_bitwise", "unexpected_a", "~", 1]
-
-            warn("unexpected_a", thing);
-            break;
-        }
-        if (
-            thing.id !== "("
-            && thing.id !== "&&"
-            && thing.id !== "||"
-            && thing.id !== "="
-            && Array.isArray(thing.expression)
-            && thing.expression.length === 2
-            && (
-                relationop[thing.expression[0].id] === true
-                || relationop[thing.expression[1].id] === true
-            )
-        ) {
-
-// test_cause:
-// ["0<0<0", "pre_bitwise", "unexpected_a", "<", 4]
-
-            warn("unexpected_a", thing);
-        }
-    }
-
-    function pop_block() {
-        blockage.live.forEach(function (name) {
-            name.dead = true;
-        });
-        delete blockage.live;
-        blockage = block_stack.pop();
-    }
-
-    function post_var(thing) {
-        thing.names.forEach(function (name) {
-            name.dead = false;
-            if (name.expression !== undefined) {
-                walk_expression(name.expression);
-
-// Probably deadcode.
-// if (name.id === "{" || name.id === "[") {
-//     name.names.forEach(subactivate);
-// } else {
-//     name.init = true;
-// }
-
-                assert_or_throw(
-                    !(name.id === "{" || name.id === "["),
-                    `Expected !(name.id === "{" || name.id === "[").`
-                );
-                name.init = true;
-            }
-            blockage.live.push(name);
-        });
-    }
-
-    function init_variable(name) {
-        const the_variable = lookup(name);
-        if (the_variable !== undefined) {
-            if (the_variable.writable) {
-                the_variable.init = true;
-                return;
-            }
-        }
-        warn("bad_assignment_a", name);
-    }
-
-    function post_function(thing) {
-        delete functionage.async;
-        delete functionage.finally;
-        delete functionage.last_statement;
-        delete functionage.loop;
-        delete functionage.switch;
-        delete functionage.try;
-        functionage = function_stack.pop();
-        if (thing.wrapped) {
-
-// test_cause:
-// ["aa=(function(){})", "post_function", "unexpected_parens", "function", 5]
-
-            warn("unexpected_parens", thing);
-        }
-        return pop_block();
-    }
-
-    preaction = action(pres);
-    postaction = action(posts);
-    preamble = amble(pres);
-    postamble = amble(posts);
-
-    preaction("assignment", pre_bitwise);
-    preaction("binary", pre_bitwise);
-    preaction("binary", function pre_bin(thing) {
-        let left;
-        let right;
-        let value;
-        if (relationop[thing.id] === true) {
-            left = thing.expression[0];
-            right = thing.expression[1];
-            if (left.id === "NaN" || right.id === "NaN") {
-
-// test_cause:
-// ["NaN===NaN", "pre_bin", "number_isNaN", "===", 4]
-
-                warn("number_isNaN", thing);
-            } else if (left.id === "typeof") {
-                if (right.id !== "(string)") {
-                    if (right.id !== "typeof") {
-
-// test_cause:
-// ["typeof 0===0", "pre_bin", "expected_string_a", "0", 12]
-
-                        warn("expected_string_a", right);
-                    }
-                } else {
-                    value = right.value;
-                    if (value === "null" || value === "undefined") {
-
-// test_cause:
-// ["
-// typeof aa==="undefined"
-// ", "pre_bin", "unexpected_typeof_a", "undefined", 13]
-
-                        warn("unexpected_typeof_a", right, value);
-                    } else if (
-                        value !== "boolean"
-                        && value !== "function"
-                        && value !== "number"
-                        && value !== "object"
-                        && value !== "string"
-                        && value !== "symbol"
-                    ) {
-
-// test_cause:
-// ["typeof 0===\"aa\"", "pre_bin", "expected_type_string_a", "aa", 12]
-
-                        warn("expected_type_string_a", right, value);
-                    }
-                }
-            }
-        }
-    });
-    preaction("binary", "==", function pre_bin_eqeq(thing) {
-
-// test_cause:
-// ["0==0", "pre_bin_eqeq", "expected_a_b", "==", 2]
-
-        warn("expected_a_b", thing, "===", "==");
-    });
-    preaction("binary", "!=", function pre_bin_noteq(thing) {
-
-// test_cause:
-// ["0!=0", "pre_bin_noteq", "expected_a_b", "!=", 2]
-
-        warn("expected_a_b", thing, "!==", "!=");
-    });
-    preaction("binary", "=>", pre_function);
-    preaction("binary", "||", function pre_bin_or(thing) {
-        thing.expression.forEach(function (thang) {
-            if (thang.id === "&&" && !thang.wrapped) {
-
-// test_cause:
-// ["0&&0||0", "pre_bin_or", "and", "&&", 2]
-
-                warn("and", thang);
-            }
-        });
-    });
-    preaction("binary", "(", function pre_bin_lparen(thing) {
-        const left = thing.expression[0];
-        let left_variable;
-        let parent;
-        if (
-            left.identifier
-            && functionage.context[left.id] === undefined
-            && typeof functionage.name === "object"
-        ) {
-            parent = functionage.name.parent;
-            if (parent) {
-                left_variable = parent.context[left.id];
-                if (
-                    left_variable !== undefined
-                    // coverage-hack
-                    // && left_variable.dead
-                    && left_variable.parent === parent
-                    && left_variable.calls !== undefined
-                    && left_variable.calls[functionage.name.id] !== undefined
-                ) {
-                    left_variable.dead = false;
-                }
-            }
-        }
-    });
-    preaction("binary", "in", function pre_bin_in(thing) {
-
-// test_cause:
-// ["aa in aa", "pre_bin_in", "infix_in", "in", 4]
-
-        warn("infix_in", thing);
-    });
-    preaction("binary", "instanceof", function pre_bin_instanceof(thing) {
-
-// test_cause:
-// ["0 instanceof 0", "pre_bin_instanceof", "unexpected_a", "instanceof", 3]
-
-        warn("unexpected_a", thing);
-    });
-    preaction("statement", "{", function pre_stmt_lbrace(thing) {
-        block_stack.push(blockage);
-        blockage = thing;
-        thing.live = [];
-    });
-    preaction("statement", "for", function pre_stmt_for(thing) {
-        let the_variable;
-        if (thing.name !== undefined) {
-            the_variable = lookup(thing.name);
-            if (the_variable !== undefined) {
-                the_variable.init = true;
-                if (!the_variable.writable) {
-
-// test_cause:
-// ["const aa=0;for(aa in aa){}", "pre_stmt_for", "bad_assignment_a", "aa", 16]
-
-                    warn("bad_assignment_a", thing.name);
-                }
-            }
-        }
-        walk_statement(thing.initial);
-    });
-    preaction("statement", "function", pre_function);
-    preaction("statement", "try", function (thing) {
-        if (thing.catch !== undefined) {
-
-// Create new catch-scope for catch-parameter.
-
-            catch_stack.push(catchage);
-            catchage = thing.catch;
-        }
-    });
-    preaction("unary", "~", pre_bitwise);
-    preaction("unary", "function", pre_function);
-    preaction("variable", function (thing) {
-        const the_variable = lookup(thing);
-        if (the_variable !== undefined) {
-            thing.variable = the_variable;
-            the_variable.used += 1;
-        }
-    });
-
-    postaction("assignment", "+=", function (thing) {
-        const right = thing.expression[1];
-        if (right.constant) {
-            if (
-                right.value === ""
-                || (right.id === "(number)" && right.value === "0")
-                || right.id === "(boolean)"
-                || right.id === "null"
-                || right.id === "undefined"
-                || Number.isNaN(right.value)
-            ) {
-                warn("unexpected_a", right);
-            }
-        }
-    });
-    postaction("assignment", function post_assign(thing) {
+    function post_a(thing) {
 
 // Assignment using = sets the init property of a variable. No other assignment
 // operator can do this. A = token keeps that variable (or array of variables
@@ -5582,7 +6457,7 @@ function jslint_phase4_walk(state) {
             if (thing.names !== undefined) {
 
 // test_cause:
-// ["if(0){aa=0}", "post_assign", "=", "", 0]
+// ["if(0){aa=0}", "post_a", "=", "", 0]
 
                 test_cause("=");
 
@@ -5611,7 +6486,7 @@ function jslint_phase4_walk(state) {
                 ) {
 
 // test_cause:
-// ["aa.aa=undefined", "post_assign", "expected_a_b", "undefined", 1]
+// ["aa.aa=undefined", "post_a", "expected_a_b", "undefined", 1]
 
                     warn(
                         "expected_a_b",
@@ -5642,14 +6517,30 @@ function jslint_phase4_walk(state) {
             ) {
 
 // test_cause:
-// ["aa+=undefined", "post_assign", "unexpected_a", "undefined", 5]
+// ["aa+=undefined", "post_a", "unexpected_a", "undefined", 5]
 
                 warn("unexpected_a", thing.expression[1]);
             }
         }
-    });
+    }
 
-    postaction("binary", function post_bin(thing) {
+    function post_a_pluseq(thing) {
+        const right = thing.expression[1];
+        if (right.constant) {
+            if (
+                right.value === ""
+                || (right.id === "(number)" && right.value === "0")
+                || right.id === "(boolean)"
+                || right.id === "null"
+                || right.id === "undefined"
+                || Number.isNaN(right.value)
+            ) {
+                warn("unexpected_a", right);
+            }
+        }
+    }
+
+    function post_b(thing) {
         let right;
         if (relationop[thing.id]) {
             if (
@@ -5663,7 +6554,7 @@ function jslint_phase4_walk(state) {
             ) {
 
 // test_cause:
-// ["if(0===0){0}", "post_bin", "weird_relation_a", "===", 5]
+// ["if(0===0){0}", "post_b", "weird_relation_a", "===", 5]
 
                 warn("weird_relation_a", thing);
             }
@@ -5673,13 +6564,13 @@ function jslint_phase4_walk(state) {
                 if (thing.expression[0].value === "") {
 
 // test_cause:
-// ["\"\"+0", "post_bin", "expected_a_b", "\"\" +", 3]
+// ["\"\"+0", "post_b", "expected_a_b", "\"\" +", 3]
 
                     warn("expected_a_b", thing, "String(...)", "\"\" +");
                 } else if (thing.expression[1].value === "") {
 
 // test_cause:
-// ["0+\"\"", "post_bin", "expected_a_b", "+ \"\"", 2]
+// ["0+\"\"", "post_b", "expected_a_b", "+ \"\"", 2]
 
                     warn("expected_a_b", thing, "String(...)", "+ \"\"");
                 }
@@ -5688,14 +6579,14 @@ function jslint_phase4_walk(state) {
             if (thing.expression[0].id === "window") {
 
 // test_cause:
-// ["aa=window[0]", "post_bin", "weird_expression_a", "window[...]", 10]
+// ["aa=window[0]", "post_b", "weird_expression_a", "window[...]", 10]
 
                 warn("weird_expression_a", thing, "window[...]");
             }
             if (thing.expression[0].id === "self") {
 
 // test_cause:
-// ["aa=self[0]", "post_bin", "weird_expression_a", "self[...]", 8]
+// ["aa=self[0]", "post_b", "weird_expression_a", "self[...]", 8]
 
                 warn("weird_expression_a", thing, "self[...]");
             }
@@ -5703,7 +6594,7 @@ function jslint_phase4_walk(state) {
             if (thing.expression.id === "RegExp") {
 
 // test_cause:
-// ["aa=RegExp.aa", "post_bin", "weird_expression_a", ".", 10]
+// ["aa=RegExp.aa", "post_b", "weird_expression_a", ".", 10]
 
                 warn("weird_expression_a", thing);
             }
@@ -5717,7 +6608,7 @@ function jslint_phase4_walk(state) {
             ) {
 
 // test_cause:
-// ["0- -0", "post_bin", "wrap_unary", "-", 4]
+// ["0- -0", "post_b", "wrap_unary", "-", 4]
 
                 warn("wrap_unary", right);
             }
@@ -5728,8 +6619,9 @@ function jslint_phase4_walk(state) {
                 thing.constant = true;
             }
         }
-    });
-    postaction("binary", "&&", function post_bin_and(thing) {
+    }
+
+    function post_b_and(thing) {
         if (
             is_weird(thing.expression[0])
             || is_equal(thing.expression[0], thing.expression[1])
@@ -5738,35 +6630,39 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["aa=(()=>0)&&(()=>0)", "post_bin_and", "weird_condition_a", "&&", 11]
-// ["aa=(``?``:``)&&(``?``:``)", "post_bin_and", "weird_condition_a", "&&", 14]
-// ["aa=/./&&/./", "post_bin_and", "weird_condition_a", "&&", 7]
-// ["aa=0&&0", "post_bin_and", "weird_condition_a", "&&", 5]
-// ["aa=[]&&[]", "post_bin_and", "weird_condition_a", "&&", 6]
-// ["aa=`${0}`&&`${0}`", "post_bin_and", "weird_condition_a", "&&", 10]
+// ["aa=(()=>0)&&(()=>0)", "post_b_and", "weird_condition_a", "&&", 11]
+// ["aa=(``?``:``)&&(``?``:``)", "post_b_and", "weird_condition_a", "&&", 14]
+// ["aa=/./&&/./", "post_b_and", "weird_condition_a", "&&", 7]
+// ["aa=0&&0", "post_b_and", "weird_condition_a", "&&", 5]
+// ["aa=[]&&[]", "post_b_and", "weird_condition_a", "&&", 6]
+// ["aa=`${0}`&&`${0}`", "post_b_and", "weird_condition_a", "&&", 10]
 // ["
 // aa=function aa(){}&&function aa(){}
-// ", "post_bin_and", "weird_condition_a", "&&", 19]
-// ["aa={}&&{}", "post_bin_and", "weird_condition_a", "&&", 6]
+// ", "post_b_and", "weird_condition_a", "&&", 19]
+// ["aa={}&&{}", "post_b_and", "weird_condition_a", "&&", 6]
 
             warn("weird_condition_a", thing);
         }
-    });
-    postaction("binary", "||", function post_bin_or(thing) {
-        if (
-            is_weird(thing.expression[0])
-            || is_equal(thing.expression[0], thing.expression[1])
-            || thing.expression[0].constant === true
-        ) {
+    }
+
+    function post_b_lbracket(thing) {
+        if (thing.expression[0].id === "RegExp") {
 
 // test_cause:
-// ["aa=0||0", "post_bin_or", "weird_condition_a", "||", 5]
+// ["aa=RegExp[0]", "post_b_lbracket", "weird_expression_a", "[", 10]
 
-            warn("weird_condition_a", thing);
+            warn("weird_expression_a", thing);
         }
-    });
-    postaction("binary", "=>", post_function);
-    postaction("binary", "(", function post_bin_lparen(thing) {
+        if (is_weird(thing.expression[1])) {
+
+// test_cause:
+// ["aa[[0]]", "post_b_lbracket", "weird_expression_a", "[", 4]
+
+            warn("weird_expression_a", thing.expression[1]);
+        }
+    }
+
+    function post_b_lparen(thing) {
         let arg;
         let array;
         let cack;
@@ -5782,7 +6678,7 @@ function jslint_phase4_walk(state) {
             if (!thing.wrapped) {
 
 // test_cause:
-// ["aa=function(){}()", "post_bin_lparen", "wrap_immediate", "(", 16]
+// ["aa=function(){}()", "post_b_lparen", "wrap_immediate", "(", 16]
 
                 warn("wrap_immediate", thing);
             }
@@ -5797,18 +6693,18 @@ function jslint_phase4_walk(state) {
                 ) {
 
 // test_cause:
-// ["new Boolean()", "post_bin_lparen", "unexpected_a", "new", 1]
-// ["new Number()", "post_bin_lparen", "unexpected_a", "new", 1]
-// ["new String()", "post_bin_lparen", "unexpected_a", "new", 1]
-// ["new Symbol()", "post_bin_lparen", "unexpected_a", "new", 1]
-// ["new aa()", "post_bin_lparen", "unexpected_a", "new", 1]
+// ["new Boolean()", "post_b_lparen", "unexpected_a", "new", 1]
+// ["new Number()", "post_b_lparen", "unexpected_a", "new", 1]
+// ["new String()", "post_b_lparen", "unexpected_a", "new", 1]
+// ["new Symbol()", "post_b_lparen", "unexpected_a", "new", 1]
+// ["new aa()", "post_b_lparen", "unexpected_a", "new", 1]
 
                     warn("unexpected_a", the_new);
                 } else if (left.id === "Function") {
                     if (!option_dict.eval) {
 
 // test_cause:
-// ["new Function()", "post_bin_lparen", "unexpected_a", "new Function", 5]
+// ["new Function()", "post_b_lparen", "unexpected_a", "new Function", 5]
 
                         warn("unexpected_a", left, "new Function");
                     }
@@ -5817,14 +6713,14 @@ function jslint_phase4_walk(state) {
                     if (arg.length !== 2 || arg[1].id === "(string)") {
 
 // test_cause:
-// ["new Array()", "post_bin_lparen", "expected_a_b", "new Array", 5]
+// ["new Array()", "post_b_lparen", "expected_a_b", "new Array", 5]
 
                         warn("expected_a_b", left, "[]", "new Array");
                     }
                 } else if (left.id === "Object") {
 
 // test_cause:
-// ["new Object()", "post_bin_lparen", "expected_a_b", "new Object", 5]
+// ["new Object()", "post_b_lparen", "expected_a_b", "new Object", 5]
 
                     warn(
                         "expected_a_b",
@@ -5844,7 +6740,7 @@ function jslint_phase4_walk(state) {
                 ) {
 
 // test_cause:
-// ["let Aa=Aa()", "post_bin_lparen", "expected_a_before_b", "Aa", 8]
+// ["let Aa=Aa()", "post_b_lparen", "expected_a_before_b", "Aa", 8]
 
                     warn("expected_a_before_b", left, "new", artifact(left));
                 }
@@ -5854,7 +6750,7 @@ function jslint_phase4_walk(state) {
             if (left.expression.id === "Date" && left.name.id === "UTC") {
 
 // test_cause:
-// ["new Date.UTC()", "post_bin_lparen", "cack", "", 0]
+// ["new Date.UTC()", "post_b_lparen", "cack", "", 0]
 
                 test_cause("cack");
                 cack = !cack;
@@ -5866,13 +6762,13 @@ function jslint_phase4_walk(state) {
                 if (the_new !== undefined) {
 
 // test_cause:
-// ["new Date.UTC()", "post_bin_lparen", "unexpected_a", "new", 1]
+// ["new Date.UTC()", "post_b_lparen", "unexpected_a", "new", 1]
 
                     warn("unexpected_a", the_new);
                 } else {
 
 // test_cause:
-// ["let Aa=Aa.Aa()", "post_bin_lparen", "expected_a_before_b", "Aa", 8]
+// ["let Aa=Aa.Aa()", "post_b_lparen", "expected_a_before_b", "Aa", 8]
 
                     warn(
                         "expected_a_before_b",
@@ -5896,7 +6792,7 @@ function jslint_phase4_walk(state) {
 // test_cause:
 // ["
 // new Date().getTime()
-// ", "post_bin_lparen", "expected_a_b", "new Date().getTime()", 1]
+// ", "post_b_lparen", "expected_a_b", "new Date().getTime()", 1]
 
                             warn(
                                 "expected_a_b",
@@ -5909,31 +6805,60 @@ function jslint_phase4_walk(state) {
                 }
             }
         }
-    });
-    postaction("binary", "[", function post_bin_lbracket(thing) {
-        if (thing.expression[0].id === "RegExp") {
+    }
+
+    function post_b_or(thing) {
+        if (
+            is_weird(thing.expression[0])
+            || is_equal(thing.expression[0], thing.expression[1])
+            || thing.expression[0].constant === true
+        ) {
 
 // test_cause:
-// ["aa=RegExp[0]", "post_bin_lbracket", "weird_expression_a", "[", 10]
+// ["aa=0||0", "post_b_or", "weird_condition_a", "||", 5]
 
-            warn("weird_expression_a", thing);
+            warn("weird_condition_a", thing);
         }
-        if (is_weird(thing.expression[1])) {
+    }
+
+    function post_s_export(the_thing) {
+
+// Some features must be at the most outermost level.
+
+        if (blockage !== token_global) {
 
 // test_cause:
-// ["aa[[0]]", "post_bin_lbracket", "weird_expression_a", "[", 4]
+// ["
+// if(0){import aa from "aa";}
+// ", "post_s_export", "misplaced_a", "import", 7]
 
-            warn("weird_expression_a", thing.expression[1]);
+            warn("misplaced_a", the_thing);
         }
-    });
-    postaction("statement", "{", pop_block);
-    postaction("statement", "const", post_var);
-    postaction("statement", "export", post_export_import);
-    postaction("statement", "for", function (thing) {
+    }
+
+    function post_s_for(thing) {
         walk_statement(thing.inc);
-    });
-    postaction("statement", "function", post_function);
-    postaction("statement", "import", function (the_thing) {
+    }
+
+    function post_s_function(thing) {
+        delete functionage.async;
+        delete functionage.finally;
+        delete functionage.loop;
+        delete functionage.statement_prv;
+        delete functionage.switch;
+        delete functionage.try;
+        functionage = function_stack.pop();
+        if (thing.wrapped) {
+
+// test_cause:
+// ["aa=(function(){})", "post_s_function", "unexpected_parens", "function", 5]
+
+            warn("unexpected_parens", thing);
+        }
+        return post_s_lbrace();
+    }
+
+    function post_s_import(the_thing) {
         const name = the_thing.name;
         if (name) {
             if (Array.isArray(name)) {
@@ -5947,11 +6872,19 @@ function jslint_phase4_walk(state) {
                 name.init = true;
                 blockage.live.push(name);
             }
-            return post_export_import(the_thing);
+            return post_s_export(the_thing);
         }
-    });
-    postaction("statement", "let", post_var);
-    postaction("statement", "try", function (thing) {
+    }
+
+    function post_s_lbrace() {
+        blockage.live.forEach(function (name) {
+            name.dead = true;
+        });
+        delete blockage.live;
+        blockage = block_stack.pop();
+    }
+
+    function post_s_try(thing) {
         if (thing.catch) {
             if (thing.catch.name) {
                 Object.assign(catchage.context[thing.catch.name.id], {
@@ -5965,9 +6898,32 @@ function jslint_phase4_walk(state) {
 
             catchage = catch_stack.pop();
         }
-    });
-    postaction("statement", "var", post_var);
-    postaction("ternary", function post_ternary(thing) {
+    }
+
+    function post_s_var(thing) {
+        thing.names.forEach(function (name) {
+            name.dead = false;
+            if (name.expression !== undefined) {
+                walk_expression(name.expression);
+
+// Probably deadcode.
+// if (name.id === "{" || name.id === "[") {
+//     name.names.forEach(subactivate);
+// } else {
+//     name.init = true;
+// }
+
+                assert_or_throw(
+                    !(name.id === "{" || name.id === "["),
+                    `Expected !(name.id === "{" || name.id === "[").`
+                );
+                name.init = true;
+            }
+            blockage.live.push(name);
+        });
+    }
+
+    function post_t(thing) {
         if (
             is_weird(thing.expression[0])
             || thing.expression[0].constant === true
@@ -5977,13 +6933,13 @@ function jslint_phase4_walk(state) {
         } else if (is_equal(thing.expression[0], thing.expression[1])) {
 
 // test_cause:
-// ["aa?aa:0", "post_ternary", "expected_a_b", "?", 3]
+// ["aa?aa:0", "post_t", "expected_a_b", "?", 3]
 
             warn("expected_a_b", thing, "||", "?");
         } else if (is_equal(thing.expression[0], thing.expression[2])) {
 
 // test_cause:
-// ["aa?0:aa", "post_ternary", "expected_a_b", "?", 3]
+// ["aa?0:aa", "post_t", "expected_a_b", "?", 3]
 
             warn("expected_a_b", thing, "&&", "?");
         } else if (
@@ -5992,7 +6948,7 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["aa?true:false", "post_ternary", "expected_a_b", "?", 3]
+// ["aa?true:false", "post_t", "expected_a_b", "?", 3]
 
             warn("expected_a_b", thing, "!!", "?");
         } else if (
@@ -6001,7 +6957,7 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["aa?false:true", "post_ternary", "expected_a_b", "?", 3]
+// ["aa?false:true", "post_t", "expected_a_b", "?", 3]
 
             warn("expected_a_b", thing, "!", "?");
         } else if (
@@ -6013,12 +6969,13 @@ function jslint_phase4_walk(state) {
         ) {
 
 // test_cause:
-// ["(aa&&!aa?0:1)", "post_ternary", "wrap_condition", "&&", 4]
+// ["(aa&&!aa?0:1)", "post_t", "wrap_condition", "&&", 4]
 
             warn("wrap_condition", thing.expression[0]);
         }
-    });
-    postaction("unary", function post_unary(thing) {
+    }
+
+    function post_u(thing) {
         if (thing.id === "`") {
             if (thing.expression.every(function (thing) {
                 return thing.constant;
@@ -6033,7 +6990,7 @@ function jslint_phase4_walk(state) {
             if (!option_dict.convert) {
 
 // test_cause:
-// ["!!0", "post_unary", "expected_a_b", "!!", 1]
+// ["!!0", "post_u", "expected_a_b", "!!", 1]
 
                 warn("expected_a_b", thing, "Boolean(...)", "!!");
             }
@@ -6047,14 +7004,14 @@ function jslint_phase4_walk(state) {
                 thing.constant = true;
             }
         }
-    });
-    postaction("unary", "function", post_function);
-    postaction("unary", "+", function post_unary_plus(thing) {
+    }
+
+    function post_u_plus(thing) {
         const right = thing.expression;
         if (!option_dict.convert) {
 
 // test_cause:
-// ["aa=+0", "post_unary_plus", "expected_a_b", "+", 4]
+// ["aa=+0", "post_u_plus", "expected_a_b", "+", 4]
 
             warn("expected_a_b", thing, "Number(...)", "+");
         }
@@ -6067,7 +7024,423 @@ function jslint_phase4_walk(state) {
         ) {
             warn("unexpected_a", thing, "+");
         }
-    });
+    }
+
+    function pre_a_bitwise(thing) {
+
+// These are the bitwise operators.
+
+        switch (!option_dict.bitwise && thing.id) {
+        case "&":
+        case "&=":
+        case "<<":
+        case "<<=":
+        case ">>":
+        case ">>=":
+        case ">>>":
+        case ">>>=":
+        case "^":
+        case "^=":
+        case "|":
+        case "|=":
+        case "~":
+
+// test_cause:
+// ["0&0", "pre_a_bitwise", "unexpected_a", "&", 2]
+// ["0&=0", "pre_a_bitwise", "unexpected_a", "&=", 2]
+// ["0<<0", "pre_a_bitwise", "unexpected_a", "<<", 2]
+// ["0<<=0", "pre_a_bitwise", "unexpected_a", "<<=", 2]
+// ["0>>0", "pre_a_bitwise", "unexpected_a", ">>", 2]
+// ["0>>=0", "pre_a_bitwise", "unexpected_a", ">>=", 2]
+// ["0>>>0", "pre_a_bitwise", "unexpected_a", ">>>", 2]
+// ["0>>>=0", "pre_a_bitwise", "unexpected_a", ">>>=", 2]
+// ["0^0", "pre_a_bitwise", "unexpected_a", "^", 2]
+// ["0^=0", "pre_a_bitwise", "unexpected_a", "^=", 2]
+// ["0|0", "pre_a_bitwise", "unexpected_a", "|", 2]
+// ["0|=0", "pre_a_bitwise", "unexpected_a", "|=", 2]
+// ["~0", "pre_a_bitwise", "unexpected_a", "~", 1]
+
+            warn("unexpected_a", thing);
+            break;
+        }
+        if (
+            thing.id !== "("
+            && thing.id !== "&&"
+            && thing.id !== "||"
+            && thing.id !== "="
+            && Array.isArray(thing.expression)
+            && thing.expression.length === 2
+            && (
+                relationop[thing.expression[0].id] === true
+                || relationop[thing.expression[1].id] === true
+            )
+        ) {
+
+// test_cause:
+// ["0<0<0", "pre_a_bitwise", "unexpected_a", "<", 4]
+
+            warn("unexpected_a", thing);
+        }
+    }
+
+    function pre_b(thing) {
+        let left;
+        let right;
+        let value;
+        if (relationop[thing.id] === true) {
+            left = thing.expression[0];
+            right = thing.expression[1];
+            if (left.id === "NaN" || right.id === "NaN") {
+
+// test_cause:
+// ["NaN===NaN", "pre_b", "number_isNaN", "===", 4]
+
+                warn("number_isNaN", thing);
+            } else if (left.id === "typeof") {
+                if (right.id !== "(string)") {
+                    if (right.id !== "typeof") {
+
+// test_cause:
+// ["typeof 0===0", "pre_b", "expected_string_a", "0", 12]
+
+                        warn("expected_string_a", right);
+                    }
+                } else {
+                    value = right.value;
+                    if (value === "null" || value === "undefined") {
+
+// test_cause:
+// ["
+// typeof aa==="undefined"
+// ", "pre_b", "unexpected_typeof_a", "undefined", 13]
+
+                        warn("unexpected_typeof_a", right, value);
+                    } else if (
+                        value !== "boolean"
+                        && value !== "function"
+                        && value !== "number"
+                        && value !== "object"
+                        && value !== "string"
+                        && value !== "symbol"
+                    ) {
+
+// test_cause:
+// ["typeof 0===\"aa\"", "pre_b", "expected_type_string_a", "aa", 12]
+
+                        warn("expected_type_string_a", right, value);
+                    }
+                }
+            }
+        }
+    }
+
+    function pre_b_eqeq(thing) {
+
+// test_cause:
+// ["0==0", "pre_b_eqeq", "expected_a_b", "==", 2]
+
+        warn("expected_a_b", thing, "===", "==");
+    }
+
+    function pre_b_in(thing) {
+
+// test_cause:
+// ["aa in aa", "pre_b_in", "infix_in", "in", 4]
+
+        warn("infix_in", thing);
+    }
+
+    function pre_b_instanceof(thing) {
+
+// test_cause:
+// ["0 instanceof 0", "pre_b_instanceof", "unexpected_a", "instanceof", 3]
+
+        warn("unexpected_a", thing);
+    }
+
+    function pre_b_lparen(thing) {
+        const left = thing.expression[0];
+        let left_variable;
+        let parent;
+        if (
+            left.identifier
+            && functionage.context[left.id] === undefined
+            && typeof functionage.name === "object"
+        ) {
+            parent = functionage.name.parent;
+            if (parent) {
+                left_variable = parent.context[left.id];
+                if (
+                    left_variable !== undefined
+                    // coverage-hack
+                    // && left_variable.dead
+                    && left_variable.parent === parent
+                    && left_variable.calls !== undefined
+                    && left_variable.calls[functionage.name.id] !== undefined
+                ) {
+                    left_variable.dead = false;
+                }
+            }
+        }
+    }
+
+    function pre_b_noteq(thing) {
+
+// test_cause:
+// ["0!=0", "pre_b_noteq", "expected_a_b", "!=", 2]
+
+        warn("expected_a_b", thing, "!==", "!=");
+    }
+
+    function pre_b_or(thing) {
+        thing.expression.forEach(function (thang) {
+            if (thang.id === "&&" && !thang.wrapped) {
+
+// test_cause:
+// ["0&&0||0", "pre_b_or", "and", "&&", 2]
+
+                warn("and", thang);
+            }
+        });
+    }
+
+    function pre_s_f(thing) {
+
+// test_cause:
+// ["()=>0", "pre_s_f", "", "", 0]
+// ["(function (){}())", "pre_s_f", "", "", 0]
+// ["function aa(){}", "pre_s_f", "", "", 0]
+
+        test_cause("");
+        if (thing.arity === "statement" && blockage.body !== true) {
+
+// test_cause:
+// ["if(0){function aa(){}\n}", "pre_s_f", "unexpected_a", "function", 7]
+
+            warn("unexpected_a", thing);
+        }
+        function_stack.push(functionage);
+        block_stack.push(blockage);
+        functionage = thing;
+        blockage = thing;
+        thing.live = [];
+        if (typeof thing.name === "object") {
+            thing.name.dead = false;
+            thing.name.init = true;
+        }
+        if (thing.extra === "get") {
+            if (thing.parameters.length !== 0) {
+
+// test_cause:
+// ["/*jslint getset*/\naa={get aa(aa){}}", "pre_s_f", "bad_get", "function", 9]
+
+                warn("bad_get", thing);
+            }
+        } else if (thing.extra === "set") {
+            if (thing.parameters.length !== 1) {
+
+// test_cause:
+// ["/*jslint getset*/\naa={set aa(){}}", "pre_s_f", "bad_set", "function", 9]
+
+                warn("bad_set", thing);
+            }
+        }
+        thing.parameters.forEach(function (name) {
+            walk_expression(name.expression);
+            if (name.id === "{" || name.id === "[") {
+                name.names.forEach(subactivate);
+            } else {
+                name.dead = false;
+                name.init = true;
+            }
+        });
+    }
+
+    function pre_s_for(thing) {
+        let the_variable;
+        if (thing.name !== undefined) {
+            the_variable = lookup(thing.name);
+            if (the_variable !== undefined) {
+                the_variable.init = true;
+                if (!the_variable.writable) {
+
+// test_cause:
+// ["const aa=0;for(aa in aa){}", "pre_s_for", "bad_assignment_a", "aa", 16]
+
+                    warn("bad_assignment_a", thing.name);
+                }
+            }
+        }
+        walk_statement(thing.initial);
+    }
+
+    function pre_s_lbrace(thing) {
+        block_stack.push(blockage);
+        blockage = thing;
+        thing.live = [];
+    }
+
+    function pre_try(thing) {
+        if (thing.catch !== undefined) {
+
+// Create new catch-scope for catch-parameter.
+
+            catch_stack.push(catchage);
+            catchage = thing.catch;
+        }
+    }
+
+    function pre_v(thing) {
+        const the_variable = lookup(thing);
+        if (the_variable !== undefined) {
+            thing.variable = the_variable;
+            the_variable.used += 1;
+        }
+    }
+
+    function subactivate(name) {
+        name.init = true;
+        name.dead = false;
+        blockage.live.push(name);
+    }
+
+    function walk_expression(thing) {
+        if (thing) {
+            if (Array.isArray(thing)) {
+
+// test_cause:
+// ["(function(){}())", "walk_expression", "isArray", "", 0]
+// ["0&&0", "walk_expression", "isArray", "", 0]
+
+                test_cause("isArray");
+                thing.forEach(walk_expression);
+            } else {
+                preamble(thing);
+                walk_expression(thing.expression);
+                if (thing.id === "function") {
+
+// test_cause:
+// ["aa=function(){}", "walk_expression", "function", "", 0]
+
+                    test_cause("function");
+                    walk_statement(thing.block);
+                }
+                if (
+                    thing.arity === "preassign" || thing.arity === "postassign"
+                ) {
+
+// test_cause:
+// ["aa=++aa", "walk_expression", "unexpected_a", "++", 4]
+// ["aa=--aa", "walk_expression", "unexpected_a", "--", 4]
+
+                    warn("unexpected_a", thing);
+                } else if (
+                    thing.arity === "statement"
+                    || thing.arity === "assignment"
+                ) {
+
+// test_cause:
+// ["aa[aa=0]", "walk_expression", "unexpected_statement_a", "=", 6]
+
+                    warn("unexpected_statement_a", thing);
+                }
+
+// test_cause:
+// ["aa=0", "walk_expression", "default", "", 0]
+
+                test_cause("default");
+                postamble(thing);
+            }
+        }
+    }
+
+    function walk_statement(thing) {
+        if (thing) {
+            if (Array.isArray(thing)) {
+
+// test_cause:
+// ["+[]", "walk_statement", "isArray", "", 0]
+
+                test_cause("isArray");
+                thing.forEach(walk_statement);
+            } else {
+                preamble(thing);
+                walk_expression(thing.expression);
+                if (thing.arity === "binary") {
+                    if (thing.id !== "(") {
+
+// test_cause:
+// ["0&&0", "walk_statement", "unexpected_expression_a", "&&", 2]
+
+                        warn("unexpected_expression_a", thing);
+                    }
+                } else if (
+                    thing.arity !== "statement"
+                    && thing.arity !== "assignment"
+                    && thing.id !== "import"
+                ) {
+
+// test_cause:
+// ["!0", "walk_statement", "unexpected_expression_a", "!", 1]
+// ["+[]", "walk_statement", "unexpected_expression_a", "+", 1]
+// ["+new aa()", "walk_statement", "unexpected_expression_a", "+", 1]
+// ["0", "walk_statement", "unexpected_expression_a", "0", 1]
+// ["
+// async function aa(){await 0;}
+// ", "walk_statement", "unexpected_expression_a", "0", 27]
+// ["typeof 0", "walk_statement", "unexpected_expression_a", "typeof", 1]
+
+                    warn("unexpected_expression_a", thing);
+                }
+                walk_statement(thing.block);
+                walk_statement(thing.else);
+                postamble(thing);
+            }
+        }
+    }
+
+    postaction = action(posts);
+    postamble = amble(posts);
+    preaction = action(pres);
+    preamble = amble(pres);
+    postaction("assignment", "+=", post_a_pluseq);
+    postaction("assignment", post_a);
+    postaction("binary", "&&", post_b_and);
+    postaction("binary", "(", post_b_lparen);
+    postaction("binary", "=>", post_s_function);
+    postaction("binary", "[", post_b_lbracket);
+    postaction("binary", "||", post_b_or);
+    postaction("binary", post_b);
+    postaction("statement", "const", post_s_var);
+    postaction("statement", "export", post_s_export);
+    postaction("statement", "for", post_s_for);
+    postaction("statement", "function", post_s_function);
+    postaction("statement", "import", post_s_import);
+    postaction("statement", "let", post_s_var);
+    postaction("statement", "try", post_s_try);
+    postaction("statement", "var", post_s_var);
+    postaction("statement", "{", post_s_lbrace);
+    postaction("ternary", post_t);
+    postaction("unary", "+", post_u_plus);
+    postaction("unary", "function", post_s_function);
+    postaction("unary", post_u);
+    preaction("assignment", pre_a_bitwise);
+    preaction("binary", "!=", pre_b_noteq);
+    preaction("binary", "(", pre_b_lparen);
+    preaction("binary", "==", pre_b_eqeq);
+    preaction("binary", "=>", pre_s_f);
+    preaction("binary", "in", pre_b_in);
+    preaction("binary", "instanceof", pre_b_instanceof);
+    preaction("binary", "||", pre_b_or);
+    preaction("binary", pre_b);
+    preaction("binary", pre_a_bitwise);
+    preaction("statement", "for", pre_s_for);
+    preaction("statement", "function", pre_s_f);
+    preaction("statement", "try", pre_try);
+    preaction("statement", "{", pre_s_lbrace);
+    preaction("unary", "function", pre_s_f);
+    preaction("unary", "~", pre_a_bitwise);
+    preaction("variable", pre_v);
 
     walk_statement(state.token_tree);
 }
@@ -6128,29 +7501,6 @@ function jslint_phase5_whitage(state) {
         ">>", ">>=", ">>>", ">>>=", "^", "^=", "|", "|=", "||"
     ]);
 
-    function expected_at(at) {
-
-// Probably deadcode.
-// if (right === undefined) {
-//     right = token_nxt;
-// }
-
-        assert_or_throw(
-            !(right === undefined),
-            `Expected !(right === undefined).`
-        );
-        warn(
-            "expected_a_at_b_c",
-            right,
-            artifact(right),
-
-// Fudge column numbers in warning message.
-
-            at + jslint_fudge,
-            right.from + jslint_fudge
-        );
-    }
-
     function at_margin(fit) {
         const at = margin + fit;
         if (right.from !== at) {
@@ -6197,6 +7547,29 @@ function jslint_phase5_whitage(state) {
                 }
             }
         });
+    }
+
+    function expected_at(at) {
+
+// Probably deadcode.
+// if (right === undefined) {
+//     right = token_nxt;
+// }
+
+        assert_or_throw(
+            !(right === undefined),
+            `Expected !(right === undefined).`
+        );
+        warn(
+            "expected_a_at_b_c",
+            right,
+            artifact(right),
+
+// Fudge column numbers in warning message.
+
+            at + jslint_fudge,
+            right.from + jslint_fudge
+        );
     }
 
     function no_space() {
@@ -6734,1273 +8107,21 @@ function jslint_phase5_whitage(state) {
     });
 }
 
-function jslint(
-    source = "",                // A text to analyze.
-    option_dict = empty(),      // An object whose keys correspond to option
-                                // ... names.
-    global_list = []            // An array of strings containing global
-                                // ... variables that the file is allowed
-                                // ... readonly access.
-) {
+function noop() {
 
-// The jslint function itself.
+// This function will do nothing.
 
-    let allowed_option = {
-
-// These are the options that are recognized in the option object or that may
-// appear in a /*jslint*/ directive. Most options will have a boolean value,
-// usually true. Some options will also predefine some number of global
-// variables.
-
-        beta: true,             // Enable experimental warnings.
-        bitwise: true,          // Allow bitwise operators.
-        browser: [              // Assume browser environment.
-            "CharacterData",
-            "DOMException",
-            "DocumentType",
-            "Element",
-            "Event",
-            "FileReader",
-            "FontFace",
-            "FormData",
-            "IntersectionObserver",
-            "MutationObserver",
-            "Storage",
-            "TextDecoder",
-            "TextEncoder",
-            "URL",
-            "Worker",
-            "XMLHttpRequest",
-            "clearInterval",
-            "clearTimeout",
-            "document",
-            "fetch",
-            "localStorage",
-            "location",
-            "navigator",
-            "screen",
-            "sessionStorage",
-            "setInterval",
-            "setTimeout",
-            "window"
-        ],
-        convert: true,          // Allow conversion operators.
-        couch: [                // Assume CouchDb environment.
-            "emit",
-            "getRow",
-            "isArray",
-            "log",
-            "provides",
-            "registerType",
-            "require",
-            "send",
-            "start",
-            "sum",
-            "toJSON"
-        ],
-        debug: true,            // Include jslint stack-trace in warnings.
-        devel: [                // Allow console.log() and friends.
-            "alert", "confirm", "console", "prompt"
-        ],
-        eval: true,             // Allow eval().
-        for: true,              // Allow for-statement.
-        getset: true,           // Allow get() and set().
-        indent2: true,          // Allow 2-space indent.
-        long: true,             // Allow long lines.
-        name: true,             // Allow weird property names.
-        node: [                 // Assume Node.js environment.
-            "Buffer",
-            "TextDecoder",
-            "TextEncoder",
-            "URL",
-            "URLSearchParams",
-            "__dirname",
-            "__filename",
-            "clearImmediate",
-            "clearInterval",
-            "clearTimeout",
-            "console",
-            "exports",
-            "module",
-            "process",
-            "require",
-            "setImmediate",
-            "setInterval",
-            "setTimeout"
-        ],
-        single: true,           // Allow single-quote strings.
-        test_cause: true,       // Test jslint's causes.
-        test_internal_error: true,      // Test jslint's internal-error
-                                        // ... handling-ability.
-        this: true,             // Allow 'this'.
-        unordered: true,        // Allow unordered cases, params, properties,
-                                // ... and variables.
-        variable: true,         // Allow unordered const and let declarations
-                                // ... that are not at top of function-scope.
-        white: true             // Allow messy whitespace.
-    };
-    let catch_list = [];        // The array containing all catch-blocks.
-    let catch_stack = [         // The stack of catch-blocks.
-        {
-            context: empty()
-        }
-    ];
-    let cause_dict = empty();   // The object of test-causes.
-    let directive_list = [];    // The directive comments.
-    let export_dict = empty();  // The exported names and values.
-    let function_list = [];     // The array containing all functions.
-    let function_stack = [];    // The stack of functions.
-    let global_dict = empty();  // The object containing the global
-                                // ... declarations.
-    let import_list = [];       // The array collecting all import-from strings.
-    let line_list = String(     // The array containing source lines.
-        "\n" + source
-    ).split(
-        // rx_crlf
-        /\n|\r\n?/
-    ).map(function (line_source) {
-        return {
-            line_source
-        };
-    });
-    let mode_stop = false;      // true if JSLint cannot finish.
-    let property_dict = empty();        // The object containing the tallied
-                                        // ... property names.
-    let standard = [            // These are the globals that are provided by
-                                // ... the language standard.
-// node --input-type=module -e '
-// /*jslint beta node*/
-// import https from "https";
-// (async function () {
-//     var dict;
-//     var result = "";
-//     await new Promise(function (resolve) {
-//         https.get((
-//             "https://developer.mozilla.org"
-//             + "/en-US/docs/Web/JavaScript/Reference/Global_Objects"
-//         ), function (res) {
-//             res.on("data", function (chunk) {
-//                 result += chunk;
-//             }).on("end", resolve).setEncoding("utf8");
-//         });
-//     });
-//     dict = {
-//         import: true
-//     };
-//     result.replace(new RegExp((
-//         "href=\"\\/en-US\\/docs\\/Web\\/JavaScript\\/Reference"
-//         + "\\/Global_Objects\\/.*?<code>(\\w+).*?<\\/code>"
-//     ), "g"), function (ignore, key) {
-//         switch (globalThis.hasOwnProperty(key) && key) {
-//         case "escape":
-//         case "unescape":
-//         case "uneval":
-//         case false:
-//             break;
-//         default:
-//             dict[key] = true;
-//         }
-//     });
-//     console.log(JSON.stringify(Object.keys(dict).sort(), undefined, 4));
-// }());
-// '
-        "Array",
-        "ArrayBuffer",
-        "Atomics",
-        "BigInt",
-        "BigInt64Array",
-        "BigUint64Array",
-        "Boolean",
-        "DataView",
-        "Date",
-        "Error",
-        "EvalError",
-        "Float32Array",
-        "Float64Array",
-        "Function",
-        "Infinity",
-        "Int16Array",
-        "Int32Array",
-        "Int8Array",
-        "Intl",
-        "JSON",
-        "Map",
-        "Math",
-        "NaN",
-        "Number",
-        "Object",
-        "Promise",
-        "Proxy",
-        "RangeError",
-        "ReferenceError",
-        "Reflect",
-        "RegExp",
-        "Set",
-        "SharedArrayBuffer",
-        "String",
-        "Symbol",
-        "SyntaxError",
-        "TypeError",
-        "URIError",
-        "Uint16Array",
-        "Uint32Array",
-        "Uint8Array",
-        "Uint8ClampedArray",
-        "WeakMap",
-        "WeakSet",
-        "WebAssembly",
-        "decodeURI",
-        "decodeURIComponent",
-        "encodeURI",
-        "encodeURIComponent",
-        "eval",
-        "globalThis",
-        "import",
-        "isFinite",
-        "isNaN",
-        "parseFloat",
-        "parseInt",
-        "undefined"
-    ];
-    let state = empty();        // jslint state-object to be passed between
-                                // jslint functions.
-    let syntax_dict = empty();  // The object containing the parser.
-    let tenure = empty();       // The predefined property registry.
-    let token_global = {        // The global object; the outermost context.
-        async: 0,
-        body: true,
-        context: empty(),
-        finally: 0,
-        from: 0,
-        id: "(global)",
-        level: 0,
-        line: jslint_fudge,
-        live: [],
-        loop: 0,
-        switch: 0,
-        thru: 0,
-        try: 0
-    };
-    let token_list = [];        // The array of tokens.
-    let warning_list = [];      // The array collecting all generated warnings.
-
-// Error reportage functions:
-
-    function artifact(the_token) {
-
-// Return a string representing an artifact.
-
-        the_token = the_token || state.token_nxt;
-        return (
-            (the_token.id === "(string)" || the_token.id === "(number)")
-            ? String(the_token.value)
-            : the_token.id
-        );
-    }
-
-    function is_weird(thing) {
-        switch (thing.id) {
-        case "(regexp)":
-            return true;
-        case "=>":
-            return true;
-        case "[":
-            return thing.arity === "unary";
-        case "function":
-            return true;
-        case "{":
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    function is_equal(aa, bb) {
-        let aa_value;
-        let bb_value;
-
-// test_cause:
-// ["0&&0", "is_equal", "", "", 0]
-
-        test_cause("");
-
-// Probably deadcode.
-// if (aa === bb) {
-//     return true;
-// }
-
-        assert_or_throw(!(aa === bb), `Expected !(aa === bb).`);
-        if (Array.isArray(aa)) {
-            return (
-                Array.isArray(bb)
-                && aa.length === bb.length
-                && aa.every(function (value, index) {
-
-// test_cause:
-// ["`${0}`&&`${0}`", "is_equal", "recurse_isArray", "", 0]
-
-                    test_cause("recurse_isArray");
-                    return is_equal(value, bb[index]);
-                })
-            );
-        }
-
-// Probably deadcode.
-// if (Array.isArray(bb)) {
-//     return false;
-// }
-
-        assert_or_throw(!Array.isArray(bb), `Expected !Array.isArray(bb).`);
-        if (aa.id === "(number)" && bb.id === "(number)") {
-            return aa.value === bb.value;
-        }
-        if (aa.id === "(string)") {
-            aa_value = aa.value;
-        } else if (aa.id === "`" && aa.constant) {
-            aa_value = aa.value[0];
-        }
-        if (bb.id === "(string)") {
-            bb_value = bb.value;
-        } else if (bb.id === "`" && bb.constant) {
-            bb_value = bb.value[0];
-        }
-        if (typeof aa_value === "string") {
-            return aa_value === bb_value;
-        }
-        if (is_weird(aa) || is_weird(bb)) {
-
-// test_cause:
-// ["aa(/./)||{}", "is_equal", "false", "", 0]
-
-            test_cause("false");
-            return false;
-        }
-        if (aa.arity === bb.arity && aa.id === bb.id) {
-            if (aa.id === ".") {
-
-// test_cause:
-// ["aa.bb&&aa.bb", "is_equal", "recurse_arity_id", "", 0]
-
-                test_cause("recurse_arity_id");
-                return (
-                    is_equal(aa.expression, bb.expression)
-                    && is_equal(aa.name, bb.name)
-                );
-            }
-            if (aa.arity === "unary") {
-
-// test_cause:
-// ["+0&&+0", "is_equal", "recurse_unary", "", 0]
-
-                test_cause("recurse_unary");
-                return is_equal(aa.expression, bb.expression);
-            }
-            if (aa.arity === "binary") {
-
-// test_cause:
-// ["aa[0]&&aa[0]", "is_equal", "recurse_binary", "", 0]
-
-                test_cause("recurse_binary");
-                return (
-                    aa.id !== "("
-                    && is_equal(aa.expression[0], bb.expression[0])
-                    && is_equal(aa.expression[1], bb.expression[1])
-                );
-            }
-            if (aa.arity === "ternary") {
-
-// test_cause:
-// ["aa=(``?``:``)&&(``?``:``)", "is_equal", "recurse_ternary", "", 0]
-
-                test_cause("recurse_ternary");
-                return (
-                    is_equal(aa.expression[0], bb.expression[0])
-                    && is_equal(aa.expression[1], bb.expression[1])
-                    && is_equal(aa.expression[2], bb.expression[2])
-                );
-            }
-
-// Probably deadcode.
-// if (aa.arity === "function" || aa.arity === "regexp") {
-//     return false;
-// }
-
-            assert_or_throw(
-                !(aa.arity === "function" || aa.arity === "regexp"),
-                `Expected !(aa.arity === "function" || aa.arity === "regexp").`
-            );
-
-// test_cause:
-// ["undefined&&undefined", "is_equal", "true", "", 0]
-
-            test_cause("true");
-            return true;
-        }
-
-// test_cause:
-// ["null&&undefined", "is_equal", "false", "", 0]
-
-        test_cause("false");
-        return false;
-    }
-
-    function test_cause(code, aa, column) {
-
-// This function will instrument <cause> to <cause_dict> for test-purposes.
-
-        if (option_dict.test_cause) {
-            cause_dict[JSON.stringify([
-                String(new Error().stack).replace((
-                    /^\u0020{4}at\u0020(?:file|stop|stop_at|test_cause|warn|warn_at)\b.*?\n/gm
-                ), "").match(
-                    /\n\u0020{4}at\u0020((?:Object\.\w+?_)?\w+?)\u0020/
-                )[1].replace((
-                    /^Object\./
-                ), ""),
-                code,
-                String(
-                    (aa === undefined || aa === token_global)
-                    ? ""
-                    : aa
-                ),
-                column || 0
-            ])] = true;
-        }
-    }
-
-    function warn_at(code, line, column, a, b, c, d) {
-
-// Report an error at some line and column of the program. The warning object
-// resembles an exception.
-
-        let mm;
-        let warning = Object.assign(empty(), {
-            a,
-            b,
-            c,
-            code,
-
-// Fudge column numbers in warning message.
-
-            column: column || jslint_fudge,
-            d,
-            line,
-            line_source: "",
-            name: "JSLintError"
-        }, line_list[line]);
-        warning.column = Math.max(
-            Math.min(warning.column, warning.line_source.length),
-            jslint_fudge
-        );
-        test_cause(code, b || a, warning.column);
-        switch (code) {
-
-// The bundle contains the raw text messages that are generated by jslint. It
-// seems that they are all error messages and warnings. There are no "Atta
-// boy!" or "You are so awesome!" messages. There is no positive reinforcement
-// or encouragement. This relentless negativity can undermine self-esteem and
-// wound the inner child. But if you accept it as sound advice rather than as
-// personal criticism, it can make your programs better.
-
-        case "and":
-            mm = `The '&&' subexpression should be wrapped in parens.`;
-            break;
-        case "bad_assignment_a":
-            mm = `Bad assignment to '${a}'.`;
-            break;
-        case "bad_directive_a":
-            mm = `Bad directive '${a}'.`;
-            break;
-        case "bad_get":
-            mm = `A get function takes no parameters.`;
-            break;
-        case "bad_module_name_a":
-            mm = `Bad module name '${a}'.`;
-            break;
-        case "bad_option_a":
-            mm = `Bad option '${a}'.`;
-            break;
-        case "bad_set":
-            mm = `A set function takes one parameter.`;
-            break;
-        case "duplicate_a":
-            mm = `Duplicate '${a}'.`;
-            break;
-        case "empty_block":
-            mm = `Empty block.`;
-            break;
-        case "expected_a":
-            mm = `Expected '${a}'.`;
-            break;
-        case "expected_a_at_b_c":
-            mm = `Expected '${a}' at column ${b}, not column ${c}.`;
-            break;
-        case "expected_a_b":
-            mm = `Expected '${a}' and instead saw '${b}'.`;
-            break;
-        case "expected_a_b_before_c_d":
-            mm = `Expected ${a} '${b}' to be ordered before ${c} '${d}'.`;
-            break;
-        case "expected_a_b_from_c_d":
-            mm = (
-                `Expected '${a}' to match '${b}' from line ${c}`
-                + ` and instead saw '${d}'.`
-            );
-            break;
-        case "expected_a_before_b":
-            mm = `Expected '${a}' before '${b}'.`;
-            break;
-        case "expected_digits_after_a":
-            mm = `Expected digits after '${a}'.`;
-            break;
-        case "expected_four_digits":
-            mm = `Expected four digits after '\\u'.`;
-            break;
-        case "expected_identifier_a":
-            mm = `Expected an identifier and instead saw '${a}'.`;
-            break;
-        case "expected_line_break_a_b":
-            mm = `Expected a line break between '${a}' and '${b}'.`;
-            break;
-        case "expected_regexp_factor_a":
-            mm = `Expected a regexp factor and instead saw '${a}'.`;
-            break;
-        case "expected_space_a_b":
-            mm = `Expected one space between '${a}' and '${b}'.`;
-            break;
-        case "expected_statements_a":
-            mm = `Expected statements before '${a}'.`;
-            break;
-        case "expected_string_a":
-            mm = `Expected a string and instead saw '${a}'.`;
-            break;
-        case "expected_type_string_a":
-            mm = `Expected a type string and instead saw '${a}'.`;
-            break;
-        case "freeze_exports":
-            mm = (
-                `Expected 'Object.freeze('. All export values should be frozen.`
-            );
-            break;
-        case "function_in_loop":
-            mm = `Don't create functions within a loop.`;
-            break;
-        case "infix_in":
-            mm = (
-                `Unexpected 'in'. Compare with undefined,`
-                + ` or use the hasOwnProperty method instead.`
-            );
-            break;
-        case "label_a":
-            mm = `'${a}' is a statement label.`;
-            break;
-        case "misplaced_a":
-            mm = `Place '${a}' at the outermost level.`;
-            break;
-        case "misplaced_directive_a":
-            mm = `Place the '/*${a}*/' directive before the first statement.`;
-            break;
-        case "missing_await_statement":
-            mm = `Expected await statement in async function.`;
-            break;
-        case "missing_browser":
-            mm = `/*global*/ requires the Assume a browser option.`;
-            break;
-        case "missing_m":
-            mm = `Expected 'm' flag on a multiline regular expression.`;
-            break;
-        case "naked_block":
-            mm = `Naked block.`;
-            break;
-        case "nested_comment":
-            mm = `Nested comment.`;
-            break;
-        case "not_label_a":
-            mm = `'${a}' is not a label.`;
-            break;
-        case "number_isNaN":
-            mm = `Use Number.isNaN function to compare with NaN.`;
-            break;
-        case "out_of_scope_a":
-            mm = `'${a}' is out of scope.`;
-            break;
-        case "redefinition_a_b":
-            mm = `Redefinition of '${a}' from line ${b}.`;
-            break;
-        case "required_a_optional_b":
-            mm = `Required parameter '${a}' after optional parameter '${b}'.`;
-            break;
-        case "reserved_a":
-            mm = `Reserved name '${a}'.`;
-            break;
-        case "subscript_a":
-            mm = `['${a}'] is better written in dot notation.`;
-            break;
-        case "todo_comment":
-            mm = `Unexpected TODO comment.`;
-            break;
-        case "too_long":
-            mm = `Line is longer than 80 characters.`;
-            break;
-        case "too_many_digits":
-            mm = `Too many digits.`;
-            break;
-        case "unclosed_comment":
-            mm = `Unclosed comment.`;
-            break;
-        case "unclosed_disable":
-            mm = (
-                `Directive '/*jslint-disable*/' was not closed`
-                + ` with '/*jslint-enable*/'.`
-            );
-            break;
-        case "unclosed_mega":
-            mm = `Unclosed mega literal.`;
-            break;
-        case "unclosed_string":
-            mm = `Unclosed string.`;
-            break;
-        case "undeclared_a":
-            mm = `Undeclared '${a}'.`;
-            break;
-        case "unexpected_a":
-            mm = `Unexpected '${a}'.`;
-            break;
-        case "unexpected_a_after_b":
-            mm = `Unexpected '${a}' after '${b}'.`;
-            break;
-        case "unexpected_a_before_b":
-            mm = `Unexpected '${a}' before '${b}'.`;
-            break;
-        case "unexpected_at_top_level_a":
-            mm = `Expected '${a}' to be in a function.`;
-            break;
-        case "unexpected_char_a":
-            mm = `Unexpected character '${a}'.`;
-            break;
-        case "unexpected_comment":
-            mm = `Unexpected comment.`;
-            break;
-        case "unexpected_directive_a":
-            mm = `When using modules, don't use directive '/\u002a${a}'.`;
-            break;
-        case "unexpected_expression_a":
-            mm = `Unexpected expression '${a}' in statement position.`;
-            break;
-        case "unexpected_label_a":
-            mm = `Unexpected label '${a}'.`;
-            break;
-        case "unexpected_parens":
-            mm = `Don't wrap function literals in parens.`;
-            break;
-        case "unexpected_space_a_b":
-            mm = `Unexpected space between '${a}' and '${b}'.`;
-            break;
-        case "unexpected_statement_a":
-            mm = `Unexpected statement '${a}' in expression position.`;
-            break;
-        case "unexpected_trailing_space":
-            mm = `Unexpected trailing space.`;
-            break;
-        case "unexpected_typeof_a":
-            mm = (
-                `Unexpected 'typeof'. Use '===' to compare directly with ${a}.`
-            );
-            break;
-        case "uninitialized_a":
-            mm = `Uninitialized '${a}'.`;
-            break;
-        case "unopened_enable":
-            mm = (
-                `Directive '/*jslint-enable*/' was not opened`
-                + ` with '/*jslint-disable*/'.`
-            );
-            break;
-        case "unreachable_a":
-            mm = `Unreachable '${a}'.`;
-            break;
-        case "unregistered_property_a":
-            mm = `Unregistered property name '${a}'.`;
-            break;
-        case "unused_a":
-            mm = `Unused '${a}'.`;
-            break;
-        case "use_double":
-            mm = `Use double quotes, not single quotes.`;
-            break;
-        case "use_open":
-            mm = (
-                `Wrap a ternary expression in parens,`
-                + ` with a line break after the left paren.`
-            );
-            break;
-        case "use_spaces":
-            mm = `Use spaces, not tabs.`;
-            break;
-        case "var_on_top":
-            mm = `Move variable declaration to top of function or script.`;
-            break;
-        case "var_switch":
-            mm = `Don't declare variables in a switch.`;
-            break;
-        case "weird_condition_a":
-            mm = `Weird condition '${a}'.`;
-            break;
-        case "weird_expression_a":
-            mm = `Weird expression '${a}'.`;
-            break;
-        case "weird_loop":
-            mm = `Weird loop.`;
-            break;
-        case "weird_property_a":
-            mm = `Weird property name '${a}'.`;
-            break;
-        case "weird_relation_a":
-            mm = `Weird relation '${a}'.`;
-            break;
-        case "wrap_condition":
-            mm = `Wrap the condition in parens.`;
-            break;
-        case "wrap_immediate":
-            mm = (
-                `Wrap an immediate function invocation in parentheses to assist`
-                + ` the reader in understanding that the expression is the`
-                + ` result of a function, and not the function itself.`
-            );
-            break;
-        case "wrap_parameter":
-            mm = `Wrap the parameter in parens.`;
-            break;
-        case "wrap_regexp":
-            mm = `Wrap this regexp in parens to avoid confusion.`;
-            break;
-        case "wrap_unary":
-            mm = `Wrap the unary expression in parens.`;
-            break;
-        }
-
-// Validate mm.
-
-        assert_or_throw(mm, code);
-        warning.message = mm;
-
-// Include stack_trace for jslint to debug itself for errors.
-
-        if (option_dict.debug) {
-            warning.stack_trace = new Error().stack;
-        }
-        if (warning.directive_quiet) {
-
-// test_cause:
-// ["0 //jslint-quiet", "semicolon", "directive_quiet", "", 0]
-
-            test_cause("directive_quiet");
-            return warning;
-        }
-        warning_list.push(warning);
-        return warning;
-    }
-
-    function stop_at(code, line, column, a, b, c, d) {
-
-// Same as warn_at, except that it stops the analysis.
-
-        throw warn_at(code, line, column, a, b, c, d);
-    }
-
-    function warn(code, the_token, a, b, c, d) {
-
-// Same as warn_at, except the warning will be associated with a specific token.
-// If there is already a warning on this token, suppress the new one. It is
-// likely that the first warning will be the most meaningful.
-
-        let the_warning;
-        the_token = the_token || state.token_nxt;
-        the_warning = warn_at(
-            code,
-            the_token.line,
-            (the_token.from || 0) + jslint_fudge,
-            a || artifact(the_token),
-            b,
-            c,
-            d
-        );
-        if (the_token.warning === undefined) {
-            the_token.warning = the_warning;
-        } else {
-            warning_list.pop();
-        }
-        return the_warning;
-    }
-
-    function stop(code, the_token, a, b, c, d) {
-
-// Similar to warn and stop_at. If the token already had a warning, that
-// warning will be replaced with this new one. It is likely that the stopping
-// warning will be the more meaningful.
-
-        the_token = the_token || state.token_nxt;
-        delete the_token.warning;
-        throw warn(code, the_token, a, b, c, d);
-    }
-
-    try {
-
-// tokenize takes a source and produces from it an array of token objects.
-// JavaScript is notoriously difficult to tokenize because of the horrible
-// interactions between automatic semicolon insertion, regular expression
-// literals, and now megastring literals. JSLint benefits from eliminating
-// automatic semicolon insertion and nested megastring literals, which allows
-// full tokenization to precede parsing.
-
-        option_dict = Object.assign(empty(), option_dict);
-        populate(global_list, global_dict, false);
-        populate(standard, global_dict, false);
-        Object.keys(option_dict).forEach(function (name) {
-            const allowed = allowed_option[name];
-            if (option_dict[name] === true && Array.isArray(allowed)) {
-                populate(allowed, global_dict, false);
-            }
-        });
-
-        Object.assign(state, {
-            allowed_option,
-            artifact,
-            catch_list,
-            catch_stack,
-            directive_list,
-            export_dict,
-            function_list,
-            function_stack,
-            global_dict,
-            import_list,
-            is_equal,
-            is_weird,
-            line_list,
-            mode_json: false,           // true if parsing JSON.
-            mode_module: false,         // true if import or export was used.
-            mode_property: false,       // true if directive /*property*/ is
-                                        // used.
-            mode_shebang: false,        // true if #! is seen on the first line.
-            option_dict,
-            property_dict,
-            source,
-            stop,
-            stop_at,
-            syntax_dict,
-            tenure,
-            test_cause,
-            token_global,
-            token_list,
-            token_nxt: token_global,
-            warn,
-            warn_at,
-            warning_list
-        });
-
-// PHASE 1. Split <source> by newlines into <line_list>.
-
-        jslint_phase1_split(state);
-        assert_or_throw(catch_stack.length === 1, `catch_stack.length === 1.`);
-        assert_or_throw(
-            function_stack.length === 0,
-            `function_stack.length === 0.`
-        );
-
-// PHASE 2. Lex <line_list> into <token_list>.
-
-        jslint_phase2_lex(state);
-        assert_or_throw(catch_stack.length === 1, `catch_stack.length === 1.`);
-        assert_or_throw(
-            function_stack.length === 0,
-            `function_stack.length === 0.`
-        );
-
-// PHASE 3. Parse <token_list> into <token_tree> using the Pratt-parser.
-
-        jslint_phase3_parse(state);
-        assert_or_throw(catch_stack.length === 1, `catch_stack.length === 1.`);
-        assert_or_throw(
-            function_stack.length === 0,
-            `function_stack.length === 0.`
-        );
-
-// PHASE 4. Walk <token_tree>, traversing all nodes of the tree. It is a
-//          recursive traversal. Each node may be processed on the way down
-//          (preaction) and on the way up (postaction).
-
-        if (!state.mode_json) {
-            jslint_phase4_walk(state);
-        }
-        assert_or_throw(catch_stack.length === 1, `catch_stack.length === 1.`);
-        assert_or_throw(
-            function_stack.length === 0,
-            `function_stack.length === 0.`
-        );
-
-// PHASE 5. Check whitespace between tokens in <token_list>.
-
-        if (!state.mode_json && warning_list.length === 0) {
-            jslint_phase5_whitage(state);
-        }
-        assert_or_throw(catch_stack.length === 1, `catch_stack.length === 1.`);
-        assert_or_throw(
-            function_stack.length === 0,
-            `function_stack.length === 0.`
-        );
-
-        if (!option_dict.browser) {
-            directive_list.forEach(function (comment) {
-                if (comment.directive === "global") {
-
-// test_cause:
-// ["/*global aa*/", "jslint", "missing_browser", "(comment)", 1]
-
-                    warn("missing_browser", comment);
-                }
-            });
-        }
-        if (option_dict.test_internal_error) {
-            assert_or_throw(undefined, "test_internal_error");
-        }
-    } catch (err) {
-        mode_stop = true;
-        err.message = "[JSLint was unable to finish]\n" + err.message;
-        err.mode_stop = true;
-        if (err.name !== "JSLintError") {
-            Object.assign(err, {
-                column: jslint_fudge,
-                line: jslint_fudge,
-                line_source: "",
-                stack_trace: err.stack
-            });
-        }
-        if (warning_list.indexOf(err) === -1) {
-            warning_list.push(err);
-        }
-    }
-
-// Sort warning_list by mode_stop first, line, column respectively.
-
-    warning_list.sort(function (aa, bb) {
-        return (
-            Boolean(bb.mode_stop) - Boolean(aa.mode_stop)
-            || aa.line - bb.line
-            || aa.column - bb.column
-        );
-
-// Update each warning with formatted_message ready-for-use by jslint_cli.
-
-    }).map(function ({
-        column,
-        line,
-        line_source,
-        message,
-        stack_trace = ""
-    }, ii, list) {
-        list[ii].formatted_message = String(
-            String(ii + 1).padStart(2, " ")
-            + ". \u001b[31m" + message + "\u001b[39m"
-            + " \u001b[90m\/\/ line " + line + ", column " + column
-            + "\u001b[39m\n"
-            + ("    " + line_source.trim()).slice(0, 72) + "\n"
-            + stack_trace
-        ).trimRight();
-    });
-
-    return {
-        causes: cause_dict,
-        directives: directive_list,
-        edition: jslint_edition,
-        exports: export_dict,
-        froms: import_list,
-        functions: function_list,
-        global: token_global,
-        id: "(JSLint)",
-        json: state.mode_json,
-        lines: line_list,
-        module: state.mode_module === true,
-        ok: warning_list.length === 0 && !mode_stop,
-        option: option_dict,
-        property: property_dict,
-        shebang: (
-            state.mode_shebang
-            ? line_list[jslint_fudge].line_source
-            : undefined
-        ),
-        stop: mode_stop,
-        tokens: token_list,
-        tree: state.token_tree,
-        warnings: warning_list
-    };
+    return;
 }
 
-async function jslint_cli({
-    cjs_module,
-    cjs_require,
-    console_error,
-    file,
-    mode_force,
-    mode_noop,
-    option,
-    process_exit,
-    source
-}) {
+function populate(array, object = empty(), value = true) {
 
-// This function will run jslint from nodejs-cli.
+// Augment an object by taking property names from an array of strings.
 
-    let data;
-    let exit_code = 0;
-    let module_fs;
-    let module_path;
-    let module_url;
-
-    function string_line_count(code) {
-
-// This function will count number of newlines in <code>.
-
-        let cnt;
-        let ii;
-
-// https://jsperf.com/regexp-counting-2/8
-
-        cnt = 0;
-        ii = 0;
-        while (true) {
-            ii = code.indexOf("\n", ii) + 1;
-            if (ii === 0) {
-                break;
-            }
-            cnt += 1;
-        }
-        return cnt;
-    }
-
-    function jslint_from_file({
-        code,
-        file,
-        line_offset = 0,
-        option = empty(),
-        warnings = []
-    }) {
-        option = Object.assign(empty(), option, {
-            file
-        });
-        switch ((
-            /\.\w+?$|$/m
-        ).exec(file)[0]) {
-        case ".html":
-
-// Recursively jslint embedded "<script>\n...\n</script>".
-
-            code.replace((
-                /^<script>\n([\S\s]*?\n)<\/script>$/gm
-            ), function (ignore, match1, ii) {
-                jslint_from_file({
-                    code: match1,
-                    file: file + ".<script>.js",
-                    line_offset: string_line_count(code.slice(0, ii)) + 1,
-                    option: Object.assign(empty(), {
-                        browser: true
-                    }, option)
-                });
-                return "";
-            });
-            return;
-        case ".md":
-
-// Recursively jslint embedded "```javascript\n...\n```".
-
-            code.replace((
-                /^```(?:javascript|js)\n([\S\s]*?\n)```$/gm
-            ), function (ignore, match1, ii) {
-                jslint_from_file({
-                    code: match1,
-                    file: file + ".<```javascript>.js",
-                    line_offset: string_line_count(code.slice(0, ii)) + 1,
-                    option
-                });
-                return "";
-            });
-            return;
-        case ".sh":
-
-// Recursively jslint embedded "node -e '\n...\n'".
-
-            code.replace((
-                /\bnode\u0020.*?-e\u0020'\n([\S\s]*?\n)'/gm
-            ), function (ignore, match1, ii) {
-                jslint_from_file({
-                    code: match1,
-                    file: file + ".<node -e>.js",
-                    line_offset: string_line_count(code.slice(0, ii)) + 1,
-                    option: Object.assign(empty(), {
-                        beta: Boolean(
-                            process.env.JSLINT_BETA
-                            && !(
-                                /0|false|null|undefined/
-                            ).test(process.env.JSLINT_BETA)
-                        ),
-                        node: true
-                    }, option)
-                });
-                return "";
-            });
-            return;
-        default:
-            warnings = jslint(
-                "\n".repeat(line_offset) + code,
-                option
-            ).warnings;
-        }
-
-// Print only first 10 warnings to stderr.
-
-        if (warnings.length > 0) {
-            exit_code = 1;
-            console_error(
-                "\u001b[1mjslint " + file + "\u001b[22m\n"
-                + warnings.slice(0, 10).map(function ({
-                    formatted_message
-                }) {
-                    return formatted_message;
-                }).join("\n")
-            );
-        }
-    }
-
-// Feature-detect nodejs.
-
-    if (!(
-        typeof process === "object"
-        && process
-        && process.versions
-        && typeof process.versions.node === "string"
-        && !mode_noop
-    )) {
-        return exit_code;
-    }
-    console_error = console_error || console.error;
-    module_fs = await import("fs");
-    module_path = await import("path");
-    module_url = await import("url");
-    process_exit = process_exit || process.exit;
-    if (!(
-
-// Feature-detect nodejs-cjs-cli.
-
-        (cjs_module && cjs_require)
-        ? cjs_module === cjs_require.main
-
-// Feature-detect nodejs-esm-cli.
-
-        : (
-            process.execArgv.indexOf("--eval") === -1
-            && process.execArgv.indexOf("-e") === -1
-            && (
-                (
-                    /[\/|\\]jslint(?:\.[cm]?js)?$/m
-                ).test(process.argv[1])
-                || mode_force
-            )
-            && module_url.fileURLToPath(jslint_import_meta_url)
-            === module_path.resolve(process.argv[1])
-        )
-    ) && !mode_force) {
-        return exit_code;
-    }
-
-// Normalize file relative to process.cwd().
-
-    file = file || process.argv[2];
-    if (!file) {
-        return;
-    }
-    file = module_path.resolve(file) + "/";
-    if (file.startsWith(process.cwd() + "/")) {
-        file = file.replace(process.cwd() + "/", "").slice(0, -1) || ".";
-    }
-    file = file.replace((
-        /\\/g
-    ), "/").replace((
-        /\/$/g
-    ), "");
-    if (source) {
-        jslint_from_file({
-            code: source,
-            file,
-            option
-        });
-        process_exit(exit_code);
-        return exit_code;
-    }
-
-// jslint_cli - jslint directory.
-
-    try {
-        data = await module_fs.promises.readdir(file, "utf8");
-    } catch (ignore) {}
-    if (data) {
-        await Promise.all(data.map(async function (file2) {
-            let code;
-            let time_start = Date.now();
-            file2 = file + "/" + file2;
-            switch ((
-                /\.\w+?$|$/m
-            ).exec(file2)[0]) {
-            case ".cjs":
-            case ".html":
-            case ".js":
-            case ".json":
-            case ".md":
-            case ".mjs":
-            case ".sh":
-                break;
-            default:
-                return;
-            }
-            try {
-                code = await module_fs.promises.readFile(file2, "utf8");
-            } catch (ignore) {
-                return;
-            }
-            if (!(
-                !(
-                    /\b(?:lock|min|raw|rollup)\b/
-                ).test(file2) && code && code.length < 1048576
-            )) {
-                return;
-            }
-            jslint_from_file({
-                code,
-                file: file2,
-                option
-            });
-            console_error(
-                "jslint - " + (Date.now() - time_start) + "ms - " + file2
-            );
-        }));
-        process_exit(exit_code);
-        return exit_code;
-    }
-
-// jslint_cli - jslint file.
-
-    try {
-        data = await module_fs.promises.readFile(file, "utf8");
-    } catch (err) {
-        console_error(err);
-        exit_code = 1;
-        process_exit(exit_code);
-        return exit_code;
-    }
-    jslint_from_file({
-        code: data,
-        file,
-        option
+    array.forEach(function (name) {
+        object[name] = value;
     });
-    process_exit(exit_code);
-    return exit_code;
+    return object;
 }
 
 jslint_export = Object.freeze(Object.assign(jslint, {

--- a/test.mjs
+++ b/test.mjs
@@ -81,6 +81,157 @@ function noop() {
     });
 }());
 
+(function testCaseJslintCodeValidate() {
+/*
+ * this function will validate each code is valid in jslint
+ */
+    Object.values({
+        array: [
+            "new Array(0);"
+        ],
+        async_await: [
+            "async function aa() {\n    await aa();\n}",
+            "async function aa() {\n"
+            + "    try {\n"
+            + "        aa();\n"
+            + "    } catch (err) {\n"
+            + "        await err();\n"
+            + "    }\n"
+            + "}\n",
+            "async function aa() {\n"
+            + "    try {\n"
+            + "        await aa();\n"
+            + "    } catch (err) {\n"
+            + "        await err();\n"
+            + "    }\n"
+            + "}\n"
+        ],
+        date: [
+            "Date.getTime();",
+            "let aa = aa().getTime();",
+            "let aa = aa.aa().getTime();"
+        ],
+        directive: [
+            "#!\n/*jslint browser:false, node*/\n\"use strict\";",
+            "/*property aa bb*/"
+        ],
+        fart: [
+            "function aa() {\n    return () => 0;\n}"
+        ],
+        jslint_disable: [
+            "/*jslint-disable*/\n0\n/*jslint-enable*/"
+        ],
+        jslint_quiet: [
+            "0 //jslint-quiet"
+        ],
+        json: [
+            "{\"aa\":[[],-0,null]}"
+        ],
+        label: [
+            "function aa() {\n"
+            + "bb:\n"
+            + "    while (true) {\n"
+            + "        if (true) {\n"
+            + "            break bb;\n"
+            + "        }\n"
+            + "    }\n"
+            + "}\n"
+        ],
+        loop: [
+            "function aa() {\n    do {\n        aa();\n    } while (aa());\n}"
+        ],
+        module: [
+            "export default Object.freeze();",
+            "import {aa, bb} from \"aa\";\naa(bb);",
+            "import {} from \"aa\";",
+            "import(\"aa\").then(function () {\n    return;\n});",
+            "let aa = 0;\nimport(aa).then(aa).then(aa).catch(aa).finally(aa);"
+        ],
+        number: [
+            "let aa = 0.0e0;",
+            "let aa = 0b0;",
+            "let aa = 0o0;",
+            "let aa = 0x0;"
+        ],
+        optional_chaining: [
+            "let aa = aa?.bb?.cc;"
+        ],
+        param: [
+            "function aa({aa, bb}) {\n"
+            + "    return {aa, bb};\n"
+            + "}\n",
+            "function aa({constructor}) {\n"
+            + "    return {constructor};\n"
+            + "}\n"
+        ],
+        property: [
+            "let aa = aa[`!`];"
+        ],
+        regexp: [
+            "function aa() {\n    return /./;\n}",
+            "let aa = /(?!.)(?:.)(?=.)/;",
+            "let aa = /./gimuy;",
+            "let aa = /[\\--\\-]/;"
+        ],
+        ternary: [
+            (
+                "let aa = (\n    aa()\n    ? 0\n    : 1\n) "
+                + "&& (\n    aa()\n    ? 0\n    : 1\n);"
+            ),
+            "let aa = (\n    aa()\n    ? `${0}`\n    : `${1}`\n);"
+        ],
+        try_catch: [
+            "let aa = 0;\n"
+            + "try {\n"
+            + "    aa();\n"
+            + "} catch (err) {\n"
+            + "    aa = err;\n"
+            + "}\n"
+            + "try {\n"
+            + "    aa();\n"
+            + "} catch (err) {\n"
+            + "    aa = err;\n"
+            + "}\n"
+            + "aa();\n"
+        ],
+        use_strict: [
+            (
+                "\"use strict\";\n"
+                + "let aa = 0;\n"
+                + "function bb() {\n"
+                + "    \"use strict\";\n"
+                + "    return aa;\n"
+                + "}\n"
+            )
+        ],
+        var: [
+            "let [\n    aa, bb = 0\n] = 0;",
+            "let [...aa] = [...aa];",
+            "let constructor = 0;",
+            "let {\n    aa: bb\n} = 0;",
+            "let {aa, bb} = 0;",
+            "let {constructor} = 0;"
+        ]
+    }).forEach(function (codeList) {
+        let elemPrv = "";
+        codeList.forEach(function (code) {
+            let warnings;
+            // Assert codeList is sorted.
+            assertOrThrow(elemPrv < code, JSON.stringify([
+                elemPrv, code
+            ], undefined, 4));
+            elemPrv = code;
+            warnings = jslint(code, {
+                beta: true
+            }).warnings;
+            assertOrThrow(
+                warnings.length === 0,
+                JSON.stringify([code, warnings])
+            );
+        });
+    });
+}());
+
 (function testCaseJslintMisc() {
 /*
  * this function will test jslint's misc handling-behavior
@@ -210,149 +361,6 @@ function noop() {
     assertOrThrow(jslint("", {
         test_internal_error: true
     }).warnings.length === 1);
-}());
-
-(function testCaseJslintCodeValidate() {
-/*
- * this function will validate each code is valid in jslint
- */
-    Object.values({
-        array: [
-            "new Array(0);"
-        ],
-        async_await: [
-            "async function aa() {\n    await aa();\n}",
-            "async function aa() {\n"
-            + "    try {\n"
-            + "        aa();\n"
-            + "    } catch (err) {\n"
-            + "        await err();\n"
-            + "    }\n"
-            + "}\n",
-            "async function aa() {\n"
-            + "    try {\n"
-            + "        await aa();\n"
-            + "    } catch (err) {\n"
-            + "        await err();\n"
-            + "    }\n"
-            + "}\n"
-        ],
-        date: [
-            "Date.getTime();",
-            "let aa = aa().getTime();",
-            "let aa = aa.aa().getTime();"
-        ],
-        directive: [
-            "#!\n/*jslint browser:false, node*/\n\"use strict\";",
-            "/*property aa bb*/"
-        ],
-        fart: [
-            "function aa() {\n    return () => 0;\n}"
-        ],
-        jslint_disable: [
-            "/*jslint-disable*/\n0\n/*jslint-enable*/"
-        ],
-        jslint_quiet: [
-            "0 //jslint-quiet"
-        ],
-        json: [
-            "{\"aa\":[[],-0,null]}"
-        ],
-        label: [
-            "function aa() {\n"
-            + "bb:\n"
-            + "    while (true) {\n"
-            + "        if (true) {\n"
-            + "            break bb;\n"
-            + "        }\n"
-            + "    }\n"
-            + "}\n"
-        ],
-        loop: [
-            "function aa() {\n    do {\n        aa();\n    } while (aa());\n}"
-        ],
-        module: [
-            "export default Object.freeze();",
-            "import {aa, bb} from \"aa\";\naa(bb);",
-            "import {} from \"aa\";",
-            "import(\"aa\").then(function () {\n    return;\n});",
-            "let aa = 0;\nimport(aa).then(aa).then(aa).catch(aa).finally(aa);"
-        ],
-        number: [
-            "let aa = 0.0e0;",
-            "let aa = 0b0;",
-            "let aa = 0o0;",
-            "let aa = 0x0;"
-        ],
-        optional_chaining: [
-            "let aa = aa?.bb?.cc;"
-        ],
-        param: [
-            "function aa({aa, bb}) {\n"
-            + "    return {aa, bb};\n"
-            + "}\n",
-            "function aa({constructor}) {\n"
-            + "    return {constructor};\n"
-            + "}\n"
-        ],
-        property: [
-            "let aa = aa[`!`];"
-        ],
-        regexp: [
-            "function aa() {\n    return /./;\n}",
-            "let aa = /(?!.)(?:.)(?=.)/;",
-            "let aa = /./gimuy;",
-            "let aa = /[\\--\\-]/;"
-        ],
-        ternary: [
-            (
-                "let aa = (\n    aa()\n    ? 0\n    : 1\n) "
-                + "&& (\n    aa()\n    ? 0\n    : 1\n);"
-            ),
-            "let aa = (\n    aa()\n    ? `${0}`\n    : `${1}`\n);"
-        ],
-        try_catch: [
-            "let aa = 0;\n"
-            + "try {\n"
-            + "    aa();\n"
-            + "} catch (err) {\n"
-            + "    aa = err;\n"
-            + "}\n"
-            + "try {\n"
-            + "    aa();\n"
-            + "} catch (err) {\n"
-            + "    aa = err;\n"
-            + "}\n"
-            + "aa();\n"
-        ],
-        use_strict: [
-            "function aa() {\n    \"use strict\";\n    return;\n}"
-        ],
-        var: [
-            "\"use strict\";\nvar aa = 0;",
-            "let [\n    aa, bb = 0\n] = 0;",
-            "let [...aa] = [...aa];",
-            "let constructor = 0;",
-            "let {\n    aa: bb\n} = 0;",
-            "let {aa, bb} = 0;",
-            "let {constructor} = 0;"
-        ]
-    }).forEach(function (codeList) {
-        let elemPrv = "";
-        codeList.forEach(function (code) {
-            let warnings;
-            // Assert codeList is sorted.
-            assertOrThrow(elemPrv < code, JSON.stringify([
-                elemPrv, code
-            ], undefined, 4));
-            elemPrv = code;
-            warnings = jslint(code).warnings;
-            assertOrThrow(
-                warnings.length === 0,
-                JSON.stringify([code, warnings])
-            );
-        });
-    });
 }());
 
 (async function testCaseJslintWarningsValidate() {


### PR DESCRIPTION
- jslint - add new beta-warning if functions are unordered.
- jslint-revamp - rearrange functions in jslint.mjs to comply with ordered-functions beta-warning.
- ci - allow manually triggering ci.

follup to pr #331.
this is a big pr, not because of code-changes, but because all named-functions have been moved to top of function-scope and ordered in ascii-order.  `jslint.mjs` has ~200 named-functions and most were moved to different locations after re-ordering.

the new accompanying warning is hidden behind `/*jslint beta*/` directive and not intended for normal-users.  use beta-directive if you want to enable it:

```
/*jslint beta*/
function bb() {
    return;
}
function aa() {
    return;
}

//  1. Expected function 'aa' to be ordered before function 'bb'. // line 5, column 10
// function aa() {
```

demo of this pr available @ https://kaizhu256.github.io/jslint/branch-alpha/index.html