### PR TITLE
- coverage - add cli-options `--exclude=aa,bb`, `--exclude-node-modules=false`, `--include=aa,bb`

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -76,8 +76,8 @@ echo "\
             + "$&\n"
             + "git checkout 60a022c511a37788e652c271af23174566a80c30\n"
         ));
-        // limit stdout to 100 lines
-        script = script.trimRight() + " 2>&1 | head -n 100\n";
+        // limit stdout to 32 lines
+        script = script.trimRight() + " 2>&1 | head -n 32\n";
         // printf script
         script = (
             "(set -e\n"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Todo
 - cli - remove cli-option `--mode-vim-plugin`
 - coverage - add macros `/*coverage-disable*/` and `/*coverage-enable*/`.
+- coverage - support globbing `*` in cli-options `--exclude` and `--include`
 - jslint - add html and css linting back into jslint.
 - jslint - add new warning requiring paren around plus-separated concatenations.
 - jslint - add numeric-separators support.
@@ -14,6 +15,7 @@
 
 # v2021.11.1-beta
 - ci - deprecate/remove jslint.cjs from ci
+- coverage - add cli-options `--exclude=aa,bb`, `--exclude-node-modules=false`, `--include=aa,bb`
 - coverage - dedupe coverage-logic now applied when only one script passed
 - jslint - add top-level-await support
 - npm - add file .npmignore

--- a/README.md
+++ b/README.md
@@ -266,8 +266,15 @@ npm install
 
 node ../jslint.mjs \
     v8_coverage_report=../.artifact/coverage_sqlite3_sh/ \
+    --exclude-node-modules=true \
+    --exclude=test/foo.js,test/bar.js \
+    --exclude=test/baz.js \
     npm run test
 ```
+- shell output
+
+![screenshot.svg](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_sh_coverage_report_spawn.svg)
+
 - screenshot file [.artifact/coverage_sqlite3_sh/index.html](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage_sqlite3_sh/index.html)
 
 [![screenshot.png](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_browser__2f.artifact_2fcoverage_sqlite3_sh_2findex.html.png)](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage_sqlite3_sh/index.html)
@@ -275,10 +282,6 @@ node ../jslint.mjs \
 - screenshot file [.artifact/coverage_sqlite3_sh/lib/sqlite3.js.html](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage_sqlite3_sh/lib/sqlite3.js.html)
 
 [![screenshot.png](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_browser__2f.artifact_2fcoverage_sqlite3_sh_2flib_2fsqlite3.js.html.png)](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage_sqlite3_sh/lib/sqlite3.js.html)
-
-- shell output
-
-![screenshot.svg](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_sh_coverage_report_spawn.svg)
 
 
 <br><br>
@@ -304,12 +307,20 @@ import jslint from "../jslint.mjs";
 
     await jslint.v8CoverageReportCreate({
         coverageDir: "../.artifact/coverage_sqlite3_js/",
-        processArgv: ["npm", "run", "test"]
+        processArgv: [
+            "--include=lib/sqlite3-binding.js,lib/sqlite3.js",
+            "--include=lib/trace.js",
+            "npm", "run", "test"
+        ]
     });
 }());
 
 '
 ```
+- shell output
+
+![screenshot.svg](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_js_coverage_report_spawn.svg)
+
 - screenshot file [.artifact/coverage_sqlite3_js/index.html](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage_sqlite3_js/index.html)
 
 [![screenshot.png](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_browser__2f.artifact_2fcoverage_sqlite3_js_2findex.html.png)](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage_sqlite3_js/index.html)
@@ -317,10 +328,6 @@ import jslint from "../jslint.mjs";
 - screenshot file [.artifact/coverage_sqlite3_js/lib/sqlite3.js.html](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage_sqlite3_js/lib/sqlite3.js.html)
 
 [![screenshot.png](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_browser__2f.artifact_2fcoverage_sqlite3_js_2flib_2fsqlite3.js.html.png)](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage_sqlite3_js/lib/sqlite3.js.html)
-
-- shell output
-
-![screenshot.svg](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_js_coverage_report_spawn.svg)
 
 
 <br><br>
@@ -379,7 +386,7 @@ right so that you can focus your creative energy where it is most needed.
 <br><br>
 # License
 - JSLint is under [Unlicense License](LICENSE).
-- CodeMirror code-editor is under [MIT License](https://github.com/codemirror/CodeMirror/blob/master/LICENSE).
+- CodeMirror editor is under [MIT License](https://github.com/codemirror/CodeMirror/blob/master/LICENSE).
 - Function `v8CoverageListMerge` is derived from [MIT Licensed v8-coverage](https://github.com/demurgos/v8-coverage/blob/73446087dc38f61b09832c9867122a23f8577099/ts/LICENSE.md).
 
 <!--

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -10676,7 +10676,7 @@ function sentinel() {}
         processArgElem[1] = processArgElem.slice(1).join("=");
         switch (processArgElem[0]) {
 
-// PR-xxx - add cli-option `--exclude=aa,bb`
+// PR-371 - add cli-option `--exclude=aa,bb`
 
         case "--exclude":
             fileExcludeList = fileExcludeList.concat(
@@ -10684,7 +10684,7 @@ function sentinel() {}
             );
             break;
 
-// PR-xxx - add cli-option `--exclude-node-modules=false`
+// PR-371 - add cli-option `--exclude-node-modules=false`
 
         case "--exclude-node-modules":
             fileIncludeNodeModules = (
@@ -10692,7 +10692,7 @@ function sentinel() {}
             ).test(processArgElem[1]);
             break;
 
-// PR-xxx - add cli-option `--include=aa,bb`
+// PR-371 - add cli-option `--include=aa,bb`
 
         case "--include":
             fileIncludeList = fileIncludeList.concat(
@@ -10772,7 +10772,7 @@ function sentinel() {}
                 !pathname
                 || pathname.startsWith("[")
 
-// PR-xxx - Filter directory node_modules.
+// PR-371 - Filter directory node_modules.
 
                 || (
                     !fileIncludeNodeModules
@@ -10781,11 +10781,11 @@ function sentinel() {}
                     ).test(pathname)
                 )
 
-// PR-xxx - Filter fileExcludeList.
+// PR-371 - Filter fileExcludeList.
 
                 || fileExcludeList.indexOf(pathname) >= 0
 
-// PR-xxx - Filter fileIncludeList.
+// PR-371 - Filter fileIncludeList.
 
                 || (
                     fileIncludeList.length > 0

--- a/test.mjs
+++ b/test.mjs
@@ -42,6 +42,7 @@ try {
     moduleFs.rmSync(".tmp", { //jslint-quiet
         recursive: true
     });
+    assertOrThrow(undefined);
 } catch (ignore) {}
 
 (function testcaseFsXxx() {
@@ -895,6 +896,9 @@ try {
                 process_argv: [
                     "node", "jslint.mjs",
                     "v8_coverage_report=.tmp/coverage_jslint",
+                    "--exclude-node-modules=0",
+                    "--exclude=aa.js",
+                    "--include=jslint.mjs",
                     "node", "jslint.mjs"
                 ]
             });
@@ -908,7 +912,7 @@ try {
                 )
             ], [
                 "v8CoverageReportCreate_ignore.js", (
-                    "/*mode-coverage-ignore-file*/\n"
+                    "/*coverage-ignore-file*/\n"
                     + "switch(0){\n"
                     + "case 0:break;\n"
                     + "}\n"


### PR DESCRIPTION
this pr adds istanbul/c8 like options `--exclude=aa,bb`, `--exclude-node-modules=false`,  and `--include=aa,bb` to command `v8_coverage_report`.  file-globbing is not currently supported, but planned for a future-pr.

```js
# Create V8 coverage report from program `npm run test` in shell.

node ../jslint.mjs \
    v8_coverage_report=../.artifact/coverage_sqlite3_sh/ \
    --exclude-node-modules=true \
    --exclude=test/foo.js,test/bar.js \
    --exclude=test/baz.js \
    --include=lib/sqlite3-binding.js,lib/sqlite3.js \
    --include=lib/trace.js \
    npm run test
```