### PR TITLE
# v2021.8.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ on:
       - beta
       - master
       - sandbox
-# shCiBase - start
 jobs:
-  build:
+# shCiBase - start
+  job1:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -32,7 +32,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-    name: node . v${{ matrix.node_version }} . ${{ matrix.architecture }} . ${{ matrix.os }}
+    name: job1 . node . v${{ matrix.node_version }} . ${{ matrix.architecture }} . ${{ matrix.os }}
     steps:
       # disable autocrlf in windows
       - run: git config --global core.autocrlf false
@@ -48,6 +48,7 @@ jobs:
       # run nodejs coverages and tests
       - run: sh jslint_ci.sh shCiBase
 # shCiBase - end
+# shCiArtifactUpload - start
       # fetch jslint_ci.sh from trusted source
       - run: git fetch origin alpha && git checkout origin/alpha jslint_ci.sh
       # upload build-artifacts to branch-gh-pages
@@ -55,3 +56,4 @@ jobs:
         env:
           CI_NODE_VERSION_ARCH_PLATFORM: v14.x64.linux
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+# shCiArtifactUpload - end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - vim - add vim plugin.
 
-# v2021.8.1-beta
+# v2021.8.20
+- warning - disable un-ergonomic warnings restricting directive-global (missing_browser and unexpected_directive_a).
 - fs - rename file ci.sh to jslint_ci.sh.
 - license - add codemirror license to rollup-assets.
-- warning - disable un-ergonomic warnings restricting directive-global (missing_browser and unexpected_directive_a).
 - website - display number of warnings, properties, functions in report.
 - website - fix uiLoader getting hidden behind highlighted text.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Status
-| Branch | [master<br>(v2021.7.24)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
+| Branch | [master<br>(v2021.8.20)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
 |--:|:--:|:--:|:--:|
 | CI | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jslint-org/jslint/actions?query=branch%3Amaster) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/jslint-org/jslint/actions?query=branch%3Abeta) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/jslint-org/jslint/actions?query=branch%3Aalpha) |
 | Coverage | [![coverage](https://jslint-org.github.io/jslint/branch-master/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch-master/.build/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-beta/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch-beta/.build/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-alpha/.build/coverage/coverage-badge.svg)](https://jslint-org.github.io/jslint/branch-alpha/.build/coverage/index.html) |

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -134,7 +134,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2021.8.1-beta";
+let jslint_edition = "v2021.8.20";
 let jslint_export;              // The jslint object to be exported.
 let jslint_fudge = 1;           // Fudge starting line and starting column to 1.
 let jslint_import_meta_url = "";        // import.meta.url used by cli.


### PR DESCRIPTION
- warning - disable un-ergonomic warnings restricting directive-global (missing_browser and unexpected_directive_a).
- fs - rename file ci.sh to jslint_ci.sh.
- license - add codemirror license to rollup-assets.
- website - display number of warnings, properties, functions in report.
- website - fix uiLoader getting hidden behind highlighted text.