### PR TITLE
- jslint - rename little-used directive `debug` to `trace` to avoid confusion with non-related directive `devel`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 # v2021.9.1-beta
 - jslint - add bigint support.
+- jslint - rename little-used directive `debug` to `trace` to avoid confusion with non-related directive `devel`.
 - vim - add vim-plugin and file jslint.vim.
 
 # v2021.8.20

--- a/README.md
+++ b/README.md
@@ -94,23 +94,12 @@ node jslint.mjs .
 -->
 
 ## To run jslint as vim-plugin:
-1. Download and save `jslint.mjs`, `jslint.vim` to directory `~/.vim/`
+1. Download and save [`jslint.mjs`](https://www.jslint.com/jslint.mjs), [`jslint.vim`](https://www.jslint.com/jslint.vim) to directory `~/.vim/`
 2. Add vim-command `:source ~/.vim/jslint.vim` to file `~/.vimrc`
-```shell
-#!/bin/sh
-
-# 1. Download and save `jslint.mjs`, `jslint.vim` to directory `~/.vim/`
-mkdir -p ~/.vim/
-curl -L https://www.jslint.com/jslint.mjs > ~/.vim/jslint.mjs
-curl -L https://www.jslint.com/jslint.vim > ~/.vim/jslint.vim
-
-# 2. Add vim-command `:source ~/.vim/jslint.vim` to file `~/.vimrc`
-printf "\n:source ~/.vim/jslint.vim\n" >> ~/.vimrc
-```
-
 3. Vim can now jslint files (via nodejs):
-- with vim-command `:SaveAndJslint`
-- with vim-key-combo `<Ctrl-S> <Ctrl-J>`
+    - with vim-command `:SaveAndJslint`
+    - with vim-key-combo `<Ctrl-S> <Ctrl-J>`
+- screenshot
 
 ![screenshot.png](asset-image-jslint-vim-plugin.png)
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Web Demo Archived
-- [Web Demo 2020 (can lint ES6)](https://www.jslint.com/branch-v2020.11.6/index.html)
-- [Web Demo 2014 (can lint ES5 only)](https://www.jslint.com/branch-v2014.7.8/jslint.html)
-- [Web Demo 2013 (can lint ES5, CSS, HTML)](https://www.jslint.com/branch-v2013.3.13/jslint.html)
+- [Web Demo 2020](https://www.jslint.com/branch-v2020.11.6/index.html)
+- [Web Demo 2014 (ES5 only)](https://www.jslint.com/branch-v2014.7.8/jslint.html)
+- [Web Demo 2013 (ES5, CSS, HTML)](https://www.jslint.com/branch-v2013.3.13/jslint.html)
 
 
 # Install
@@ -94,21 +94,21 @@ node jslint.mjs .
 -->
 
 ## To run jslint as vim-plugin:
-### 1. Download and save `jslint.mjs`, `jslint.vim` to directory `~/.vim/`
-### 2. Add vim-command `:source ~/.vim/jslint.vim` to file `~/.vimrc`
+1. Download and save `jslint.mjs`, `jslint.vim` to directory `~/.vim/`
+2. Add vim-command `:source ~/.vim/jslint.vim` to file `~/.vimrc`
 ```shell
 #!/bin/sh
 
-### 1. Download and save `jslint.mjs`, `jslint.vim` to directory `~/.vim/`
+# 1. Download and save `jslint.mjs`, `jslint.vim` to directory `~/.vim/`
 mkdir -p ~/.vim/
 curl -L https://www.jslint.com/jslint.mjs > ~/.vim/jslint.mjs
 curl -L https://www.jslint.com/jslint.vim > ~/.vim/jslint.vim
 
-### 2. Add vim-command `:source ~/.vim/jslint.vim` to file `~/.vimrc`
+# 2. Add vim-command `:source ~/.vim/jslint.vim` to file `~/.vimrc`
 printf "\n:source ~/.vim/jslint.vim\n" >> ~/.vimrc
 ```
 
-### 3. Vim can now jslint files (via nodejs):
+3. Vim can now jslint files (via nodejs):
 - with vim-command `:SaveAndJslint`
 - with vim-key-combo `<Ctrl-S> <Ctrl-J>`
 

--- a/browser.mjs
+++ b/browser.mjs
@@ -897,7 +897,6 @@ eval("console.log(\\"hello world\\");");
 // .... /*jslint bitwise*/ ....... Allow bitwise operators.
 // .... /*jslint browser*/ ....... Assume browser environment.
 // .... /*jslint convert*/ ....... Allow conversion operators.
-// .... /*jslint debug*/ ......... Include jslint stack-trace in warnings.
 // .... /*jslint devel*/ ......... Allow console.log() and friends.
 // .... /*jslint for*/ ........... Allow for-statement.
 // .... /*jslint getset*/ ........ Allow get() and set().
@@ -907,6 +906,7 @@ eval("console.log(\\"hello world\\");");
 // .... /*jslint node*/ .......... Assume Node.js environment.
 // .... /*jslint single*/ ........ Allow single-quote strings.
 // .... /*jslint this*/ .......... Allow 'this'.
+// .... /*jslint trace*/ ......... Include jslint stack-trace in warnings.
 // .... /*jslint unordered*/ ..... Allow unordered cases, params, properties,
 // ................................... and variables.
 // .... /*jslint variable*/ ...... Allow unordered const and let declarations

--- a/index.html
+++ b/index.html
@@ -258,14 +258,14 @@
         <div title="Assume browser environment.">
         <label><input type="checkbox" value="browser">browser</label>
         </div>
-        <div title="Include jslint stack-trace in warnings.">
-        <label><input type="checkbox" value="debug">debug</label>
-        </div>
         <div title="Allow console.log() and friends.">
         <label><input type="checkbox" value="devel">devel</label>
         </div>
         <div title="Assume Node.js environment.">
         <label><input type="checkbox" value="node">node</label>
+        </div>
+        <div title="Include jslint stack-trace in warnings.">
+        <label><input type="checkbox" value="trace">trace</label>
         </div>
     </div>
     <div>Allow...

--- a/jslint.vim
+++ b/jslint.vim
@@ -25,4 +25,6 @@ endfunction
 command! -nargs=* -bang SaveAndJslint call SaveAndJslint("<bang>")
 
 "" map vim-key-combo "<ctrl-s> <ctrl-j>" to ":SaveAndJslint"
-nnoremap <c-s><c-j> :SaveAndJslint <cr>
+inoremap <c-s><c-j> <esc> :SaveAndJslint <cr>
+nnoremap <c-s><c-j> <esc> :SaveAndJslint <cr>
+vnoremap <c-s><c-j> <esc> :SaveAndJslint <cr>

--- a/test.mjs
+++ b/test.mjs
@@ -68,7 +68,7 @@ function noop() {
         file: "syntax-error.js",
         mode_cli: true,
         option: {
-            debug: true
+            trace: true
         },
         process_exit: processExit1,
         source: "syntax error"
@@ -78,9 +78,6 @@ function noop() {
         // suppress error
         console_error: noop,
         mode_cli: true,
-        option: {
-            debug: true
-        },
         process_argv: [
             "node",
             "jslint.mjs",
@@ -117,6 +114,9 @@ function noop() {
             + "    }\n"
             + "}\n"
         ],
+
+// PR-351 - Add BigInt support.
+
         bigint: [
             "let aa = 0b0n;\n",
             "let aa = 0o0n;\n",
@@ -275,8 +275,6 @@ function noop() {
         ], [
             "registerType();", {couch: true}, []
         ], [
-            "", {debug: true}, []
-        ], [
             "debugger;", {devel: true}, []
         ], [
             "new Function();\neval();", {eval: true}, []
@@ -312,6 +310,8 @@ function noop() {
             "let aa = 'aa';", {single: true}, []
         ], [
             "let aa = this;", {this: true}, []
+        ], [
+            "", {trace: true}, []
         ], [
             (
                 "function aa({bb, aa}) {\n"


### PR DESCRIPTION
the `debug` directive is used by jslint-developers to diagnose internal bugs.

renaming it to `trace` to prevent user-confusion with similarly named directived `devel` (that's completely unrelated).
