### PR TITLE
Lint report "notifications"

### DIFF
--- a/browser.mjs
+++ b/browser.mjs
@@ -493,7 +493,7 @@ body {
 </style>
             `).trim();
     html += "<fieldset id=\"JSLINT_REPORT_WARNINGS\">\n";
-    html += "<legend>Report: Warnings</legend>\n";
+    html += "<legend>Report: Warnings (" + warnings.length + ")</legend>\n";
     html += "<div>\n";
     if (stop) {
         html += "<div class=\"center\">JSLint was unable to finish.</div>\n";
@@ -551,7 +551,7 @@ body {
 // </dl>
 
     html += "<fieldset id=\"JSLINT_REPORT_FUNCTIONS\">\n";
-    html += "<legend>Report: Functions</legend>\n";
+    html += "<legend>Report: Functions (" + functions.length +")</legend>\n";
     html += "<div>\n";
     if (json) {
 

--- a/browser.mjs
+++ b/browser.mjs
@@ -524,7 +524,11 @@ body {
 // Produce the /*property*/ directive.
 
     html += "<fieldset id=\"JSLINT_REPORT_PROPERTIES\">\n";
-    html += "<legend>Report: Properties (" + Object.keys(property).length + ")" + "</legend>\n";
+    html += (
+        "<legend>Report: Properties ("
+        + Object.keys(property).length
+        + ")</legend>\n"
+    );
     html += "<label>\n";
     html += "<textarea readonly>";
     html += "/*property";

--- a/browser.mjs
+++ b/browser.mjs
@@ -551,7 +551,7 @@ body {
 // </dl>
 
     html += "<fieldset id=\"JSLINT_REPORT_FUNCTIONS\">\n";
-    html += "<legend>Report: Functions (" + functions.length +")</legend>\n";
+    html += "<legend>Report: Functions (" + functions.length + ")</legend>\n";
     html += "<div>\n";
     if (json) {
 

--- a/browser.mjs
+++ b/browser.mjs
@@ -524,7 +524,8 @@ body {
 // Produce the /*property*/ directive.
 
     html += "<fieldset id=\"JSLINT_REPORT_PROPERTIES\">\n";
-    html += "<legend>Report: Properties (" + Object.keys(property).length + ")" + "</legend>\n";
+    html += "<legend>Report: Properties (" 
+    + Object.keys(property).length + ")" + "</legend>\n";
     html += "<label>\n";
     html += "<textarea readonly>";
     html += "/*property";

--- a/browser.mjs
+++ b/browser.mjs
@@ -524,8 +524,7 @@ body {
 // Produce the /*property*/ directive.
 
     html += "<fieldset id=\"JSLINT_REPORT_PROPERTIES\">\n";
-    html += "<legend>Report: Properties (" 
-    + Object.keys(property).length + ")" + "</legend>\n";
+    html += "<legend>Report: Properties (" + Object.keys(property).length + ")" + "</legend>\n";
     html += "<label>\n";
     html += "<textarea readonly>";
     html += "/*property";

--- a/browser.mjs
+++ b/browser.mjs
@@ -524,7 +524,7 @@ body {
 // Produce the /*property*/ directive.
 
     html += "<fieldset id=\"JSLINT_REPORT_PROPERTIES\">\n";
-    html += "<legend>Report: Properties</legend>\n";
+    html += "<legend>Report: Properties (" + Object.keys(property).length + ")" + "</legend>\n";
     html += "<label>\n";
     html += "<textarea readonly>";
     html += "/*property";


### PR DESCRIPTION
Users can view how many errors and functions they have at a glance with "notifications".
![Screenshot 2021-07-28 9 27 46 PM](https://user-images.githubusercontent.com/79121360/127431954-3a0a72ed-b3c0-4ccf-b0f4-0298f3b91334.png)

Should there be a space between the Report name and the number?