### PR TITLE
# v2021.7.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - vim - add vim plugin.
 
-# v2021.7.1-beta
+# v2021.7.24
 - bugfix - fix jslint not warning about function-redefinition when function is defined inside a call.
 - bugfix - fix website crashing when linting pure json-object.
 - ci - fix race-condition when inlining css.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Status
-| Branch | [master<br>(v2021.6.30)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
+| Branch | [master<br>(v2021.7.24)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
 |--:|:--:|:--:|:--:|
 | CI | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jslint-org/jslint/actions?query=branch%3Amaster) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/jslint-org/jslint/actions?query=branch%3Abeta) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/jslint-org/jslint/actions?query=branch%3Aalpha) |
 | Coverage | [![coverage](https://jslint-org.github.io/jslint/branch-master/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch-master/.build/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-beta/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch-beta/.build/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-alpha/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch-alpha/.build/coverage/index.html) |

--- a/browser.mjs
+++ b/browser.mjs
@@ -873,10 +873,8 @@ function jslint_ui_onresize() {
     if (!mode_debug) {
         editor.setValue(String(`
 #!/usr/bin/env node
-
 /*jslint browser, node*/
 /*global caches, indexedDb*/ //jslint-quiet
-
 import https from "https";
 import jslint from \u0022./jslint.mjs\u0022;
 
@@ -885,6 +883,8 @@ import jslint from \u0022./jslint.mjs\u0022;
 /*jslint-enable*/
 
 eval("console.log(\\"hello world\\");"); //jslint-quiet
+
+eval("console.log(\\"hello world\\");");
 
 // Optional directives.
 // .... /*jslint beta*/ .......... Enable experimental warnings.

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -134,7 +134,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2021.7.1-beta";
+let jslint_edition = "v2021.7.24";
 let jslint_export;              // The jslint object to be exported.
 let jslint_fudge = 1;           // Fudge starting line and starting column to 1.
 let jslint_import_meta_url = "";        // import.meta.url used by cli.


### PR DESCRIPTION
- bugfix - fix jslint not warning about function-redefinition when function is defined inside a call.
- bugfix - fix website crashing when linting pure json-object.
- ci - fix race-condition when inlining css.
- doc - update README.md with links to archived web-demos.
- jslint - add new beta-warning against redefining global-variables.
- jslint - add new beta-warning if functions are unordered.
- jslint - add new warning disallowing string-literal as property-name, e.g. {`aa`:0}.
- jslint - comment out shebang in jslint.mjs so older ios devices can use website.
- jslint - deprecate directive `/*jslint eval*/` - use `//jslint-quiet` instead.
- jslint-revamp - rearrange functions in jslint.mjs to comply with ordered-functions beta-warning.
- jslint-revamp - revamp cause-based testing with more robust instrumentation.
- tests - test artifact and column-position in warnings are correct.