### PR TITLE
V2021.11.20 - add top-level-await support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - perf - improve performance by hoisting inlined regexps out of loops and subfunctions
 
-# v2021.11.1-beta
+# v2021.11.20
+- jslint - add top-level-await support
 - ci - deprecate/remove jslint.cjs from ci
 - coverage - add cli-options `--exclude=aa,bb`, `--exclude-node-modules=false`, `--include=aa,bb`
 - coverage - dedupe coverage-logic now applied when only one script passed
-- jslint - add top-level-await support
 - npm - add file .npmignore
 - website - add clickable-links to editor-code in report-warnings and report-functions
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Status
-| Branch | [master<br>(v2021.10.20)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
+| Branch | [master<br>(v2021.11.20)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
 |--:|:--:|:--:|:--:|
 | CI | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jslint-org/jslint/actions?query=branch%3Amaster) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/jslint-org/jslint/actions?query=branch%3Abeta) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/jslint-org/jslint/actions?query=branch%3Aalpha) |
 | Coverage | [![coverage](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/index.html) |

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -165,7 +165,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2021.11.1-beta";
+let jslint_edition = "v2021.11.20";
 let jslint_export;                      // The jslint object to be exported.
 let jslint_fudge = 1;                   // Fudge starting line and starting
                                         // ... column to 1.

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -121,7 +121,7 @@
     mkdir, modeCoverageIgnoreFile, modeIndex, mode_cli, mode_json, mode_module,
     mode_noop, mode_property, mode_shebang, mode_stop, module, moduleFsInit,
     moduleName, module_list, name, names, node, noop, now,
-    nr, nud, ok, on, open, opening, option,
+    nr, nud, objectDeepCopyWithKeysSorted, ok, on, open, opening, option,
     option_dict, order, package_name, padEnd, padStart, parameters, parent,
     parentIi, parse, pathname, platform, pop, processArgv, process_argv,
     process_env, process_exit, process_version, promises, property,
@@ -183,7 +183,7 @@ let moduleUrl;
 
 async function assertErrorThrownAsync(asyncFunc, regexp) {
 
-// This function will assert <asyncFunc> throws an error.
+// This function will assert calling <asyncFunc> throws an error.
 
     let err;
     try {
@@ -191,7 +191,7 @@ async function assertErrorThrownAsync(asyncFunc, regexp) {
     } catch (errCaught) {
         err = errCaught;
     }
-    assertOrThrow(err, "no error thrown");
+    assertOrThrow(err, "No error thrown.");
     assertOrThrow(
         regexp === undefined || new RegExp(regexp).test(err.message),
         err
@@ -206,7 +206,11 @@ function assertJsonEqual(aa, bb, message) {
     bb = JSON.stringify(objectDeepCopyWithKeysSorted(bb));
     if (aa !== bb) {
         throw new Error(
-            message || JSON.stringify(aa) + " !== " + JSON.stringify(bb)
+            JSON.stringify(aa) + " !== " + JSON.stringify(bb) + (
+                message
+                ? " - " + message
+                : ""
+            )
         );
     }
 }
@@ -9548,13 +9552,13 @@ function objectDeepCopyWithKeysSorted(obj) {
         return obj;
     }
 
-// recursively deep-copy list with child-keys sorted
+// Recursively deep-copy list with child-keys sorted.
 
     if (Array.isArray(obj)) {
         return obj.map(objectDeepCopyWithKeysSorted);
     }
 
-// recursively deep-copy obj with keys sorted
+// Recursively deep-copy obj with keys sorted.
 
     sorted = {};
     Object.keys(obj).sort().forEach(function (key) {
@@ -10979,6 +10983,7 @@ jslint_export = Object.freeze(Object.assign(jslint, {
     jstestOnExit,
     moduleFsInit,
     noop,
+    objectDeepCopyWithKeysSorted,
     v8CoverageListMerge,
     v8CoverageReportCreate
 }));

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -1151,38 +1151,38 @@ shJsonNormalize() {(set -e
 # 3. write normalized json-data back to file $1
     node --input-type=module --eval '
 import moduleFs from "fs";
+function noop(val) {
+
+// This function will do nothing except return <val>.
+
+    return val;
+}
+function objectDeepCopyWithKeysSorted(obj) {
+
+// This function will recursively deep-copy <obj> with keys sorted.
+
+    let sorted;
+    if (typeof obj !== "object" || !obj) {
+        return obj;
+    }
+
+// Recursively deep-copy list with child-keys sorted.
+
+    if (Array.isArray(obj)) {
+        return obj.map(objectDeepCopyWithKeysSorted);
+    }
+
+// Recursively deep-copy obj with keys sorted.
+
+    sorted = {};
+    Object.keys(obj).sort().forEach(function (key) {
+        sorted[key] = objectDeepCopyWithKeysSorted(obj[key]);
+    });
+    return sorted;
+}
 (async function () {
-    function noop(val) {
-
-// this function will do nothing except return <val>
-
-        return val;
-    }
-    function objectDeepCopyWithKeysSorted(obj) {
-
-// this function will recursively deep-copy <obj> with keys sorted
-
-        let sorted;
-        if (typeof obj !== "object" || !obj) {
-            return obj;
-        }
-
-// recursively deep-copy list with child-keys sorted
-
-        if (Array.isArray(obj)) {
-            return obj.map(objectDeepCopyWithKeysSorted);
-        }
-
-// recursively deep-copy obj with keys sorted
-
-        sorted = {};
-        Object.keys(obj).sort().forEach(function (key) {
-            sorted[key] = objectDeepCopyWithKeysSorted(obj[key]);
-        });
-        return sorted;
-    }
     console.error("shJsonNormalize - " + process.argv[1]);
-    moduleFs.promises.writeFile(
+    await moduleFs.promises.writeFile(
         process.argv[1],
         JSON.stringify(
             objectDeepCopyWithKeysSorted(
@@ -1198,7 +1198,7 @@ import moduleFs from "fs";
                 )
             ),
             undefined,
-            4
+            Number(process.argv[2]) || 4
         ) + "\n"
     );
 }());

--- a/package.json
+++ b/package.json
@@ -22,5 +22,5 @@
         "test": "node jslint.mjs v8_coverage_report=.artifact/coverage node test.mjs",
         "test2": "sh jslint_ci.sh shCiBase"
     },
-    "version": "2021.11.1-beta"
+    "version": "2021.11.20"
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "zero-dependency"
     ],
     "license": "UNLICENSE",
+    "main": "jslint.mjs",
     "name": "@jslint-org/jslint",
     "repository": {
         "type": "git",

--- a/test.mjs
+++ b/test.mjs
@@ -622,6 +622,9 @@ try {
     await assertErrorThrownAsync(function () {
         assertJsonEqual(1, 2);
     });
+    await assertErrorThrownAsync(function () {
+        assertJsonEqual(1, 2, "undefined");
+    });
     // test assertOrThrow's error handling-behavior
     await assertErrorThrownAsync(function () {
         assertOrThrow(undefined, "undefined");


### PR DESCRIPTION
- jslint - add top-level-await support
- ci - deprecate/remove jslint.cjs from ci
- coverage - add cli-options `--exclude=aa,bb`, `--exclude-node-modules=false`, `--include=aa,bb`
- coverage - dedupe coverage-logic now applied when only one script passed
- npm - add file .npmignore
- website - add clickable-links to editor-code in report-warnings and report-functions
