### PR TITLE
- bugfix - fix warnings against destructured fart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - perf - improve performance by hoisting inlined regexps out of loops and subfunctions
 
 # v2022.2.1-beta
+- bugfix - fix issue #382 - fix warnings against destructured fart
 - bugfix - fix issue #379 - warn against naked-statement in fart.
 - update commonjs-wrapper jslint.cjs to load jslint in strict-mode.
 

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -3444,7 +3444,7 @@ import moduleHttps from "https";
             the_token.dot = true;
         }
 
-// PR-xxx - Bugfix - Fixes issue #382 - failure to detect destructured fart.
+// PR-385 - Bugfix - Fixes issue #382 - failure to detect destructured fart.
 // Farts are now detected by keeping a list of most recent "(" tokens at any
 // given depth. When a "=>" token is encountered, the most recent "(" token at
 // current depth is marked as a fart.
@@ -4537,7 +4537,7 @@ function jslint_phase3_parse(state) {
                 enroll(name, "parameter", true);
             } else {
 
-// PR-xxx - Bugfix - Fixes issue #382 - fix warnings against destructured fart.
+// PR-385 - Bugfix - Fixes issue #382 - fix warnings against destructured fart.
 
 // test_cause:
 // ["([aa])=>0", "enroll_parameter", "expected_a_before_b", "(", 1]
@@ -5552,7 +5552,7 @@ function jslint_phase3_parse(state) {
         let the_paren = token_now;
         let the_value;
 
-// PR-xxx - Bugfix - Fixes issue #382 - failure to detect destructured fart.
+// PR-385 - Bugfix - Fixes issue #382 - failure to detect destructured fart.
 
         if (token_now.is_fart) {
             the_paren.free = false;

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -95,6 +95,7 @@
 
 /*property
     fud_stmt,
+    is_fart,
     mode_conditional,
     JSLINT_BETA, NODE_V8_COVERAGE, a, all, argv, arity, artifact,
     assertErrorThrownAsync, assertJsonEqual, assertOrThrow, assign, async, b,
@@ -1832,6 +1833,9 @@ function jslint_phase2_lex(state) {
                                 // ... literal.
     let mode_regexp;            // true if regular expression literal seen on
                                 // ... this line.
+    let paren_backtrack_list = [];      // List of most recent "(" tokens at any
+                                        // ... paren-depth.
+    let paren_depth = 0;                // Keeps track of current paren-depth.
     let rx_token = new RegExp(
         "^("
         + "(\\s+)"
@@ -3393,9 +3397,11 @@ import moduleHttps from "https";
             from,
             id,
             identifier: Boolean(identifier),
+            is_fart: false,
             line,
             nr: token_list.length,
-            thru: column
+            thru: column,
+            value
         };
         token_list.push(the_token);
 
@@ -3403,12 +3409,6 @@ import moduleHttps from "https";
 
         if (id !== "(comment)" && id !== ";") {
             mode_directive = false;
-        }
-
-// If the token is to have a value, give it one.
-
-        if (value !== undefined) {
-            the_token.value = value;
         }
 
 // If this token is an identifier that touches a preceding number, or
@@ -3442,6 +3442,29 @@ import moduleHttps from "https";
         }
         if (token_prv_expr.id === "." && the_token.identifier) {
             the_token.dot = true;
+        }
+
+// PR-xxx - Bugfix - Fixes issue #382 - failure to detect destructured fart.
+// Farts are now detected by keeping a list of most recent "(" tokens at any
+// given depth. When a "=>" token is encountered, the most recent "(" token at
+// current depth is marked as a fart.
+
+        switch (id) {
+        case "(":
+            paren_backtrack_list[paren_depth] = the_token;
+            paren_depth += 1;
+            break;
+        case ")":
+            paren_depth -= 1;
+            break;
+        case "=>":
+            if (
+                token_prv_expr.id === ")"
+                && paren_backtrack_list[paren_depth]
+            ) {
+                paren_backtrack_list[paren_depth].is_fart = true;
+            }
+            break;
         }
 
 // The previous token is used to detect adjacency problems.
@@ -3559,7 +3582,7 @@ function jslint_phase3_parse(state) {
                 match === undefined
 
 // test_cause:
-// ["()", "advance", "expected_a_b", "(end)", 1]
+// ["{0:0}", "advance", "expected_a_b", "0", 2]
 
                 ? stop("expected_a_b", token_nxt, id, artifact())
 
@@ -4354,21 +4377,6 @@ function jslint_phase3_parse(state) {
         return the_symbol;
     }
 
-    function lookahead() {
-
-// Look ahead one token without advancing, skipping comments.
-
-        let cadet;
-        let ii = token_ii;
-        while (true) {
-            cadet = token_list[ii];
-            if (cadet.id !== "(comment)") {
-                return cadet;
-            }
-            ii += 1;
-        }
-    }
-
     function parse_expression(rbp, initial) {
 
 // This is the heart of JSLINT, the Pratt parser. In addition to parsing, it
@@ -4486,8 +4494,12 @@ function jslint_phase3_parse(state) {
         return left;
     }
 
-    function parse_fart(pl) {
+    function parse_fart() {
+        let parameters;
+        let signature;
         let the_fart;
+        let the_paren = token_now;
+        [parameters, signature] = prefix_function_arg();
         advance("=>");
         the_fart = token_now;
         the_fart.arity = "binary";
@@ -4511,6 +4523,8 @@ function jslint_phase3_parse(state) {
         the_fart.context = empty();
         the_fart.finally = 0;
         the_fart.loop = 0;
+        the_fart.parameters = parameters;
+        the_fart.signature = signature;
         the_fart.switch = 0;
         the_fart.try = 0;
 
@@ -4518,15 +4532,29 @@ function jslint_phase3_parse(state) {
 
         function_stack.push(functionage);
         functionage = the_fart;
-        the_fart.parameters = pl[0];
-        the_fart.signature = pl[1];
-        the_fart.parameters.forEach(function (name) {
+        the_fart.parameters.forEach(function enroll_parameter(name) {
+            if (name.identifier) {
+                enroll(name, "parameter", true);
+            } else {
+
+// PR-xxx - Bugfix - Fixes issue #382 - fix warnings against destructured fart.
 
 // test_cause:
-// ["(aa)=>{}", "parse_fart", "parameter", "", 0]
+// ["([aa])=>0", "enroll_parameter", "expected_a_before_b", "(", 1]
+// ["({aa})=>0", "enroll_parameter", "expected_a_before_b", "(", 1]
 
-            test_cause("parameter");
-            enroll(name, "parameter", true);
+                warn("expected_a_before_b", the_paren, "function", "(");
+
+// test_cause:
+// ["([aa])=>0", "enroll_parameter", "expected_a_b", "=>", 7]
+// ["({aa})=>0", "enroll_parameter", "expected_a_b", "=>", 7]
+
+                warn("expected_a_b", the_fart, "{", "=>");
+
+// Recurse enroll_parameter().
+
+                name.names.forEach(enroll_parameter);
+            }
         });
         if (token_nxt.id === "{") {
 
@@ -5058,6 +5086,9 @@ function jslint_phase3_parse(state) {
             if (name.identifier) {
                 enroll(name, "parameter", false);
             } else {
+
+// Recurse enroll_parameter().
+
                 name.names.forEach(enroll_parameter);
             }
         });
@@ -5518,25 +5549,14 @@ function jslint_phase3_parse(state) {
     }
 
     function prefix_lparen() {
-        const cadet = lookahead().id;
-        const the_paren = token_now;
+        let the_paren = token_now;
         let the_value;
 
-// We can distinguish between a parameter list for => and a wrapped expression
-// with one token of lookahead.
+// PR-xxx - Bugfix - Fixes issue #382 - failure to detect destructured fart.
 
-        if (
-            token_nxt.id === ")"
-            || token_nxt.id === "..."
-            || (token_nxt.identifier && (cadet === "," || cadet === "="))
-        ) {
-
-// test_cause:
-// ["()=>0", "prefix_lparen", "fart", "", 0]
-
-            test_cause("fart");
+        if (token_now.is_fart) {
             the_paren.free = false;
-            return parse_fart(prefix_function_arg());
+            return parse_fart();
         }
 
 // test_cause:
@@ -5554,31 +5574,6 @@ function jslint_phase3_parse(state) {
         }
         the_value.wrapped = true;
         advance(")", the_paren);
-        if (token_nxt.id === "=>") {
-            if (the_value.arity !== "variable") {
-                if (the_value.id === "{" || the_value.id === "[") {
-
-// test_cause:
-// ["([])=>0", "prefix_lparen", "expected_a_before_b", "(", 1]
-// ["({})=>0", "prefix_lparen", "expected_a_before_b", "(", 1]
-
-                    warn("expected_a_before_b", the_paren, "function", "(");
-
-// test_cause:
-// ["([])=>0", "prefix_lparen", "expected_a_b", "=>", 5]
-// ["({})=>0", "prefix_lparen", "expected_a_b", "=>", 5]
-
-                    return stop("expected_a_b", token_nxt, "{", "=>");
-                }
-
-// test_cause:
-// ["(0)=>0", "prefix_lparen", "expected_identifier_a", "0", 2]
-
-                return stop("expected_identifier_a", the_value);
-            }
-            the_paren.expression = [the_value];
-            return parse_fart([the_paren.expression, "(" + the_value.id + ")"]);
-        }
         return the_value;
     }
 

--- a/test.mjs
+++ b/test.mjs
@@ -234,217 +234,231 @@ try {
 
 // This function will validate each code is valid in jslint.
 
-    Object.values({
-        array: [
-            "new Array(0);"
-        ],
-        async_await: [
-            "async function aa() {\n    await aa();\n}",
-            (
-                "async function aa() {\n"
-                + "    try {\n"
-                + "        aa();\n"
-                + "    } catch (err) {\n"
-                + "        await err();\n"
-                + "    }\n"
-                + "}\n"
-            ), (
-                "async function aa() {\n"
-                + "    try {\n"
-                + "        await aa();\n"
-                + "    } catch (err) {\n"
-                + "        await err();\n"
-                + "    }\n"
-                + "}\n"
-            ),
+    jstestDescribe((
+        "test jslint's handling-behavior"
+    ), function () {
+        jstestIt((
+            "test jslint's code-validate handling-behavior"
+        ), function () {
+            Object.values({
+                array: [
+                    "new Array(0);"
+                ],
+                async_await: [
+                    "async function aa() {\n    await aa();\n}",
+                    (
+                        "async function aa() {\n"
+                        + "    try {\n"
+                        + "        aa();\n"
+                        + "    } catch (err) {\n"
+                        + "        await err();\n"
+                        + "    }\n"
+                        + "}\n"
+                    ),
+                    (
+                        "async function aa() {\n"
+                        + "    try {\n"
+                        + "        await aa();\n"
+                        + "    } catch (err) {\n"
+                        + "        await err();\n"
+                        + "    }\n"
+                        + "}\n"
+                    ),
 
 // PR-370 - Add top-level-await support.
 
-            "await String();\n"
-        ],
+                    "await String();\n"
+                ],
 
 // PR-351 - Add BigInt support.
 
-        bigint: [
-            "let aa = 0b0n;\n",
-            "let aa = 0o0n;\n",
-            "let aa = 0x0n;\n",
-            "let aa = BigInt(0n);\n",
-            "let aa = typeof aa === \"bigint\";\n"
-        ],
-        date: [
-            "Date.getTime();",
-            "let aa = aa().getTime();",
-            "let aa = aa.aa().getTime();"
-        ],
-        directive: [
-            "#!\n/*jslint browser:false, node*/\n\"use strict\";",
-            "/*property aa bb*/"
-        ],
-        fart: [
-            "function aa() {\n    return () => 0;\n}"
-        ],
-        for: [
-            (
-                "/*jslint for*/\n"
-                + "function aa(bb) {\n"
-                + "    for (bb = 0; bb < 0; bb += 1) {\n"
-                + "        bb();\n"
-                + "    }\n"
-                + "}\n"
-            )
-        ],
-        jslint_disable: [
-            "/*jslint-disable*/\n0\n/*jslint-enable*/"
-        ],
-        jslint_quiet: [
-            "0 //jslint-quiet"
-        ],
-        json: [
-            "{\"aa\":[[],-0,null]}"
-        ],
-        label: [
-            (
-                "function aa() {\n"
-                + "bb:\n"
-                + "    while (true) {\n"
-                + "        if (true) {\n"
-                + "            break bb;\n"
-                + "        }\n"
-                + "    }\n"
-                + "}\n"
-            )
-        ],
-        loop: [
-            (
-                "function aa() {\n"
-                + "    do {\n"
-                + "        aa();\n"
-                + "    } while (aa());\n"
-                + "}\n"
-            ),
+                bigint: [
+                    "let aa = 0b0n;\n",
+                    "let aa = 0o0n;\n",
+                    "let aa = 0x0n;\n",
+                    "let aa = BigInt(0n);\n",
+                    "let aa = typeof aa === \"bigint\";\n"
+                ],
+                date: [
+                    "Date.getTime();",
+                    "let aa = aa().getTime();",
+                    "let aa = aa.aa().getTime();"
+                ],
+                directive: [
+                    "#!\n/*jslint browser:false, node*/\n\"use strict\";",
+                    "/*property aa bb*/"
+                ],
+                fart: [
+                    "function aa() {\n    return () => 0;\n}"
+                ],
+                for: [
+                    (
+                        "/*jslint for*/\n"
+                        + "function aa(bb) {\n"
+                        + "    for (bb = 0; bb < 0; bb += 1) {\n"
+                        + "        bb();\n"
+                        + "    }\n"
+                        + "}\n"
+                    )
+                ],
+                jslint_disable: [
+                    "/*jslint-disable*/\n0\n/*jslint-enable*/"
+                ],
+                jslint_quiet: [
+                    "0 //jslint-quiet"
+                ],
+                json: [
+                    "{\"aa\":[[],-0,null]}"
+                ],
+                label: [
+                    (
+                        "function aa() {\n"
+                        + "bb:\n"
+                        + "    while (true) {\n"
+                        + "        if (true) {\n"
+                        + "            break bb;\n"
+                        + "        }\n"
+                        + "    }\n"
+                        + "}\n"
+                    )
+                ],
+                loop: [
+                    (
+                        "function aa() {\n"
+                        + "    do {\n"
+                        + "        aa();\n"
+                        + "    } while (aa());\n"
+                        + "}\n"
+                    ),
 
 // PR-378 - Relax warning "function_in_loop".
 
-            (
-                "function aa() {\n"
-                + "    while (true) {\n"
-                + "        (function () {\n"
-                + "            return;\n"
-                + "        }());\n"
-                + "    }\n"
-                + "}\n"
-            )
-        ],
-        module: [
-            "export default Object.freeze();",
-            "import {aa, bb} from \"aa\";\naa(bb);",
-            "import {} from \"aa\";",
-            "import(\"aa\").then(function () {\n    return;\n});",
-            "let aa = 0;\nimport(aa).then(aa).then(aa).catch(aa).finally(aa);"
-        ],
-        number: [
-            "let aa = 0.0e0;",
-            "let aa = 0b0;",
-            "let aa = 0o0;",
-            "let aa = 0x0;"
-        ],
-        optional_chaining: [
-            "let aa = aa?.bb?.cc;"
-        ],
-        param: [
-            (
-                "function aa({aa, bb}) {\n"
-                + "    return {aa, bb};\n"
-                + "}\n"
-            ), (
-                "function aa({constructor}) {\n"
-                + "    return {constructor};\n"
-                + "}\n"
-            )
-        ],
-        property: [
-            "let aa = aa[`!`];"
-        ],
-        regexp: [
-            "function aa() {\n    return /./;\n}",
-            "let aa = /(?!.)(?:.)(?=.)/;",
-            "let aa = /./gimuy;",
-            "let aa = /[\\--\\-]/;"
-        ],
-        ternary: [
-            (
-                "let aa = (\n    aa()\n    ? 0\n    : 1\n) "
-                + "&& (\n    aa()\n    ? 0\n    : 1\n);"
-            ),
-            "let aa = (\n    aa()\n    ? `${0}`\n    : `${1}`\n);"
-        ],
-        try_catch: [
-            (
-                "let aa = 0;\n"
-                + "try {\n"
-                + "    aa();\n"
-                + "} catch (err) {\n"
-                + "    aa = err;\n"
-                + "}\n"
-                + "try {\n"
-                + "    aa();\n"
-                + "} catch (err) {\n"
-                + "    aa = err;\n"
-                + "}\n"
-                + "aa();\n"
-            )
-        ],
-        use_strict: [
-            (
-                "\"use strict\";\n"
-                + "let aa = 0;\n"
-                + "function bb() {\n"
-                + "    \"use strict\";\n"
-                + "    return aa;\n"
-                + "}\n"
-            )
-        ],
-        var: [
+                    (
+                        "function aa() {\n"
+                        + "    while (true) {\n"
+                        + "        (function () {\n"
+                        + "            return;\n"
+                        + "        }());\n"
+                        + "    }\n"
+                        + "}\n"
+                    )
+                ],
+                module: [
+                    "export default Object.freeze();",
+                    "import {aa, bb} from \"aa\";\naa(bb);",
+                    "import {} from \"aa\";",
+                    "import(\"aa\").then(function () {\n    return;\n});",
+                    (
+                        "let aa = 0;\n"
+                        + "import(aa).then(aa).then(aa)"
+                        + ".catch(aa).finally(aa);\n"
+                    )
+                ],
+                number: [
+                    "let aa = 0.0e0;",
+                    "let aa = 0b0;",
+                    "let aa = 0o0;",
+                    "let aa = 0x0;"
+                ],
+                optional_chaining: [
+                    "let aa = aa?.bb?.cc;"
+                ],
+                param: [
+                    (
+                        "function aa({aa, bb}) {\n"
+                        + "    return {aa, bb};\n"
+                        + "}\n"
+                    ),
+                    (
+                        "function aa({constructor}) {\n"
+                        + "    return {constructor};\n"
+                        + "}\n"
+                    )
+                ],
+                property: [
+                    "let aa = aa[`!`];"
+                ],
+                regexp: [
+                    "function aa() {\n    return /./;\n}",
+                    "let aa = /(?!.)(?:.)(?=.)/;",
+                    "let aa = /./gimuy;",
+                    "let aa = /[\\--\\-]/;"
+                ],
+                ternary: [
+                    (
+                        "let aa = (\n    aa()\n    ? 0\n    : 1\n) "
+                        + "&& (\n    aa()\n    ? 0\n    : 1\n);"
+                    ),
+                    "let aa = (\n    aa()\n    ? `${0}`\n    : `${1}`\n);"
+                ],
+                try_catch: [
+                    (
+                        "let aa = 0;\n"
+                        + "try {\n"
+                        + "    aa();\n"
+                        + "} catch (err) {\n"
+                        + "    aa = err;\n"
+                        + "}\n"
+                        + "try {\n"
+                        + "    aa();\n"
+                        + "} catch (err) {\n"
+                        + "    aa = err;\n"
+                        + "}\n"
+                        + "aa();\n"
+                    )
+                ],
+                use_strict: [
+                    (
+                        "\"use strict\";\n"
+                        + "let aa = 0;\n"
+                        + "function bb() {\n"
+                        + "    \"use strict\";\n"
+                        + "    return aa;\n"
+                        + "}\n"
+                    )
+                ],
+                var: [
 
 // PR-363 - Bugfix - add test against false-warning
 // <uninitialized 'bb'> in code '/*jslint node*/\nlet {aa:bb} = {}; bb();'
 
-            "/*jslint node*/\n",
-            ""
-        ].map(function (directive) {
-            return [
-                "let [\n    aa, bb = 0\n] = 0;\naa();\nbb();",
-                "let [...aa] = [...aa];\naa();",
-                "let constructor = 0;\nconstructor();",
-                "let {\n    aa: bb\n} = 0;\nbb();",
-                "let {\n    aa: bb,\n    bb: cc\n} = 0;\nbb();\ncc();",
-                "let {aa, bb} = 0;\naa();\nbb();",
-                "let {constructor} = 0;\nconstructor();"
-            ].map(function (code) {
-                return directive + code;
-            });
-        }).flat()
-    }).forEach(function (codeList) {
-        let elemPrv = "";
-        codeList.forEach(function (code) {
-            let warnings;
-            // Assert codeList is sorted.
-            assertOrThrow(elemPrv < code, JSON.stringify([
-                elemPrv, code
-            ], undefined, 4));
-            elemPrv = code;
-            [
-                jslint.jslint,
-                jslintCjs.jslint
-            ].forEach(function (jslint) {
-                warnings = jslint.jslint(code, {
-                    beta: true
-                }).warnings;
-                assertOrThrow(
-                    warnings.length === 0,
-                    JSON.stringify([code, warnings])
-                );
+                    "/*jslint node*/\n",
+                    ""
+                ].map(function (directive) {
+                    return [
+                        "let [\n    aa, bb = 0\n] = 0;\naa();\nbb();",
+                        "let [...aa] = [...aa];\naa();",
+                        "let constructor = 0;\nconstructor();",
+                        "let {\n    aa: bb\n} = 0;\nbb();",
+                        "let {\n    aa: bb,\n    bb: cc\n} = 0;\nbb();\ncc();",
+                        "let {aa, bb} = 0;\naa();\nbb();",
+                        "let {constructor} = 0;\nconstructor();"
+                    ].map(function (code) {
+                        return directive + code;
+                    });
+                }).flat()
+            }).forEach(function (codeList) {
+                let elemPrv = "";
+                codeList.forEach(function (code) {
+                    let warnings;
+                    // Assert codeList is sorted.
+                    assertOrThrow(elemPrv < code, JSON.stringify([
+                        elemPrv, code
+                    ], undefined, 4));
+                    elemPrv = code;
+                    [
+                        jslint.jslint,
+                        jslintCjs.jslint
+                    ].forEach(function (jslint) {
+                        warnings = jslint.jslint(code, {
+                            beta: true
+                        }).warnings;
+                        assertOrThrow(
+                            warnings.length === 0,
+                            JSON.stringify([code, warnings])
+                        );
+                    });
+                });
             });
         });
     });


### PR DESCRIPTION
this pr fixes issue #382.

the issue is an edge-case where jslint fails to properly detect destructured fat-arrows and warn against them.

Fat-arrows are now detected by keeping a list of most recent "(" tokens at any
given depth. When a "=>" token is encountered, the most recent "(" token at
current depth is marked as a fat-arrow.
