### PR TITLE
- bugfix - fix cryptic-warning against using "delete" keyword in fat-arrow.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@
 - jslint - require regexp to use open-form.
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
 - jslint - unify analysis of variable-assignment/function-parameters into one function
-- jslint- add new warning "Expected Object.create(null) instead of {}"
+- jslint - add new warning "Expected Object.create(null) instead of {}"
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - perf - improve performance by hoisting inlined regexps out of loops and subfunctions
 
 # v2022.2.1-beta
-- bugfix - fix issue #379 - cryptic-warning against using "delete" keyword in fat-arrow.
+- bugfix - fix issue #379 - warn against naked-statement in fart.
 - update commonjs-wrapper jslint.cjs to load jslint in strict-mode.
 
 # v2021.12.20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@
 - jslint - require regexp to use open-form.
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
 - jslint - unify analysis of variable-assignment/function-parameters into one function
+- jslint- add new warning "Expected Object.create(null) instead of {}"
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - perf - improve performance by hoisting inlined regexps out of loops and subfunctions
+
+# v2022.2.1-beta
+- bugfix - fix issue #379 - cryptic-warning against using "delete" keyword in fat-arrow.
+- update commonjs-wrapper jslint.cjs to load jslint in strict-mode.
 
 # v2021.12.20
 - npm - add file jslint.cjs so package @jslint-org/jslint can be published as dual-module

--- a/jslint.cjs
+++ b/jslint.cjs
@@ -1,14 +1,19 @@
 /*jslint beta, node*/
 /*property
-    readFileSync, replace, runInNewContext
+    module, readFileSync, replace, runInNewContext
 */
 require("vm").runInNewContext(
-    require("fs").readFileSync(__dirname + "/jslint.mjs", "utf8").replace(
-        "\nexport default Object.freeze(jslint_export);",
-        "\nexports = jslint_export;"
-    ).replace(
-        "\njslint_import_meta_url = import.meta.url;",
-        "\n// jslint_import_meta_url = import.meta.url;"
+    (
+        "\"use strict\";"
+        + require("fs").readFileSync(__dirname + "/jslint.mjs", "utf8").replace(
+            "\nexport default Object.freeze(jslint_export);",
+            "\nmodule.exports = jslint_export;"
+        ).replace(
+            "\njslint_import_meta_url = import.meta.url;",
+            "\n// jslint_import_meta_url = import.meta.url;"
+        )
     ),
-    module
+    {
+        module
+    }
 );

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -94,6 +94,7 @@
 /*jslint beta, node*/
 
 /*property
+    fud_stmt,
     mode_conditional,
     JSLINT_BETA, NODE_V8_COVERAGE, a, all, argv, arity, artifact,
     assertErrorThrownAsync, assertJsonEqual, assertOrThrow, assign, async, b,
@@ -107,7 +108,7 @@
     example_list, exec, execArgv, exit, export_dict, exports, expression, extra,
     file, fileList, fileURLToPath, filter, finally, flag, floor, for, forEach,
     formatted_message, free, freeze, from, froms,
-    fsWriteFileWithParents, fud, functionName, function_list, function_stack,
+    fsWriteFileWithParents, functionName, function_list, function_stack,
     functions, get, getset, github_repo, global, global_dict, global_list,
     holeList, htmlEscape, id, identifier, import, import_list, inc, indent2,
     index, indexOf, init, initial, isArray, isBlockCoverage, isHole, isNaN,
@@ -115,13 +116,13 @@
     jslint_charset_ascii, jslint_cli, jslint_edition, jslint_phase1_split,
     jslint_phase2_lex, jslint_phase3_parse, jslint_phase4_walk,
     jslint_phase5_whitage, jslint_report, json, jstestDescribe, jstestIt,
-    jstestOnExit, keys, label, lbp, led, length, level, line, lineList,
+    jstestOnExit, keys, label, lbp, led_infix, length, level, line, lineList,
     line_list, line_offset, line_source, lines, linesCovered, linesTotal, live,
     log, long, loop, m, main, map, margin, match, max, message, meta, min,
     mkdir, modeCoverageIgnoreFile, modeIndex, mode_cli, mode_json, mode_module,
     mode_noop, mode_property, mode_shebang, mode_stop, module, moduleFsInit,
     moduleName, module_list, name, names, node, noop, now,
-    nr, nud, objectDeepCopyWithKeysSorted, ok, on, open, opening, option,
+    nr, nud_prefix, objectDeepCopyWithKeysSorted, ok, on, open, opening, option,
     option_dict, order, package_name, padEnd, padStart, parameters, parent,
     parentIi, parse, pathname, platform, pop, processArgv, process_argv,
     process_env, process_exit, process_version, promises, property,
@@ -3607,7 +3608,7 @@ function jslint_phase3_parse(state) {
 // other assignment operators can modify, but they cannot initialize.
 
         const the_symbol = symbol(id, 20);
-        the_symbol.led = function (left) {
+        the_symbol.led_infix = function (left) {
             const the_token = token_now;
             let right;
             the_token.arity = "assignment";
@@ -3919,7 +3920,7 @@ function jslint_phase3_parse(state) {
 
         const the_symbol = symbol(id);
         the_symbol.constant = true;
-        the_symbol.nud = (
+        the_symbol.nud_prefix = (
             typeof value === "function"
             ? value
             : function () {
@@ -4113,7 +4114,7 @@ function jslint_phase3_parse(state) {
 // Create an infix operator.
 
         const the_symbol = symbol(id, bp);
-        the_symbol.led = function (left) {
+        the_symbol.led_infix = function (left) {
             const the_token = token_now;
             the_token.arity = "binary";
             if (f !== undefined) {
@@ -4339,13 +4340,13 @@ function jslint_phase3_parse(state) {
 // Create a right associative infix operator.
 
         const the_symbol = symbol(id, bp);
-        the_symbol.led = function parse_infixr_led(left) {
+        the_symbol.led_infix = function parse_infixr_led(left) {
             const the_token = token_now;
 
 // test_cause:
-// ["0**0", "parse_infixr_led", "led", "", 0]
+// ["0**0", "parse_infixr_led", "led_infix", "", 0]
 
-            test_cause("led");
+            test_cause("led_infix");
             the_token.arity = "binary";
             the_token.expression = [left, parse_expression(bp - 1)];
             return the_token;
@@ -4371,21 +4372,67 @@ function jslint_phase3_parse(state) {
     function parse_expression(rbp, initial) {
 
 // This is the heart of JSLINT, the Pratt parser. In addition to parsing, it
-// is looking for ad hoc lint patterns. We add .fud to Pratt's model, which is
-// like .nud except that it is only used on the first token of a statement.
-// Having .fud makes it much easier to define statement-oriented languages like
-// JavaScript. I retained Pratt's nomenclature.
+// is looking for ad hoc lint patterns. We add .fud_stmt to Pratt's model, which
+// is like .nud_prefix except that it is only used on the first token of a
+// statement. Having .fud_stmt makes it much easier to define statement-oriented
+// languages like JavaScript. I retained Pratt's nomenclature.
 // They are elements of the parsing method called Top Down Operator Precedence.
 
-// .nud     Null denotation
-// .fud     First null denotation
-// .led     Left denotation
-//  lbp     Left binding power
-//  rbp     Right binding power
+// .nud_prefix  Null denotation. The prefix handler.
+// .fud_stmt    First null denotation. The statement handler.
+// .led_infix   Left denotation. The infix/postfix handler.
+//  lbp         Left binding power of infix operator. It tells us how strongly
+//              the operator binds to the argument at its left.
+//  rbp         Right binding power.
 
-// It processes a nud (variable, constant, prefix operator). It will then
-// process leds (infix operators) until the bind powers cause it to stop. It
-// returns the expression's parse tree.
+// It processes a nud_prefix (variable, constant, prefix operator). It will then
+// process leds (infix operators) until the bind powers cause it to stop (it
+// consumes tokens until it meets a token whose lbp <= rbp). Specifically, it
+// means that it collects all tokens that bind together before returning to the
+// operator that called it. It returns the expression's parse tree.
+
+// For example, "3 + 1 * 2 * 4 + 5"
+// parses into
+// {
+//     "id": "+",
+//     "expression": [
+//         {
+//             "id": "+",
+//             "expression": [
+//                 {
+//                     "id": "(number)",
+//                     "value": "3"
+//                 },
+//                 {
+//                     "id": "*",
+//                     "expression": [
+//                         {
+//                             "id": "*",
+//                             "expression": [
+//                                 {
+//                                     "id": "(number)",
+//                                     "value": "1"
+//                                 },
+//                                 {
+//                                     "id": "(number)",
+//                                     "value": "2"
+//                                 }
+//                             ]
+//                         },
+//                         {
+//                             "id": "(number)",
+//                             "value": "4"
+//                         }
+//                     ]
+//                 }
+//             ]
+//         },
+//         {
+//             "id": "(number)",
+//             "value": "5"
+//         }
+//     ]
+// }
 
         let left;
         let the_symbol;
@@ -4397,13 +4444,13 @@ function jslint_phase3_parse(state) {
             advance();
         }
         the_symbol = syntax_dict[token_now.id];
-        if (the_symbol !== undefined && the_symbol.nud !== undefined) {
+        if (the_symbol !== undefined && the_symbol.nud_prefix !== undefined) {
 
 // test_cause:
 // ["0", "parse_expression", "symbol", "", 0]
 
             test_cause("symbol");
-            left = the_symbol.nud();
+            left = the_symbol.nud_prefix();
         } else if (token_now.identifier) {
 
 // test_cause:
@@ -4428,13 +4475,13 @@ function jslint_phase3_parse(state) {
             the_symbol = syntax_dict[token_nxt.id];
             if (
                 the_symbol === undefined
-                || the_symbol.led === undefined
+                || the_symbol.led_infix === undefined
                 || the_symbol.lbp <= rbp
             ) {
                 break;
             }
             advance();
-            left = the_symbol.led(left);
+            left = the_symbol.led_infix(left);
         }
         return left;
     }
@@ -4447,7 +4494,8 @@ function jslint_phase3_parse(state) {
         the_fart.name = "=>";
         the_fart.level = functionage.level + 1;
         function_list.push(the_fart);
-// PR-xxx - Relax warning "function_in_loop".
+
+// PR-384 - Relax warning "function_in_loop".
 //
 //         if (functionage.loop > 0) {
 
@@ -4460,13 +4508,11 @@ function jslint_phase3_parse(state) {
 // Give the function properties storing its names and for observing the depth
 // of loops and switches.
 
-        Object.assign(the_fart, {
-            context: empty(),
-            finally: 0,
-            loop: 0,
-            switch: 0,
-            try: 0
-        });
+        the_fart.context = empty();
+        the_fart.finally = 0;
+        the_fart.loop = 0;
+        the_fart.switch = 0;
+        the_fart.try = 0;
 
 // Push the current function context and establish a new one.
 
@@ -4482,25 +4528,25 @@ function jslint_phase3_parse(state) {
             test_cause("parameter");
             enroll(name, "parameter", true);
         });
-        switch (token_nxt.id) {
-
-// PR-xxx - Bugfix - Fixes issue #379 - fart-warning against "delete" keyword.
-
-// test_cause:
-// ["()=>delete aa", "parse_fart", "unexpected_a", "delete", 5]
-
-        case "delete":
-            stop("unexpected_a");
-            break;
-        case "{":
+        if (token_nxt.id === "{") {
 
 // test_cause:
 // ["()=>{}", "parse_fart", "expected_a_b", "=>", 3]
 
             warn("expected_a_b", the_fart, "function", "=>");
             the_fart.block = block("body");
-            break;
-        default:
+        } else if (
+            syntax_dict[token_nxt.id] !== undefined
+            && syntax_dict[token_nxt.id].fud_stmt !== undefined
+        ) {
+
+// PR-384 - Bugfix - Fixes issue #379 - warn against naked-statement in fart.
+
+// test_cause:
+// ["()=>delete aa", "parse_fart", "unexpected_a_after_b", "=>", 5]
+
+            stop("unexpected_a_after_b", token_nxt, token_nxt.id, "=>");
+        } else {
             the_fart.expression = parse_expression(0);
         }
         functionage = function_stack.pop();
@@ -4722,7 +4768,7 @@ function jslint_phase3_parse(state) {
         the_symbol = syntax_dict[first.id];
         if (
             the_symbol !== undefined
-            && the_symbol.fud !== undefined
+            && the_symbol.fud_stmt !== undefined
 
 // PR-318 - Bugfix - Fixes issues #316, #317 - dynamic-import().
 
@@ -4731,7 +4777,7 @@ function jslint_phase3_parse(state) {
             the_symbol.disrupt = false;
             the_symbol.statement = true;
             token_now.arity = "statement";
-            the_statement = the_symbol.fud();
+            the_statement = the_symbol.fud_stmt();
             functionage.statement_prv = the_statement;
         } else {
 
@@ -4801,7 +4847,7 @@ function jslint_phase3_parse(state) {
 // Create one of the postassign operators.
 
         const the_symbol = symbol(id, 150);
-        the_symbol.led = function (left) {
+        the_symbol.led_infix = function (left) {
             token_now.expression = left;
             token_now.arity = "postassign";
             check_mutation(token_now.expression);
@@ -4815,7 +4861,7 @@ function jslint_phase3_parse(state) {
 // Create one of the preassign operators.
 
         const the_symbol = symbol(id);
-        the_symbol.nud = function () {
+        the_symbol.nud_prefix = function () {
             const the_token = token_now;
             the_token.arity = "preassign";
             the_token.expression = parse_expression(150);
@@ -4830,7 +4876,7 @@ function jslint_phase3_parse(state) {
 // Create a prefix operator.
 
         const the_symbol = symbol(id);
-        the_symbol.nud = function () {
+        the_symbol.nud_prefix = function () {
             const the_token = token_now;
             the_token.arity = "unary";
             if (typeof f === "function") {
@@ -5613,12 +5659,12 @@ function jslint_phase3_parse(state) {
         anon = "anonymous";
     }
 
-    function stmt(id, fud) {
+    function stmt(id, fud_stmt) {
 
 // Create a statement.
 
         const the_symbol = symbol(id);
-        the_symbol.fud = fud;
+        the_symbol.fud_stmt = fud_stmt;
         return the_symbol;
     }
 
@@ -6747,7 +6793,7 @@ function jslint_phase3_parse(state) {
 // Create a ternary operator.
 
         const the_symbol = symbol(id1, 30);
-        the_symbol.led = function parse_ternary_led(left) {
+        the_symbol.led_infix = function parse_ternary_led(left) {
             const the_token = token_now;
             let second;
             second = parse_expression(20);

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -2606,7 +2606,7 @@ function sentinel() {}
     coverageDir + "v8_coverage_merged.json",
     JSON.stringify(v8CoverageObj, undefined, 1)
   );
-  fileDict = {};
+  fileDict = Object.create(null);
   await Promise.all(v8CoverageObj.result.map(async function ({
     functions,
     url: pathname

--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
         "test2": "sh jslint_ci.sh shCiBase"
     },
     "type": "module",
-    "version": "2021.12.20"
+    "version": "2022.2.1-beta"
 }

--- a/test.mjs
+++ b/test.mjs
@@ -578,60 +578,71 @@ try {
     }).warnings.length === 1);
 }());
 
-(async function testcaseJslintWarningsValidate() {
-/*
- * this function will validate each jslint <warning> is raised with given
- * malformed <code>
- */
-    String(
-        await moduleFs.promises.readFile("jslint.mjs", "utf8")
-    ).replace((
-        /(\n\s*?\/\/\s*?test_cause:\s*?)(\S[\S\s]*?\S)(\n\n\s*?) *?\S/g
-    ), function (match0, header, causeList, footer) {
-        let tmp;
-        // console.error(match0);
-        // Validate header.
-        assertOrThrow(header === "\n\n// test_cause:\n", match0);
-        // Validate footer.
-        assertOrThrow(footer === "\n\n", match0);
-        // Validate causeList.
-        causeList = causeList.replace((
-            /^\/\/ /gm
-        ), "").replace((
-            /^\["\n([\S\s]*?)\n"(,.*?)$/gm
-        ), function (ignore, source, param) {
-            source = "[" + JSON.stringify(source) + param;
-            assertOrThrow(source.length > (80 - 3), source);
-            return source;
-        }).replace((
-            / \/\/jslint-quiet$/gm
-        ), "");
-        tmp = causeList.split("\n").map(function (cause) {
-            return (
-                "["
-                + JSON.parse(cause).map(function (elem) {
-                    return JSON.stringify(elem);
-                }).join(", ")
-                + "]"
-            );
-        }).sort().join("\n");
-        assertOrThrow(causeList === tmp, "\n" + causeList + "\n\n" + tmp);
-        causeList.split("\n").forEach(function (cause) {
-            cause = JSON.parse(cause);
-            tmp = jslint.jslint(cause[0], {
-                beta: true,
-                test_cause: true
-            }).causes;
-            // Validate cause.
-            assertOrThrow(
-                tmp[JSON.stringify(cause.slice(1))],
-                (
-                    "\n" + JSON.stringify(cause) + "\n\n"
-                    + Object.keys(tmp).sort().join("\n")
-                )
-            );
+(function testcaseJslintWarningsValidate() {
+
+// this function will validate each jslint <warning> is raised with given
+// malformed <code>
+
+    jstestDescribe((
+        "test jslint's handling-behavior"
+    ), function () {
+        jstestIt((
+            "test jslint's warning handling-behavior"
+        ), async function () {
+            String(
+                await moduleFs.promises.readFile("jslint.mjs", "utf8")
+            ).replace((
+                /(\n\s*?\/\/\s*?test_cause:\s*?)(\S[\S\s]*?\S)(\n\n\s*?) *?\S/g
+            ), function (match0, header, causeList, footer) {
+                let tmp;
+                // console.error(match0);
+                // Validate header.
+                assertOrThrow(header === "\n\n// test_cause:\n", match0);
+                // Validate footer.
+                assertOrThrow(footer === "\n\n", match0);
+                // Validate causeList.
+                causeList = causeList.replace((
+                    /^\/\/ /gm
+                ), "").replace((
+                    /^\["\n([\S\s]*?)\n"(,.*?)$/gm
+                ), function (ignore, source, param) {
+                    source = "[" + JSON.stringify(source) + param;
+                    assertOrThrow(source.length > (80 - 3), source);
+                    return source;
+                }).replace((
+                    / \/\/jslint-quiet$/gm
+                ), "");
+                tmp = causeList.split("\n").map(function (cause) {
+                    return (
+                        "["
+                        + JSON.parse(cause).map(function (elem) {
+                            return JSON.stringify(elem);
+                        }).join(", ")
+                        + "]"
+                    );
+                }).sort().join("\n");
+                assertOrThrow(
+                    causeList === tmp,
+                    "\n" + causeList + "\n\n" + tmp
+                );
+                causeList.split("\n").forEach(function (cause) {
+                    cause = JSON.parse(cause);
+                    tmp = jslint.jslint(cause[0], {
+                        beta: true,
+                        test_cause: true
+                    }).causes;
+                    // Validate cause.
+                    assertOrThrow(
+                        tmp[JSON.stringify(cause.slice(1))],
+                        (
+                            "\n" + JSON.stringify(cause) + "\n\n"
+                            + Object.keys(tmp).sort().join("\n")
+                        )
+                    );
+                });
+                return "";
+            });
         });
-        return "";
     });
 }());
 


### PR DESCRIPTION
- bugfix - fix issue #379 - cryptic-warning against using "delete" keyword in fat-arrow.
- update commonjs-wrapper jslint.cjs to load jslint in strict-mode.

online-demo of this pr available @ https://kaizhu256.github.io/jslint/branch-alpha/index.html

![image](https://user-images.githubusercontent.com/280571/152707813-2b9ff185-d687-4433-8c97-1b1740029489.png)
