### PR TITLE
# v2022.3.30

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-    name: |
+    name: >
       job1
       node
       v${{ matrix.node_version }}
@@ -60,11 +60,11 @@ jobs:
       # https://github.com/actions/cache
       - uses: actions/cache@v2
         with:
-          key: |
+          key: >
+            ${{ hashFiles('./package.json') }}
             ${{ matrix.architecture }}
             ${{ matrix.node_version }}
             ${{ matrix.os }}
-            ${{ hashFiles('./package.json') }}
           path: .github_cache
       # https://github.com/actions/setup-node
       - uses: actions/setup-node@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 - perf - improve performance by hoisting inlined regexps out of loops and subfunctions
 
-# v2022.3.1-beta
+# v2022.3.30
 - website - use localStorage to persist jslint-options selected in ui
 - website - add optional debug-mode to use sessionStorage to persist jslint-globals and jslint-source from ui
 - jslint - add numeric-separator support

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Status
-| Branch | [master<br>(v2022.2.20)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
+| Branch | [master<br>(v2022.3.30)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
 |--:|:--:|:--:|:--:|
 | CI | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jslint-org/jslint/actions?query=branch%3Amaster) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/jslint-org/jslint/actions?query=branch%3Abeta) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/jslint-org/jslint/actions?query=branch%3Aalpha) |
 | Coverage | [![coverage](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/index.html) |

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -167,7 +167,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2022.3.1-beta";
+let jslint_edition = "v2022.3.30";
 let jslint_export;                      // The jslint object to be exported.
 let jslint_fudge = 1;                   // Fudge starting line and starting
                                         // ... column to 1.

--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
         "test2": "sh jslint_ci.sh shCiBase"
     },
     "type": "module",
-    "version": "2022.3.1-beta"
+    "version": "2022.3.30"
 }

--- a/test.mjs
+++ b/test.mjs
@@ -213,23 +213,6 @@ jstestDescribe((
         });
     });
     jstestIt((
-        "test cli-report-misc handling-behavior"
-    ), function () {
-        jslint.jslint_cli({
-            // suppress error
-            console_error: noop,
-            mode_cli: true,
-            process_argv: [
-                "node",
-                "jslint.mjs",
-                "jslint_report=.tmp/jslint_report.html",
-                "aa.js"
-            ],
-            process_exit: processExit1,
-            source: "(aa)=>aa; function aa([aa]){}"
-        });
-    });
-    jstestIt((
         "test cli-report-json-error handling-behavior"
     ), function () {
         jslint.jslint_cli({
@@ -244,6 +227,36 @@ jstestDescribe((
             ],
             process_exit: processExit1,
             source: "["
+        });
+    });
+    jstestIt((
+        "test cli-report-misc handling-behavior"
+    ), function () {
+        jslint.jslint_cli({
+            // suppress error
+            console_error: noop,
+            mode_cli: true,
+            process_argv: [
+                "node",
+                "jslint.mjs",
+                "jslint_report=.tmp/jslint_report.html",
+                "aa.js"
+            ],
+            process_exit: processExit0,
+            source: "let aa = 0;"
+        });
+        jslint.jslint_cli({
+            // suppress error
+            console_error: noop,
+            mode_cli: true,
+            process_argv: [
+                "node",
+                "jslint.mjs",
+                "jslint_report=.tmp/jslint_report.html",
+                "aa.js"
+            ],
+            process_exit: processExit1,
+            source: "(aa)=>aa; function aa([aa]){}"
         });
     });
     jstestIt((


### PR DESCRIPTION
- website - use localStorage to persist jslint-options selected in ui
- website - add optional debug-mode to use sessionStorage to persist jslint-globals and jslint-source from ui
- jslint - add numeric-separator support
- jslint - move regexp-literals to module-level so they are explicitly cached, to improve performance
- ci - add check for package.json.fileCount