### PR TITLE
- wrapper - add jslint-addon for codemirror

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -75,6 +75,10 @@ echo "\
             + "$&\n"
             + "git checkout 60a022c511a37788e652c271af23174566a80c30\n"
         ));
+        // modify script - curl jslint_wrapper_codemirror.js
+        script = script.replace((
+            /curl -Ls https:\/\/www.jslint.com\//g
+        ), "cat ");
         // printf script
         script = (
             "(set -e\n"

--- a/.ci.sh
+++ b/.ci.sh
@@ -114,11 +114,17 @@ echo "\
 ' "$@" # '
     # screenshot asset_image_logo
     shImageLogoCreate &
+    # background http-file-server to serve webpages for screenshot
+    PORT=8080 npm_config_timeout_exit=10000 shHttpFileServer &
     # screenshot html
     node --input-type=module --eval '
 import moduleChildProcess from "child_process";
 (async function () {
     await Promise.all([
+        (
+            "http://localhost:8080"
+            + "/.artifact/jslint_wrapper_codemirror.html"
+        ),
         (
             "https://"
             + process.env.UPSTREAM_OWNER
@@ -304,7 +310,7 @@ import moduleFs from "fs";
         }, {
             file: "README.md",
             src: (
-                /\n### to run jslint in vs code:\n[\S\s]*?\n\n\n/i
+                /\n# quickstart jslint in vscode\n[\S\s]*?\n\n\n/i
             ).exec(fileDict["README.md"])[0]
         }, {
             file: "package.json",
@@ -380,7 +386,7 @@ import moduleFs from "fs";
                     "type": "git",
                     "url": "https://github.com/jslint-org/jslint.git"
                 },
-                "version": "0.0.4"
+                "version": "2022.5.1"
             }, undefined, 4)
         }
     ].map(async function ({

--- a/.ci.sh
+++ b/.ci.sh
@@ -42,7 +42,13 @@ import moduleFs from "fs";
 import moduleFs from "fs";
 import moduleChildProcess from "child_process";
 (async function () {
+    let fileDict = {};
     let screenshotCurl;
+    await Promise.all([
+        "README.md"
+    ].map(async function (file) {
+        fileDict[file] = await moduleFs.promises.readFile(file, "utf8");
+    }));
     screenshotCurl = await moduleFs.promises.stat("jslint.mjs");
     screenshotCurl = String(`
 echo "\
@@ -54,11 +60,11 @@ echo "\
         /250/g
     ), Math.floor(screenshotCurl.size / 1024));
     // parallel-task - run-and-screenshot example-shell-commands in README.md
-    await Promise.all(Array.from(String(
-        await moduleFs.promises.readFile("README.md", "utf8")
-    ).matchAll(
-        /\n```shell <!-- shRunWithScreenshotTxt (.*?) -->\n([\S\s]*?\n)```\n/g
-    )).map(async function ([
+    await Promise.all(Array.from(
+        fileDict["README.md"].matchAll(
+            /\n```shell <!-- shRunWithScreenshotTxt (.*?) -->\n([\S\s]*?\n)```\n/g
+        )
+    ).map(async function ([
         ignore, file, script0
     ]) {
         let script = script0;
@@ -119,16 +125,13 @@ echo "\
     # screenshot asset_image_logo
     shImageLogoCreate &
     # background http-file-server to serve webpages for screenshot
-    PORT=8080 npm_config_timeout_exit=10000 shHttpFileServer &
+    PORT=8080 npm_config_timeout_exit=5000 shHttpFileServer &
     # screenshot html
     node --input-type=module --eval '
 import moduleChildProcess from "child_process";
 (async function () {
     await Promise.all([
-        (
-            "http://localhost:8080"
-            + "/.artifact/jslint_wrapper_codemirror.html"
-        ),
+        "http://localhost:8080/jslint_wrapper_codemirror.html",
         (
             "https://"
             + process.env.UPSTREAM_OWNER
@@ -187,9 +190,11 @@ import moduleFs from "fs";
     let versionMaster;
     await Promise.all([
         "CHANGELOG.md",
+        "README.md",
         "index.html",
         "jslint.mjs",
-        "jslint_ci.sh"
+        "jslint_ci.sh",
+        "jslint_wrapper_codemirror.html"
     ].map(async function (file) {
         fileDict[file] = await moduleFs.promises.readFile(file, "utf8");
     }));
@@ -203,6 +208,15 @@ import moduleFs from "fs";
     });
     await Promise.all([
         {
+            file: "README.md",
+            src: fileDict["README.md"].replace((
+                /\n```html <!-- jslint_wrapper_codemirror.html -->\n[\S\s]*?\n```\n/
+            ), (
+                "\n```html <!-- jslint_wrapper_codemirror.html -->\n"
+                + fileDict["jslint_wrapper_codemirror.html"]
+                + "```\n"
+            ))
+        }, {
             file: "index.html",
             src: fileDict["index.html"].replace((
                 /\n<style class="JSLINT_REPORT_STYLE">\n[\S\s]*?\n<\/style>\n/

--- a/.ci.sh
+++ b/.ci.sh
@@ -81,10 +81,6 @@ echo "\
             + "$&\n"
             + "git checkout 60a022c511a37788e652c271af23174566a80c30\n"
         ));
-        // modify script - curl jslint_wrapper_codemirror.js
-        script = script.replace((
-            /curl -Ls https:\/\/www.jslint.com\//g
-        ), "cat ");
         // printf script
         script = (
             "(set -e\n"

--- a/.ci.sh
+++ b/.ci.sh
@@ -125,19 +125,23 @@ echo "\
     # screenshot asset_image_logo
     shImageLogoCreate &
     # background http-file-server to serve webpages for screenshot
-    PORT=8080 npm_config_timeout_exit=5000 shHttpFileServer &
+    # PORT=8080 npm_config_timeout_exit=5000 shHttpFileServer &
     # screenshot html
     node --input-type=module --eval '
 import moduleChildProcess from "child_process";
 (async function () {
+    let {
+        GITHUB_BRANCH0,
+        GITHUB_GITHUB_IO
+    } = process.env;
     await Promise.all([
-        "http://localhost:8080/jslint_wrapper_codemirror.html",
         (
-            "https://"
-            + process.env.UPSTREAM_OWNER
-            + ".github.io/"
-            + process.env.UPSTREAM_REPO
-            + "/branch-beta/index.html"
+            `https://${GITHUB_GITHUB_IO}/branch-${GITHUB_BRANCH0}`
+            + `/jslint_wrapper_codemirror.html`
+        ),
+        (
+            `https://${GITHUB_GITHUB_IO}/branch-${GITHUB_BRANCH0}`
+            + `/index.html`
         ),
         ".artifact/apidoc.html",
         ".artifact/coverage_sqlite3_js/index.html",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - perf - improve performance by hoisting inlined regexps out of loops and subfunctions
 
 # v2022.5.1-beta
+- update codemirror-editor to v5.65.3
 - wrapper - add jslint-addon for codemirror
 - allow jslint.mjs to auto-export itself to globalThis when given search-param `?window_jslint=1`
 - wrapper - add jslint-extension for vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@
 - perf - improve performance by hoisting inlined regexps out of loops and subfunctions
 
 # v2022.5.1-beta
-- vscode - add jslint-extension for vscode
+- wrapper - add jslint-addon for codemirror
+- allow jslint.mjs to auto-export itself to globalThis when given search-param `?jslint_export_global=1`
+- wrapper - add jslint-extension for vscode
 - bugfix - fix jslint falsely believing megastring literals `0` and `1` are similar
 - bugfix - fix function jstestOnExit() from exiting prematurely and suppressing additional error-messages
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 # v2022.5.1-beta
 - wrapper - add jslint-addon for codemirror
-- allow jslint.mjs to auto-export itself to globalThis when given search-param `?jslint_export_global=1`
+- allow jslint.mjs to auto-export itself to globalThis when given search-param `?window_jslint=1`
 - wrapper - add jslint-extension for vscode
 - bugfix - fix jslint falsely believing megastring literals `0` and `1` are similar
 - bugfix - fix function jstestOnExit() from exiting prematurely and suppressing additional error-messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - perf - improve performance by hoisting inlined regexps out of loops and subfunctions
 
 # v2022.5.1-beta
+- add codemirror-example-file jslint_wrapper_codemirror.html
 - update codemirror-editor to v5.65.3
 - wrapper - add jslint-addon for codemirror
 - allow jslint.mjs to auto-export itself to globalThis when given search-param `?window_jslint=1`

--- a/README.md
+++ b/README.md
@@ -350,22 +350,21 @@ curl -Ls https://www.jslint.com/jslint_wrapper_codemirror.js \
 printf '
 <!DOCTYPE html>
 <head>
-    <link rel="stylesheet" href="https://codemirror.net/lib/codemirror.css">
-    <link rel="stylesheet" href="https://codemirror.net/addon/lint/lint.css">
-    <script defer src="https://codemirror.net/lib/codemirror.js"></script>
-    <script defer
-        src="https://codemirror.net/mode/javascript/javascript.js"></script>
-    <script defer src="https://codemirror.net/addon/lint/lint.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.3/codemirror.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.3/addon/lint/lint.css">
+    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.3/codemirror.js"></script>
+    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.3/mode/javascript/javascript.js"></script>
+    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.3/addon/lint/lint.js"></script>
     <script type="module" src="./jslint.mjs?window_jslint=1"></script>
     <script defer src="./jslint_wrapper_codemirror.js"></script>
 </head>
-<body style="background:#bbb; font-family:sans-serif; margin:0; padding:20px;">
+<body style="background: #bbb; font-family: sans-serif; margin: 20px;">
     <h1>CodeMirror: JSLint Demo</h1>
     <h3>
 This demo will auto-lint the code below, and auto-generate a report as you type.
     </h3>
     <textarea id="editor1">console.log(&apos;hello world&apos;);</textarea>
-    <div style="margin-top:20px;"><div id="JSLINT_REPORT_HTML"></div></div>
+    <div style="margin-top: 20px;"><div class="JSLINT_REPORT_HTML"></div></div>
 <script type=module>
 window.addEventListener("load", function () {
     let editor = window.CodeMirror.fromTextArea(document.getElementById(
@@ -374,23 +373,21 @@ window.addEventListener("load", function () {
         gutters: ["CodeMirror-lint-markers"],
         indentUnit: 4,
         lineNumbers: true,
-        lint: {lintOnChange: false},
+        lint: {lintOnChange: true, options: {}},
         mode: "javascript"
     });
-    function onChange() {
-        clearTimeout(editor.state.lint.timeout);
-        editor.state.lint.timeout = setTimeout(function () {
-            editor.performLint();
-            document.getElementById(
-                "JSLINT_REPORT_HTML"
-            ).outerHTML = window.jslint.jslint_report(window.jslint_result);
-        }, editor.state.lint.options.delay);
-    }
-    editor.on("change", onChange);
-    onChange();
+    editor.on("lintJslintAfter", function ({
+        result
+    }) {
+        document.querySelector(
+            ".JSLINT_REPORT_HTML"
+        ).innerHTML = window.jslint.jslint_report(result);
+    });
+    editor.performLint();
 });
 </script>
 </body>
+</html>
 ' > .artifact/jslint_wrapper_codemirror.html
 
 ```

--- a/README.md
+++ b/README.md
@@ -370,6 +370,8 @@ body {
 }
 </style>
 </head>
+
+
 <body>
     <h1>CodeMirror: JSLint Demo</h1>
     <h3>
@@ -383,11 +385,10 @@ This demo will auto-lint the code below, and auto-generate a report as you type.
 <!-- Container for jslint-report. -->
 
     <div class="JSLINT_ JSLINT_REPORT_"></div>
+
+
 <script type=module>
 window.addEventListener("load", function () {
-
-// Initialize codemirror-editor.
-
     let editor = window.CodeMirror.fromTextArea(document.getElementById(
         "editor1"
     ), {
@@ -397,19 +398,10 @@ window.addEventListener("load", function () {
         indentUnit: 4,
         lineNumbers: true,
         lint: {
-
-// Enable auto-lint.
-
-            lintOnChange: true,
-
-// Initialize jslint-options here.
-
+            lintOnChange: true, // Enable auto-lint.
             options: {
                 // browser: true,
                 // node: true
-
-// Initialize jslint-globals here.
-
                 globals: [
                     // "caches",
                     // "indexedDb"
@@ -422,14 +414,8 @@ window.addEventListener("load", function () {
 // Initialize event-handling before linter is run.
 
     editor.on("lintJslintBefore", function (/* options */) {
-
-// Modify jslint-options here.
-
         // options.browser = true;
         // options.node = true;
-
-// Modify jslint-globals here.
-
         // options.globals = [
         //     "caches",
         //     "indexedDb"
@@ -456,10 +442,9 @@ window.addEventListener("load", function () {
 </body>
 </html>
 ```
+3. Live example at https://www.jslint.com/jslint_wrapper_codemirror.html
 
-- screenshot
-
-[![screenshot](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_browser__2fjslint_wrapper_codemirror.html.png)](https://jslint-org.github.io/jslint/branch-beta/jslint_wrapper_codemirror.html)
+[![screenshot](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_browser__2fjslint_2fbranch-beta_2fjslint_wrapper_codemirror.html.png)](https://jslint-org.github.io/jslint/jslint_wrapper_codemirror.html)
 
 
 <br><br>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Douglas Crockford <douglas@crockford.com>
 3. [API Doc](#api-doc)
 
 4. [Quickstart Install](#quickstart-install)
-    - [To install, just download https://www.jslint.com/jslint.mjs and save to file:](#to-install-just-download-httpswwwjslintcomjslintmjs-and-save-to-file)
+    - [To install, just download and save https://www.jslint.com/jslint.mjs to file:](#to-install-just-download-and-save-httpswwwjslintcomjslintmjs-to-file)
     - [To run `jslint.mjs` in shell:](#to-run-jslintmjs-in-shell)
     - [To import `jslint.mjs` in ES Module environment:](#to-import-jslintmjs-in-es-module-environment)
     - [To import `jslint.mjs` in CommonJS environment:](#to-import-jslintmjs-in-commonjs-environment)
@@ -76,7 +76,7 @@ Douglas Crockford <douglas@crockford.com>
 
 
 <br><br>
-### To install, just download https://www.jslint.com/jslint.mjs and save to file:
+### To install, just download and save https://www.jslint.com/jslint.mjs to file:
 ```shell <!-- shRunWithScreenshotTxt .artifact/screenshot_sh_install_download.svg -->
 #!/bin/sh
 
@@ -223,18 +223,17 @@ node --input-type=module --eval '
 import jslint from "./jslint.mjs";
 import fs from "fs";
 (async function () {
-    let report;
     let result;
     let source = "function foo() {console.log(\u0027hello world\u0027);}\n";
 
 // Create JSLint report from <source> in javascript.
 
     result = jslint.jslint(source);
-    report = jslint.jslint_report(result);
-    report = `<body class="JSLINT_">\n${report}\n</body>\n`;
+    result = jslint.jslint_report(result);
+    result = `<body class="JSLINT_">\n${result}\n</body>\n`;
 
     await fs.promises.mkdir(".artifact/", {recursive: true});
-    await fs.promises.writeFile(".artifact/jslint_report_hello.html", report);
+    await fs.promises.writeFile(".artifact/jslint_report_hello.html", result);
     console.error("wrote file .artifact/jslint_report_hello.html");
 }());
 
@@ -336,58 +335,37 @@ import jslint from "../jslint.mjs";
 
 <br><br>
 # Quickstart JSLint in CodeMirror
-1. Download and save [`jslint.mjs`](https://www.jslint.com/jslint.mjs), [`jslint_wrapper_codemirror.js`](https://www.jslint.com/jslint_wrapper_codemirror.js)
-2. Create and serve static html-page below:
 ```shell <!-- shRunWithScreenshotTxt .artifact/screenshot_sh_jslint_wrapper_codemirror.svg -->
 #!/bin/sh
 
-# Copy jslint files.
+# 1. Download and save jslint.mjs, jslint_wrapper_codemirror.js to file:
 
 mkdir -p .artifact/
-cp jslint.mjs .artifact/
-cp jslint_wrapper_codemirror.js .artifact/
+curl -Ls https://www.jslint.com/jslint.mjs > .artifact/jslint.mjs
+curl -Ls https://www.jslint.com/jslint_wrapper_codemirror.js \
+    > .artifact/jslint_wrapper_codemirror.js
 
-# Create static html-page jslint_wrapper_codemirror.html.
+# 2. Create and serve static html-page below:
 
 printf '
 <!DOCTYPE html>
-<html lang="en">
 <head>
-    <title>CodeMirror: JSLint Demo</title>
     <link rel="stylesheet" href="https://codemirror.net/lib/codemirror.css">
     <link rel="stylesheet" href="https://codemirror.net/addon/lint/lint.css">
-    <style>
-    body {
-        background: lightgray;
-        color: darkslategray;
-        font-family: sans-serif;
-        margin: 0;
-        padding: 0 20px;
-    }
-    body > * {
-        margin: 20px 0 0 0;
-        padding: 0;
-    }
-    </style>
-</head>
-<body>
-    <h1>CodeMirror: JSLint Demo</h1>
-    <h2>
-        This demo will automatically lint code below,
-        and generate reports as you type.
-    </h2>
-    <textarea id="editor1">console.log('"'"'hello world'"'"');</textarea>
-    <div><div id="JSLINT_REPORT_HTML"></div></div>
-    <script defer
-        src="https://codemirror.net/lib/codemirror.js"></script>
+    <script defer src="https://codemirror.net/lib/codemirror.js"></script>
     <script defer
         src="https://codemirror.net/mode/javascript/javascript.js"></script>
-    <script defer
-        src="https://codemirror.net/addon/lint/lint.js"></script>
-    <script type="module"
-        src="./jslint.mjs?jslint_export_global=1"></script>
-    <script defer
-        src="./jslint_wrapper_codemirror.js"></script>
+    <script defer src="https://codemirror.net/addon/lint/lint.js"></script>
+    <script type="module" src="./jslint.mjs?window_jslint=1"></script>
+    <script defer src="./jslint_wrapper_codemirror.js"></script>
+</head>
+<body style="background:#bbb; font-family:sans-serif; margin:0; padding:20px;">
+    <h1>CodeMirror: JSLint Demo</h1>
+    <h3>
+This demo will auto-lint the code below, and auto-generate a report as you type.
+    </h3>
+    <textarea id="editor1">console.log(&apos;hello world&apos;);</textarea>
+    <div style="margin-top:20px;"><div id="JSLINT_REPORT_HTML"></div></div>
 <script type=module>
 window.addEventListener("load", function () {
     let editor = window.CodeMirror.fromTextArea(document.getElementById(
@@ -395,32 +373,24 @@ window.addEventListener("load", function () {
     ), {
         gutters: ["CodeMirror-lint-markers"],
         indentUnit: 4,
-        indentWithTabs: false,
         lineNumbers: true,
-        lint: {
-            lintOnChange: false
-        },
+        lint: {lintOnChange: false},
         mode: "javascript"
     });
     function onChange() {
-        let state = editor.state.lint;
-        if (!state) {
-            return;
-        }
-        clearTimeout(state.timeout);
-        state.timeout = setTimeout(function () {
+        clearTimeout(editor.state.lint.timeout);
+        editor.state.lint.timeout = setTimeout(function () {
             editor.performLint();
             document.getElementById(
                 "JSLINT_REPORT_HTML"
             ).outerHTML = window.jslint.jslint_report(window.jslint_result);
-        }, state.options.delay);
+        }, editor.state.lint.options.delay);
     }
     editor.on("change", onChange);
     onChange();
 });
 </script>
 </body>
-</html>
 ' > .artifact/jslint_wrapper_codemirror.html
 
 ```

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ import fs from "fs";
 
     result = jslint.jslint(source);
     result = jslint.jslint_report(result);
-    result = `<body class="JSLINT_">\n${result}\n</body>\n`;
+    result = `<body class="JSLINT_ JSLINT_REPORT_">\n${result}</body>\n`;
 
     await fs.promises.mkdir(".artifact/", {recursive: true});
     await fs.promises.writeFile(".artifact/jslint_report_hello.html", result);
@@ -335,69 +335,131 @@ import jslint from "../jslint.mjs";
 
 <br><br>
 # Quickstart JSLint in CodeMirror
-```shell <!-- shRunWithScreenshotTxt .artifact/screenshot_sh_jslint_wrapper_codemirror.svg -->
-#!/bin/sh
+1. Download and save [`jslint.mjs`](https://www.jslint.com/jslint.mjs), [`jslint_wrapper_codemirror.js`](https://www.jslint.com/jslint_wrapper_codemirror.js) to file.
 
-# 1. Download and save jslint.mjs, jslint_wrapper_codemirror.js to file:
-
-mkdir -p .artifact/
-curl -Ls https://www.jslint.com/jslint.mjs > .artifact/jslint.mjs
-curl -Ls https://www.jslint.com/jslint_wrapper_codemirror.js \
-    > .artifact/jslint_wrapper_codemirror.js
-
-# 2. Create and serve static html-page below:
-
-printf '
+2. Edit, save, and serve example html-file below:
+```html <!-- jslint_wrapper_codemirror.html -->
 <!DOCTYPE html>
+<html lang="en">
 <head>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.3/codemirror.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.3/addon/lint/lint.css">
-    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.3/codemirror.js"></script>
-    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.3/mode/javascript/javascript.js"></script>
-    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.3/addon/lint/lint.js"></script>
+    <meta charset="utf-8">
+    <title>CodeMirror: JSLint Demo</title>
+
+<!-- Assets from codemirror. -->
+
+    <link rel="stylesheet" href="https://codemirror.net/lib/codemirror.css">
+    <link rel="stylesheet" href="https://codemirror.net/addon/lint/lint.css">
+    <script defer src="https://codemirror.net/lib/codemirror.js"></script>
+    <script defer
+        src="https://codemirror.net/mode/javascript/javascript.js"></script>
+    <script defer src="https://codemirror.net/addon/lint/lint.js"></script>
+
+<!-- Assets from jslint. -->
+
     <script type="module" src="./jslint.mjs?window_jslint=1"></script>
     <script defer src="./jslint_wrapper_codemirror.js"></script>
+<style>
+body {
+    background: #bbb;
+    color: #333;
+    font-family: sans-serif;
+    margin: 20px;
+}
+.JSLINT_.JSLINT_REPORT_ {
+    margin-top: 20px;
+}
+</style>
 </head>
-<body style="background: #bbb; font-family: sans-serif; margin: 20px;">
+<body>
     <h1>CodeMirror: JSLint Demo</h1>
     <h3>
 This demo will auto-lint the code below, and auto-generate a report as you type.
     </h3>
-    <textarea id="editor1">console.log(&apos;hello world&apos;);</textarea>
-    <div style="margin-top: 20px;"><div class="JSLINT_REPORT_HTML"></div></div>
+
+<!-- Container for codemirror-editor. -->
+
+    <textarea id="editor1">console.log('hello world');</textarea>
+
+<!-- Container for jslint-report. -->
+
+    <div class="JSLINT_ JSLINT_REPORT_"></div>
 <script type=module>
 window.addEventListener("load", function () {
+
+// Initialize codemirror-editor.
+
     let editor = window.CodeMirror.fromTextArea(document.getElementById(
         "editor1"
     ), {
-        gutters: ["CodeMirror-lint-markers"],
+        gutters: [
+            "CodeMirror-lint-markers"
+        ],
         indentUnit: 4,
         lineNumbers: true,
-        lint: {lintOnChange: true, options: {}},
+        lint: {
+
+// Enable auto-lint.
+
+            lintOnChange: true,
+
+// Initialize jslint-options here.
+
+            options: {
+                // browser: true,
+                // node: true
+
+// Initialize jslint-globals here.
+
+                globals: [
+                    // "caches",
+                    // "indexedDb"
+                ]
+            }
+        },
         mode: "javascript"
     });
-    editor.on("lintJslintAfter", function ({
-        result
-    }) {
-        document.querySelector(
-            ".JSLINT_REPORT_HTML"
-        ).innerHTML = window.jslint.jslint_report(result);
+
+// Initialize event-handling before linter is run.
+
+    editor.on("lintJslintBefore", function (/* options */) {
+
+// Modify jslint-options here.
+
+        // options.browser = true;
+        // options.node = true;
+
+// Modify jslint-globals here.
+
+        // options.globals = [
+        //     "caches",
+        //     "indexedDb"
+        // ];
+        return;
     });
+
+// Initialize event-handling after linter is run.
+
+    editor.on("lintJslintAfter", function (options) {
+
+// Generate jslint-report from options.result.
+
+        document.querySelector(
+            ".JSLINT_REPORT_"
+        ).innerHTML = window.jslint.jslint_report(options.result);
+    });
+
+// Manually trigger linter.
+
     editor.performLint();
 });
 </script>
 </body>
 </html>
-' > .artifact/jslint_wrapper_codemirror.html
-
 ```
-- shell output
-
-![screenshot](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_sh_jslint_wrapper_codemirror.svg)
 
 - screenshot
 
-[![screenshot](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_browser__2f.artifact_2fjslint_wrapper_codemirror.html.png)](https://jslint-org.github.io/jslint/branch-beta/.artifact/jslint_wrapper_codemirror.html)
+[![screenshot](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_browser__2fjslint_wrapper_codemirror.html.png)](https://jslint-org.github.io/jslint/branch-beta/jslint_wrapper_codemirror.html)
 
 
 <br><br>

--- a/README.md
+++ b/README.md
@@ -35,19 +35,19 @@ Douglas Crockford <douglas@crockford.com>
     - [To create V8 coverage report from Node.js / Npm program in shell:](#to-create-v8-coverage-report-from-nodejs--npm-program-in-shell)
     - [To create V8 coverage report from Node.js / Npm program in javascript:](#to-create-v8-coverage-report-from-nodejs--npm-program-in-javascript)
 
-7. [Quickstart JSLint in Vim](#quickstart-jslint-in-vim)
-    - [To run JSLint in Vim:](#to-run-jslint-in-vim)
+7. [Quickstart JSLint in CodeMirror](#quickstart-jslint-in-codemirror)
 
-8. [Quickstart JSLint in VS Code](#quickstart-jslint-in-vs-code)
-    - [To run JSLint in VS Code:](#to-run-jslint-in-vs-code)
+8. [Quickstart JSLint in Vim](#quickstart-jslint-in-vim)
 
-9. [Description](#description)
+9. [Quickstart JSLint in VSCode](#quickstart-jslint-in-vscode)
 
-10. [Package Listing](#package-listing)
+10. [Description](#description)
 
-11. [Changelog](#changelog)
+11. [Package Listing](#package-listing)
 
-12. [License](#license)
+12. [Changelog](#changelog)
+
+13. [License](#license)
 
 
 <br><br>
@@ -231,6 +231,7 @@ import fs from "fs";
 
     result = jslint.jslint(source);
     report = jslint.jslint_report(result);
+    report = `<body class="JSLINT_">\n${report}\n</body>\n`;
 
     await fs.promises.mkdir(".artifact/", {recursive: true});
     await fs.promises.writeFile(".artifact/jslint_report_hello.html", report);
@@ -334,11 +335,106 @@ import jslint from "../jslint.mjs";
 
 
 <br><br>
-# Quickstart JSLint in Vim
+# Quickstart JSLint in CodeMirror
+1. Download and save [`jslint.mjs`](https://www.jslint.com/jslint.mjs), [`jslint_wrapper_codemirror.js`](https://www.jslint.com/jslint_wrapper_codemirror.js)
+2. Create and serve static html-page below:
+```shell <!-- shRunWithScreenshotTxt .artifact/screenshot_sh_jslint_wrapper_codemirror.svg -->
+#!/bin/sh
+
+# Copy jslint files.
+
+mkdir -p .artifact/
+cp jslint.mjs .artifact/
+cp jslint_wrapper_codemirror.js .artifact/
+
+# Create static html-page jslint_wrapper_codemirror.html.
+
+printf '
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>CodeMirror: JSLint Demo</title>
+    <link rel="stylesheet" href="https://codemirror.net/lib/codemirror.css">
+    <link rel="stylesheet" href="https://codemirror.net/addon/lint/lint.css">
+    <style>
+    body {
+        background: lightgray;
+        color: darkslategray;
+        font-family: sans-serif;
+        margin: 0;
+        padding: 0 20px;
+    }
+    body > * {
+        margin: 20px 0 0 0;
+        padding: 0;
+    }
+    </style>
+</head>
+<body>
+    <h1>CodeMirror: JSLint Demo</h1>
+    <h2>
+        This demo will automatically lint code below,
+        and generate reports as you type.
+    </h2>
+    <textarea id="editor1">console.log('"'"'hello world'"'"');</textarea>
+    <div><div id="JSLINT_REPORT_HTML"></div></div>
+    <script defer
+        src="https://codemirror.net/lib/codemirror.js"></script>
+    <script defer
+        src="https://codemirror.net/mode/javascript/javascript.js"></script>
+    <script defer
+        src="https://codemirror.net/addon/lint/lint.js"></script>
+    <script type="module"
+        src="./jslint.mjs?jslint_export_global=1"></script>
+    <script defer
+        src="./jslint_wrapper_codemirror.js"></script>
+<script type=module>
+window.addEventListener("load", function () {
+    let editor = window.CodeMirror.fromTextArea(document.getElementById(
+        "editor1"
+    ), {
+        gutters: ["CodeMirror-lint-markers"],
+        indentUnit: 4,
+        indentWithTabs: false,
+        lineNumbers: true,
+        lint: {
+            lintOnChange: false
+        },
+        mode: "javascript"
+    });
+    function onChange() {
+        let state = editor.state.lint;
+        if (!state) {
+            return;
+        }
+        clearTimeout(state.timeout);
+        state.timeout = setTimeout(function () {
+            editor.performLint();
+            document.getElementById(
+                "JSLINT_REPORT_HTML"
+            ).outerHTML = window.jslint.jslint_report(window.jslint_result);
+        }, state.options.delay);
+    }
+    editor.on("change", onChange);
+    onChange();
+});
+</script>
+</body>
+</html>
+' > .artifact/jslint_wrapper_codemirror.html
+
+```
+- shell output
+
+![screenshot](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_sh_jslint_wrapper_codemirror.svg)
+
+- screenshot
+
+[![screenshot](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_browser__2f.artifact_2fjslint_wrapper_codemirror.html.png)](https://jslint-org.github.io/jslint/branch-beta/.artifact/jslint_wrapper_codemirror.html)
 
 
 <br><br>
-### To run JSLint in Vim:
+# Quickstart JSLint in Vim
 1. Download and save [`jslint.mjs`](https://www.jslint.com/jslint.mjs), [`jslint_wrapper_vim.vim`](https://www.jslint.com/jslint_wrapper_vim.vim) to directory `~/.vim/`
 2. Add vim-command `:source ~/.vim/jslint_wrapper_vim.vim` to file `~/.vimrc`
 3. Vim can now jslint files (via nodejs):
@@ -350,16 +446,12 @@ import jslint from "../jslint.mjs";
 
 
 <br><br>
-# Quickstart JSLint in VS Code
-
-
-<br><br>
-### To run JSLint in VS Code:
-1. In VS Code, search and install extension [`vscode-jslint`](https://marketplace.visualstudio.com/items?itemName=jslint.vscode-jslint)
-2. In VS Code, while editing a javascript file:
+# Quickstart JSLint in VSCode
+1. In VSCode, search and install extension [`vscode-jslint`](https://marketplace.visualstudio.com/items?itemName=jslint.vscode-jslint)
+2. In VSCode, while editing a javascript file:
     - right-click context-menu and select `[JSLint - Lint File]`
     - or use key-binding `[Ctrl + Shift + J], [L]`
-    - or use key-binding `[ Cmd + Shift + J], [L]` (Mac)
+    - or use key-binding `[ Cmd + Shift + J], [L]` for Mac
 - screenshot
 
 [![screenshot](https://jslint-org.github.io/jslint/asset_image_jslint_wrapper_vscode.png)](https://marketplace.visualstudio.com/items?itemName=jslint.vscode-jslint)

--- a/asset_codemirror_rollup.js
+++ b/asset_codemirror_rollup.js
@@ -5,40 +5,41 @@ shRawLibFetch
     "fetchList": [
         {
             "comment": true,
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/LICENSE"
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.65.3/LICENSE"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js",
-            "url2": "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.62.0/codemirror.js"
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.65.3/codemirror.js",
+            "url2": "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.3/codemirror.js"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/edit/matchbrackets.js"
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/edit/matchbrackets.js"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/edit/trailingspace.js"
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/edit/trailingspace.js"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.js"
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/lint/lint.js"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/selection/active-line.js"
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/selection/active-line.js"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/mode/javascript/javascript.js"
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.65.3/mode/javascript/javascript.js"
         }
-    ]
+    ],
+    "replaceList": []
 }
 */
 
 
 /*
-repo https://github.com/codemirror/CodeMirror/tree/5.62.0
-committed 2021-06-21T07:13:20Z
+repo https://github.com/codemirror/CodeMirror/tree/5.65.3
+committed 2022-04-20T09:49:25Z
 */
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.62.0/LICENSE
+file https://github.com/codemirror/CodeMirror/blob/5.65.3/LICENSE
 */
 /*
 MIT License
@@ -66,7 +67,7 @@ THE SOFTWARE.
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
+file https://github.com/codemirror/CodeMirror/blob/5.65.3/codemirror.js
 */
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
@@ -1394,7 +1395,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
   // Add a span to a line.
   function addMarkedSpan(line, span, op) {
     var inThisOp = op && window.WeakSet && (op.markedSpans || (op.markedSpans = new WeakSet));
-    if (inThisOp && inThisOp.has(line.markedSpans)) {
+    if (inThisOp && line.markedSpans && inThisOp.has(line.markedSpans)) {
       line.markedSpans.push(span);
     } else {
       line.markedSpans = line.markedSpans ? line.markedSpans.concat([span]) : [span];
@@ -2421,12 +2422,14 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
   function mapFromLineView(lineView, line, lineN) {
     if (lineView.line == line)
       { return {map: lineView.measure.map, cache: lineView.measure.cache} }
-    for (var i = 0; i < lineView.rest.length; i++)
-      { if (lineView.rest[i] == line)
-        { return {map: lineView.measure.maps[i], cache: lineView.measure.caches[i]} } }
-    for (var i$1 = 0; i$1 < lineView.rest.length; i$1++)
-      { if (lineNo(lineView.rest[i$1]) > lineN)
-        { return {map: lineView.measure.maps[i$1], cache: lineView.measure.caches[i$1], before: true} } }
+    if (lineView.rest) {
+      for (var i = 0; i < lineView.rest.length; i++)
+        { if (lineView.rest[i] == line)
+          { return {map: lineView.measure.maps[i], cache: lineView.measure.caches[i]} } }
+      for (var i$1 = 0; i$1 < lineView.rest.length; i$1++)
+        { if (lineNo(lineView.rest[i$1]) > lineN)
+          { return {map: lineView.measure.maps[i$1], cache: lineView.measure.caches[i$1], before: true} } }
+    }
   }
 
   // Render a line into the hidden node display.externalMeasured. Used
@@ -2653,9 +2656,11 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
   }
 
   function widgetTopHeight(lineObj) {
+    var ref = visualLine(lineObj);
+    var widgets = ref.widgets;
     var height = 0;
-    if (lineObj.widgets) { for (var i = 0; i < lineObj.widgets.length; ++i) { if (lineObj.widgets[i].above)
-      { height += widgetHeight(lineObj.widgets[i]); } } }
+    if (widgets) { for (var i = 0; i < widgets.length; ++i) { if (widgets[i].above)
+      { height += widgetHeight(widgets[i]); } } }
     return height
   }
 
@@ -3220,13 +3225,19 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
     var curFragment = result.cursors = document.createDocumentFragment();
     var selFragment = result.selection = document.createDocumentFragment();
 
+    var customCursor = cm.options.$customCursor;
+    if (customCursor) { primary = true; }
     for (var i = 0; i < doc.sel.ranges.length; i++) {
       if (!primary && i == doc.sel.primIndex) { continue }
       var range = doc.sel.ranges[i];
       if (range.from().line >= cm.display.viewTo || range.to().line < cm.display.viewFrom) { continue }
       var collapsed = range.empty();
-      if (collapsed || cm.options.showCursorWhenSelecting)
-        { drawSelectionCursor(cm, range.head, curFragment); }
+      if (customCursor) {
+        var head = customCursor(cm, range);
+        if (head) { drawSelectionCursor(cm, head, curFragment); }
+      } else if (collapsed || cm.options.showCursorWhenSelecting) {
+        drawSelectionCursor(cm, range.head, curFragment);
+      }
       if (!collapsed)
         { drawSelectionRange(cm, range, selFragment); }
     }
@@ -3241,6 +3252,12 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
     cursor.style.left = pos.left + "px";
     cursor.style.top = pos.top + "px";
     cursor.style.height = Math.max(0, pos.bottom - pos.top) * cm.options.cursorHeight + "px";
+
+    if (/\bcm-fat-cursor\b/.test(cm.getWrapperElement().className)) {
+      var charPos = charCoords(cm, head, "div", null, null);
+      var width = charPos.right - charPos.left;
+      cursor.style.width = (width > 0 ? width : cm.defaultCharWidth()) + "px";
+    }
 
     if (pos.other) {
       // Secondary cursor, shown when on a 'jump' in bi-directional text
@@ -3414,10 +3431,14 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
   function updateHeightsInViewport(cm) {
     var display = cm.display;
     var prevBottom = display.lineDiv.offsetTop;
+    var viewTop = Math.max(0, display.scroller.getBoundingClientRect().top);
+    var oldHeight = display.lineDiv.getBoundingClientRect().top;
+    var mustScroll = 0;
     for (var i = 0; i < display.view.length; i++) {
       var cur = display.view[i], wrapping = cm.options.lineWrapping;
       var height = (void 0), width = 0;
       if (cur.hidden) { continue }
+      oldHeight += cur.line.height;
       if (ie && ie_version < 8) {
         var bot = cur.node.offsetTop + cur.node.offsetHeight;
         height = bot - prevBottom;
@@ -3432,6 +3453,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
       }
       var diff = cur.line.height - height;
       if (diff > .005 || diff < -.005) {
+        if (oldHeight < viewTop) { mustScroll -= diff; }
         updateLineHeight(cur.line, height);
         updateWidgetHeight(cur.line);
         if (cur.rest) { for (var j = 0; j < cur.rest.length; j++)
@@ -3446,6 +3468,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
         }
       }
     }
+    if (Math.abs(mustScroll) > 2) { display.scroller.scrollTop += mustScroll; }
   }
 
   // Read and store the height of line widgets associated with the
@@ -3706,6 +3729,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
       this.vert.firstChild.style.height =
         Math.max(0, measure.scrollHeight - measure.clientHeight + totalHeight) + "px";
     } else {
+      this.vert.scrollTop = 0;
       this.vert.style.display = "";
       this.vert.firstChild.style.height = "0";
     }
@@ -4456,6 +4480,10 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
     // The element in which the editor lives.
     d.wrapper = elt("div", [d.scrollbarFiller, d.gutterFiller, d.scroller], "CodeMirror");
 
+    // This attribute is respected by automatic translation systems such as Google Translate,
+    // and may also be respected by tools used by human translators.
+    d.wrapper.setAttribute('translate', 'no');
+
     // Work around IE7 z-index bug (not perfect, hence IE7 not really being supported)
     if (ie && ie_version < 8) { d.gutters.style.zIndex = -1; d.scroller.style.paddingRight = 0; }
     if (!webkit && !(gecko && mobile)) { d.scroller.draggable = true; }
@@ -4553,6 +4581,12 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
 
   function onScrollWheel(cm, e) {
     var delta = wheelEventDelta(e), dx = delta.x, dy = delta.y;
+    var pixelsPerUnit = wheelPixelsPerUnit;
+    if (e.deltaMode === 0) {
+      dx = e.deltaX;
+      dy = e.deltaY;
+      pixelsPerUnit = 1;
+    }
 
     var display = cm.display, scroll = display.scroller;
     // Quit if there's nothing to scroll here
@@ -4581,10 +4615,10 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
     // estimated pixels/delta value, we just handle horizontal
     // scrolling entirely here. It'll be slightly off from native, but
     // better than glitching out.
-    if (dx && !gecko && !presto && wheelPixelsPerUnit != null) {
+    if (dx && !gecko && !presto && pixelsPerUnit != null) {
       if (dy && canScrollY)
-        { updateScrollTop(cm, Math.max(0, scroll.scrollTop + dy * wheelPixelsPerUnit)); }
-      setScrollLeft(cm, Math.max(0, scroll.scrollLeft + dx * wheelPixelsPerUnit));
+        { updateScrollTop(cm, Math.max(0, scroll.scrollTop + dy * pixelsPerUnit)); }
+      setScrollLeft(cm, Math.max(0, scroll.scrollLeft + dx * pixelsPerUnit));
       // Only prevent default scrolling if vertical scrolling is
       // actually possible. Otherwise, it causes vertical scroll
       // jitter on OSX trackpads when deltaX is small and deltaY
@@ -4597,15 +4631,15 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
 
     // 'Project' the visible viewport to cover the area that is being
     // scrolled into view (if we know enough to estimate it).
-    if (dy && wheelPixelsPerUnit != null) {
-      var pixels = dy * wheelPixelsPerUnit;
+    if (dy && pixelsPerUnit != null) {
+      var pixels = dy * pixelsPerUnit;
       var top = cm.doc.scrollTop, bot = top + display.wrapper.clientHeight;
       if (pixels < 0) { top = Math.max(0, top + pixels - 50); }
       else { bot = Math.min(cm.doc.height, bot + pixels + 50); }
       updateDisplaySimple(cm, {top: top, bottom: bot});
     }
 
-    if (wheelSamples < 20) {
+    if (wheelSamples < 20 && e.deltaMode !== 0) {
       if (display.wheelStartX == null) {
         display.wheelStartX = scroll.scrollLeft; display.wheelStartY = scroll.scrollTop;
         display.wheelDX = dx; display.wheelDY = dy;
@@ -8282,7 +8316,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
   }
 
   function hiddenTextarea() {
-    var te = elt("textarea", null, null, "position: absolute; bottom: -1em; padding: 0; width: 1px; height: 1em; outline: none");
+    var te = elt("textarea", null, null, "position: absolute; bottom: -1em; padding: 0; width: 1px; height: 1em; min-height: 1em; outline: none");
     var div = elt("div", [te], null, "overflow: hidden; position: relative; width: 3px; height: 0px;");
     // The textarea is kept positioned near the cursor to prevent the
     // fact that it'll be scrolled into view on input from scrolling
@@ -9045,9 +9079,11 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
   ContentEditableInput.prototype.supportsTouch = function () { return true };
 
   ContentEditableInput.prototype.receivedFocus = function () {
+      var this$1 = this;
+
     var input = this;
     if (this.selectionInEditor())
-      { this.pollSelection(); }
+      { setTimeout(function () { return this$1.pollSelection(); }, 20); }
     else
       { runInOp(this.cm, function () { return input.cm.curOp.selectionChanged = true; }); }
 
@@ -9876,14 +9912,14 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/codemirror.js
 
   addLegacyProps(CodeMirror);
 
-  CodeMirror.version = "5.62.0";
+  CodeMirror.version = "5.65.3";
 
   return CodeMirror;
 })));
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/edit/matchbrackets.js
+file https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/edit/matchbrackets.js
 */
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
@@ -10048,7 +10084,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/edit/matchbracke
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/edit/trailingspace.js
+file https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/edit/trailingspace.js
 */
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
@@ -10080,7 +10116,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/edit/trailingspa
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.js
+file https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/lint/lint.js
 */
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
@@ -10143,25 +10179,42 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.js
     CodeMirror.on(node, "mouseout", hide);
   }
 
-  function LintState(cm, options, hasGutter) {
+  function LintState(cm, conf, hasGutter) {
     this.marked = [];
-    this.options = options;
+    if (conf instanceof Function) conf = {getAnnotations: conf};
+    if (!conf || conf === true) conf = {};
+    this.options = {};
+    this.linterOptions = conf.options || {};
+    for (var prop in defaults) this.options[prop] = defaults[prop];
+    for (var prop in conf) {
+      if (defaults.hasOwnProperty(prop)) {
+        if (conf[prop] != null) this.options[prop] = conf[prop];
+      } else if (!conf.options) {
+        this.linterOptions[prop] = conf[prop];
+      }
+    }
     this.timeout = null;
     this.hasGutter = hasGutter;
     this.onMouseOver = function(e) { onMouseOver(cm, e); };
     this.waitingFor = 0
   }
 
-  function parseOptions(_cm, options) {
-    if (options instanceof Function) return {getAnnotations: options};
-    if (!options || options === true) options = {};
-    return options;
+  var defaults = {
+    highlightLines: false,
+    tooltips: true,
+    delay: 500,
+    lintOnChange: true,
+    getAnnotations: null,
+    async: false,
+    selfContain: null,
+    formatAnnotation: null,
+    onUpdateLinting: null
   }
 
   function clearMarks(cm) {
     var state = cm.state.lint;
     if (state.hasGutter) cm.clearGutter(GUTTER_ID);
-    if (isHighlightErrorLinesEnabled(state)) clearErrorLines(cm);
+    if (state.options.highlightLines) clearErrorLines(cm);
     for (var i = 0; i < state.marked.length; ++i)
       state.marked[i].clear();
     state.marked.length = 0;
@@ -10172,10 +10225,6 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.js
       var has = line.wrapClass && /\bCodeMirror-lint-line-\w+\b/.exec(line.wrapClass);
       if (has) cm.removeLineClass(line, "wrap", has[0]);
     })
-  }
-
-  function isHighlightErrorLinesEnabled(state) {
-    return state.options.highlightLines;
   }
 
   function makeMarker(cm, labels, severity, multiple, tooltips) {
@@ -10220,7 +10269,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.js
     return tip;
   }
 
-  function lintAsync(cm, getAnnotations, passOptions) {
+  function lintAsync(cm, getAnnotations) {
     var state = cm.state.lint
     var id = ++state.waitingFor
     function abort() {
@@ -10233,7 +10282,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.js
       if (state.waitingFor != id) return
       if (arg2 && annotations instanceof CodeMirror) annotations = arg2
       cm.operation(function() {updateLinting(cm, annotations)})
-    }, passOptions, cm);
+    }, state.linterOptions, cm);
   }
 
   function startLinting(cm) {
@@ -10244,13 +10293,12 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.js
      * Passing rules in `options` property prevents JSHint (and other linters) from complaining
      * about unrecognized rules like `onUpdateLinting`, `delay`, `lintOnChange`, etc.
      */
-    var passOptions = options.options || options;
     var getAnnotations = options.getAnnotations || cm.getHelper(CodeMirror.Pos(0, 0), "lint");
     if (!getAnnotations) return;
     if (options.async || getAnnotations.async) {
-      lintAsync(cm, getAnnotations, passOptions)
+      lintAsync(cm, getAnnotations)
     } else {
-      var annotations = getAnnotations(cm.getValue(), passOptions, cm);
+      var annotations = getAnnotations(cm.getValue(), state.linterOptions, cm);
       if (!annotations) return;
       if (annotations.then) annotations.then(function(issues) {
         cm.operation(function() {updateLinting(cm, issues)})
@@ -10295,9 +10343,9 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.js
       // use original annotations[line] to show multiple messages
       if (state.hasGutter)
         cm.setGutterMarker(line, GUTTER_ID, makeMarker(cm, tipLabel, maxSeverity, annotations[line].length > 1,
-                                                       state.options.tooltips));
+                                                       options.tooltips));
 
-      if (isHighlightErrorLinesEnabled(state))
+      if (options.highlightLines)
         cm.addLineClass(line, "wrap", LINT_LINE_ID + maxSeverity);
     }
     if (options.onUpdateLinting) options.onUpdateLinting(annotationsNotSorted, annotations, cm);
@@ -10307,7 +10355,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.js
     var state = cm.state.lint;
     if (!state) return;
     clearTimeout(state.timeout);
-    state.timeout = setTimeout(function(){startLinting(cm);}, state.options.delay || 500);
+    state.timeout = setTimeout(function(){startLinting(cm);}, state.options.delay);
   }
 
   function popupTooltips(cm, annotations, e) {
@@ -10347,8 +10395,8 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.js
     if (val) {
       var gutters = cm.getOption("gutters"), hasLintGutter = false;
       for (var i = 0; i < gutters.length; ++i) if (gutters[i] == GUTTER_ID) hasLintGutter = true;
-      var state = cm.state.lint = new LintState(cm, parseOptions(cm, val), hasLintGutter);
-      if (state.options.lintOnChange !== false)
+      var state = cm.state.lint = new LintState(cm, val, hasLintGutter);
+      if (state.options.lintOnChange)
         cm.on("change", onChange);
       if (state.options.tooltips != false && state.options.tooltips != "gutter")
         CodeMirror.on(cm.getWrapperElement(), "mouseover", state.onMouseOver);
@@ -10364,7 +10412,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.js
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/selection/active-line.js
+file https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/selection/active-line.js
 */
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
@@ -10441,7 +10489,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/selection/active
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.62.0/mode/javascript/javascript.js
+file https://github.com/codemirror/CodeMirror/blob/5.65.3/mode/javascript/javascript.js
 */
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
@@ -10775,6 +10823,7 @@ CodeMirror.defineMode("javascript", function(config, parserConfig) {
     cx.state.context = new Context(cx.state.context, cx.state.localVars, true)
     cx.state.localVars = null
   }
+  pushcontext.lex = pushblockcontext.lex = true
   function popcontext() {
     cx.state.localVars = cx.state.context.vars
     cx.state.context = cx.state.context.prev

--- a/index.html
+++ b/index.html
@@ -663,9 +663,12 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
 /7xoEqvL+2E8VOyCTuT/7j269Zy4jUtN+g4="
     ) format("woff2");
 }
-*,
-*:after,
-*:before {
+.JSLINT_,
+.JSLINT_ *,
+.JSLINT_ *:after,
+.JSLINT_ *:before,
+.JSLINT_:after,
+.JSLINT_:before {
     border: 0;
     box-sizing: border-box;
     margin: 0;
@@ -709,7 +712,7 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
 }
 
 /* css - jslint_report - general */
-body {
+.JSLINT_ {
     background: antiquewhite;
 }
 .JSLINT_ fieldset {
@@ -1179,7 +1182,9 @@ body {
 </fieldset>
 </main>
 <div id="JSLINT_REPORT_HTML"></div>
-<script defer src="asset_codemirror_rollup.js"></script>
+<script defer src="./asset_codemirror_rollup.js"></script>
+<script defer type="module" src="./jslint.mjs?jslint_export_global=1"></script>
+<script defer src="./jslint_wrapper_codemirror.js"></script>
 <script type="module">
 // browser.mjs
 // Original Author: Douglas Crockford (https://www.jslint.com).
@@ -1211,31 +1216,26 @@ body {
 
 
 /*jslint beta, browser*/
-
-/*global CodeMirror*/
-
 /*property
-    Pos, Tab, addEventListener, ch, checked, clear, click, closest, column,
+    CodeMirror, Tab, addEventListener, ch, checked, clear, click, closest,
     ctrlKey, display, dom_style_report_unmatched, editor, error, extraKeys,
     focus, forEach, from, fromTextArea, getItem, getValue, globals, gutters,
     indentSelection, indentUnit, indentWithTabs, innerHTML, jslint,
     jslint_edition, jslint_report, jslint_result, key, length, line,
-    lineNumbers, lineWrapping, lint, lintOnChange, map, matchBrackets, message,
-    metaKey, mode, mode_stop, name, offsetWidth, on, outerHTML, parse,
-    performLint, preventDefault, push, querySelector, querySelectorAll,
-    registerHelper, replace, replaceSelection, result, reverse, search,
-    setCursor, setItem, setSize, setValue, severity, showTrailingSpace,
-    somethingSelected, sort, split, stopPropagation, stringify, style,
-    styleActiveLine, tagName, target, test, textContent, to, trim, value,
-    warnings, width
+    lineNumbers, lineWrapping, lint, lintOnChange, matchBrackets, metaKey, mode,
+    name, offsetWidth, on, outerHTML, parse, performLint, preventDefault, push,
+    querySelector, querySelectorAll, replace, replaceSelection, reverse, search,
+    setCursor, setItem, setSize, setValue, showTrailingSpace, somethingSelected,
+    sort, split, stopPropagation, stringify, style, styleActiveLine, tagName,
+    target, test, textContent, trim, value, width
 */
-
-import jslint from "./jslint.mjs";
 
 // This is the web script companion file for JSLint. It includes code for
 // interacting with the browser and displaying the reports.
 
+let CodeMirror = window.CodeMirror;
 let editor;
+let jslint = window.jslint;
 let jslint_option_dict = {
     lintOnChange: false
 };
@@ -1312,7 +1312,7 @@ async function jslint_run() {
 
         document.querySelector(
             "#JSLINT_REPORT_HTML"
-        ).outerHTML = jslint.jslint_report(jslint_option_dict.result);
+        ).outerHTML = jslint.jslint_report(window.jslint_result);
         listener_window_onresize();
     } catch (err) {
         console.error(err); //jslint-quiet
@@ -1323,37 +1323,6 @@ async function jslint_run() {
     setTimeout(function () {
         document.querySelector("#uiLoader1").style.display = "none";
     }, 500);
-}
-
-function jslint_wrapper_codemirror(CodeMirror) {
-
-// This function will integrate jslint with CodeMirror's lint addon.
-// Requires CodeMirror and jslint.
-
-    CodeMirror.registerHelper("lint", "javascript", function (text, options) {
-        options.result = jslint.jslint(text, options, options.globals);
-
-// Debug jslint result.
-
-        window.jslint_result = options.result;
-        return options.result.warnings.map(function ({
-            column,
-            line,
-            message,
-            mode_stop
-        }) {
-            return {
-                from: CodeMirror.Pos(line - 1, column - 1), //jslint-quiet
-                message,
-                severity: (
-                    mode_stop
-                    ? "error"
-                    : "warning"
-                ),
-                to: CodeMirror.Pos(line - 1, column) //jslint-quiet
-            };
-        });
-    });
 }
 
 function listener_window_onresize() {
@@ -1600,12 +1569,12 @@ editor = CodeMirror.fromTextArea(document.querySelector(
 ), {
     extraKeys: {
         "Shift-Tab": "indentLess",
-        Tab: function (cm) {
-            if (cm.somethingSelected()) {
-                cm.indentSelection("add");
+        Tab: function () {
+            if (editor.somethingSelected()) {
+                editor.indentSelection("add");
                 return;
             }
-            cm.replaceSelection("    ");
+            editor.replaceSelection("    ");
         }
     },
     gutters: ["CodeMirror-lint-markers"],
@@ -1615,14 +1584,10 @@ editor = CodeMirror.fromTextArea(document.querySelector(
     lineWrapping: true,
     lint: jslint_option_dict,
     matchBrackets: true,
-    mode: "text/javascript",
+    mode: "javascript",
     showTrailingSpace: true,
     styleActiveLine: true
 });
-
-// Init CodeMirror linter.
-
-jslint_wrapper_codemirror(CodeMirror);
 
 // Init event-handling for CodeMirror editor.
 

--- a/index.html
+++ b/index.html
@@ -688,7 +688,7 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
     -webkit-text-size-adjust: none;
     text-size-adjust: none;
 }
-.JSLINT_REPORT_HTML div {
+.JSLINT_REPORT_ div {
     box-sizing: border-box;
 }
 /*csslint ignore:end*/
@@ -1193,7 +1193,7 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
     </div>
 </fieldset>
 </main>
-<div class="JSLINT_ JSLINT_REPORT_HTML"></div>
+<div class="JSLINT_ JSLINT_REPORT_"></div>
 <script type="module">
 // browser.mjs
 // Original Author: Douglas Crockford (https://www.jslint.com).
@@ -1318,7 +1318,7 @@ async function jslint_run() {
 // Display the reports.
 
         document.querySelector(
-            ".JSLINT_REPORT_HTML"
+            ".JSLINT_REPORT_"
         ).innerHTML = jslint.jslint_report(jslint_option_dict.result);
         listener_window_onresize();
     } catch (err) {

--- a/index.html
+++ b/index.html
@@ -688,7 +688,7 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
     -webkit-text-size-adjust: none;
     text-size-adjust: none;
 }
-#JSLINT_REPORT_HTML div {
+.JSLINT_REPORT_HTML div {
     box-sizing: border-box;
 }
 /*csslint ignore:end*/
@@ -1193,7 +1193,7 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
     </div>
 </fieldset>
 </main>
-<div class="JSLINT_" id="JSLINT_REPORT_HTML"></div>
+<div class="JSLINT_ JSLINT_REPORT_HTML"></div>
 <script type="module">
 // browser.mjs
 // Original Author: Douglas Crockford (https://www.jslint.com).
@@ -1229,14 +1229,14 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
     CodeMirror, Tab, addEventListener, ch, checked, clear, click, closest,
     ctrlKey, display, dom_style_report_unmatched, editor, error, extraKeys,
     focus, forEach, from, fromTextArea, getItem, getValue, globals, gutters,
-    indentSelection, indentUnit, indentWithTabs, innerHTML, jslint,
-    jslint_edition, jslint_report, jslint_result, key, length, line,
-    lineNumbers, lineWrapping, lint, lintOnChange, matchBrackets, metaKey, mode,
-    name, offsetWidth, on, outerHTML, parse, performLint, preventDefault, push,
-    querySelector, querySelectorAll, replace, replaceSelection, reverse, search,
-    setCursor, setItem, setSize, setValue, showTrailingSpace, somethingSelected,
-    sort, split, stopPropagation, stringify, style, styleActiveLine, tagName,
-    target, test, textContent, trim, value, width
+    indentSelection, indentUnit, innerHTML, jslint, jslint_edition,
+    jslint_report, key, length, line, lineNumbers, lineWrapping, lint,
+    lintOnChange, matchBrackets, metaKey, mode, name, offsetWidth, on, options,
+    parse, performLint, preventDefault, push, querySelector, querySelectorAll,
+    replace, replaceSelection, result, reverse, search, setCursor, setItem,
+    setSize, setValue, showTrailingSpace, somethingSelected, sort, split,
+    stopPropagation, stringify, style, styleActiveLine, tagName, target, test,
+    textContent, trim, value, width
 */
 
 // This is the web script companion file for JSLint. It includes code for
@@ -1245,9 +1245,7 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
 let CodeMirror = window.CodeMirror;
 let editor;
 let jslint = window.jslint;
-let jslint_option_dict = {
-    lintOnChange: false
-};
+let jslint_option_dict = {};
 let mode_debug;
 let mode_persist_state_debouncing;
 
@@ -1320,8 +1318,8 @@ async function jslint_run() {
 // Display the reports.
 
         document.querySelector(
-            "#JSLINT_REPORT_HTML"
-        ).outerHTML = jslint.jslint_report(window.jslint_result);
+            ".JSLINT_REPORT_HTML"
+        ).innerHTML = jslint.jslint_report(jslint_option_dict.result);
         listener_window_onresize();
     } catch (err) {
         console.error(err); //jslint-quiet
@@ -1590,7 +1588,10 @@ editor = CodeMirror.fromTextArea(document.querySelector(
     indentUnit: 4,
     lineNumbers: true,
     lineWrapping: true,
-    lint: jslint_option_dict,
+    lint: {
+        lintOnChange: false,
+        options: jslint_option_dict
+    },
     matchBrackets: true,
     mode: "javascript",
     showTrailingSpace: true,

--- a/index.html
+++ b/index.html
@@ -1,20 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<meta
-    name="description"
-    content="JSLint, The JavaScript Code Quality and Coverage Tool. This file allows JSLint
-    to be run from a web browser. It can accept a source program and analyze
-    it without sending it over the network."
->
-<meta name="author" content="Douglas Crockford">
-<link rel="icon" type="image/png" href="asset_image_logo_512.svg">
-<title>JSLint: The JavaScript Code Quality and Coverage Tool</title>
-<!-- Google Lighthouse Performance - Reduce Largest Contentful Paint. -->
-<link as="script" rel="preload" href="asset_codemirror_rollup.js">
-<link rel="modulepreload" href="jslint.mjs">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+        name="description"
+        content="JSLint, The JavaScript Code Quality and Coverage Tool.
+        This file allows JSLint to be run from a web browser.
+        It can accept a source program and analyze it
+        without sending it over the network."
+    >
+    <meta name="author" content="Douglas Crockford">
+    <link rel="icon" type="image/png" href="asset_image_logo_512.svg">
+    <title>JSLint: The JavaScript Code Quality and Coverage Tool</title>
+    <script defer src="./asset_codemirror_rollup.js"></script>
+    <script type="module" src="./jslint.mjs?window_jslint=1"></script>
+    <script defer src="./jslint_wrapper_codemirror.js"></script>
 <style>
 /*jslint-disable*/
 /*
@@ -23,27 +24,28 @@ shRawLibFetch
     "fetchList": [
         {
             "comment": true,
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/LICENSE"
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.65.3/LICENSE"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/lib/codemirror.css"
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.65.3/lib/codemirror.css"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.css"
+            "url": "https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/lint/lint.css"
         }
-    ]
+    ],
+    "replaceList": []
 }
 */
 
 
 /*
-repo https://github.com/codemirror/CodeMirror/tree/5.62.0
-committed 2021-06-21T07:13:20Z
+repo https://github.com/codemirror/CodeMirror/tree/5.65.3
+committed 2022-04-20T09:49:25Z
 */
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.62.0/LICENSE
+file https://github.com/codemirror/CodeMirror/blob/5.65.3/LICENSE
 */
 /*
 MIT License
@@ -71,7 +73,7 @@ THE SOFTWARE.
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.62.0/lib/codemirror.css
+file https://github.com/codemirror/CodeMirror/blob/5.65.3/lib/codemirror.css
 */
 /* BASICS */
 
@@ -135,20 +137,13 @@ file https://github.com/codemirror/CodeMirror/blob/5.62.0/lib/codemirror.css
 .cm-fat-cursor div.CodeMirror-cursors {
   z-index: 1;
 }
-.cm-fat-cursor-mark {
-  background-color: rgba(20, 255, 20, 0.5);
-  -webkit-animation: blink 1.06s steps(1) infinite;
-  -moz-animation: blink 1.06s steps(1) infinite;
-  animation: blink 1.06s steps(1) infinite;
-}
-.cm-animate-fat-cursor {
-  width: auto;
-  border: 0;
-  -webkit-animation: blink 1.06s steps(1) infinite;
-  -moz-animation: blink 1.06s steps(1) infinite;
-  animation: blink 1.06s steps(1) infinite;
-  background-color: #7e7;
-}
+.cm-fat-cursor .CodeMirror-line::selection,
+.cm-fat-cursor .CodeMirror-line > span::selection,
+.cm-fat-cursor .CodeMirror-line > span > span::selection { background: transparent; }
+.cm-fat-cursor .CodeMirror-line::-moz-selection,
+.cm-fat-cursor .CodeMirror-line > span::-moz-selection,
+.cm-fat-cursor .CodeMirror-line > span > span::-moz-selection { background: transparent; }
+.cm-fat-cursor { caret-color: transparent; }
 @-moz-keyframes blink {
   0% {}
   50% { background-color: transparent; }
@@ -246,6 +241,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
   height: 100%;
   outline: none; /* Prevent dragging from highlighting the element */
   position: relative;
+  z-index: 0;
 }
 .CodeMirror-sizer {
   position: relative;
@@ -426,7 +422,7 @@ span.CodeMirror-selectedtext { background: none; }
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.62.0/addon/lint/lint.css
+file https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/lint/lint.css
 */
 /* The lint marker gutter */
 .CodeMirror-lint-markers {
@@ -664,20 +660,36 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
     ) format("woff2");
 }
 .JSLINT_,
-.JSLINT_ *,
-.JSLINT_ *:after,
-.JSLINT_ *:before,
-.JSLINT_:after,
-.JSLINT_:before {
+.JSLINT_ address,
+.JSLINT_ button,
+.JSLINT_ cite,
+.JSLINT_ dd,
+.JSLINT_ dfn,
+.JSLINT_ dl,
+.JSLINT_ dt,
+.JSLINT_ fieldset,
+.JSLINT_ fieldset > div,
+.JSLINT_ input,
+.JSLINT_ label,
+.JSLINT_ legend,
+.JSLINT_ ol,
+.JSLINT_ samp,
+.JSLINT_ style,
+.JSLINT_ textarea,
+.JSLINT_ ul {
     border: 0;
     box-sizing: border-box;
     margin: 0;
     padding: 0;
 }
+/* disable text inflation algorithm used on some smartphones and tablets */
 .JSLINT_ {
     -ms-text-size-adjust: none;
     -webkit-text-size-adjust: none;
     text-size-adjust: none;
+}
+#JSLINT_REPORT_HTML div {
+    box-sizing: border-box;
 }
 /*csslint ignore:end*/
 
@@ -1181,10 +1193,7 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
     </div>
 </fieldset>
 </main>
-<div id="JSLINT_REPORT_HTML"></div>
-<script defer src="./asset_codemirror_rollup.js"></script>
-<script defer type="module" src="./jslint.mjs?jslint_export_global=1"></script>
-<script defer src="./jslint_wrapper_codemirror.js"></script>
+<div class="JSLINT_" id="JSLINT_REPORT_HTML"></div>
 <script type="module">
 // browser.mjs
 // Original Author: Douglas Crockford (https://www.jslint.com).
@@ -1420,7 +1429,7 @@ document.addEventListener("keydown", function (evt) {
     }
 });
 
-// Init event-handling for #JSLINT_.
+// Init event-handling for .JSLINT_.
 
 document.querySelector(
     ".JSLINT_"
@@ -1579,7 +1588,6 @@ editor = CodeMirror.fromTextArea(document.querySelector(
     },
     gutters: ["CodeMirror-lint-markers"],
     indentUnit: 4,
-    indentWithTabs: false,
     lineNumbers: true,
     lineWrapping: true,
     lint: jslint_option_dict,
@@ -1654,6 +1662,7 @@ eval("console.log(\\"hello world\\");");
 }
 
 // Init exports.
+
 window.dom_style_report_unmatched = dom_style_report_unmatched;
 window.editor = editor;
 </script>

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -251,8 +251,8 @@ let jslint_rgx_token = new RegExp(
     + ")"
     + "(.*)$"
 );
-let jslint_rgx_url_search_export_global = (
-    /[&?]jslint_export_global=1(?:$|&)/m
+let jslint_rgx_url_search_window_jslint = (
+    /[&?]window_jslint=1(?:$|&)/m
 );
 let jslint_rgx_weird_property = (
     /^_|\$|Sync$|_$/m
@@ -1709,15 +1709,18 @@ async function jslint_cli({
         return count;
     }
 
-// PR-xxx
-// Check import.meta.url for directive to export jslint globally.
-// This is useful for pre-ESM-era browser-scripts that rely on window.jslint
+// PR-396 - window.jslint
+// Check import.meta.url for directive to export jslint to window-object.
+// Useful for ES5-era browser-scripts that rely on window.jslint,
+// like CodeMirror.
+//
+// Example usage:
+// <script type="module" src="./jslint.mjs?window_jslint=1"></script>
 
     import_meta_url = import_meta_url || jslint_import_meta_url;
     if (
-        jslint_rgx_url_search_export_global.test(import_meta_url)
-        && typeof globalThis === "object"
-        && globalThis
+        jslint_rgx_url_search_window_jslint.test(import_meta_url)
+        && (typeof globalThis === "object" && globalThis)
     ) {
         globalThis.jslint = jslint;
     }
@@ -1725,8 +1728,7 @@ async function jslint_cli({
 // Feature-detect nodejs.
 
     if (!(
-        typeof process === "object"
-        && process
+        (typeof process === "object" && process)
         && process.versions
         && typeof process.versions.node === "string"
         && !mode_noop
@@ -1898,10 +1900,9 @@ async function jslint_cli({
         option
     });
     if (mode_report) {
-        await fsWriteFileWithParents(
-            mode_report,
-            `<body class="JSLINT_">\n${jslint_report(result)}\n</body>\n`
-        );
+        result = jslint.jslint_report(result);
+        result = `<body class="JSLINT_">\n${result}\n</body>\n`;
+        await fsWriteFileWithParents(mode_report, result);
     }
     process_exit(exit_code);
     return exit_code;
@@ -9172,20 +9173,36 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
     ) format("woff2");
 }
 .JSLINT_,
-.JSLINT_ *,
-.JSLINT_ *:after,
-.JSLINT_ *:before,
-.JSLINT_:after,
-.JSLINT_:before {
+.JSLINT_ address,
+.JSLINT_ button,
+.JSLINT_ cite,
+.JSLINT_ dd,
+.JSLINT_ dfn,
+.JSLINT_ dl,
+.JSLINT_ dt,
+.JSLINT_ fieldset,
+.JSLINT_ fieldset > div,
+.JSLINT_ input,
+.JSLINT_ label,
+.JSLINT_ legend,
+.JSLINT_ ol,
+.JSLINT_ samp,
+.JSLINT_ style,
+.JSLINT_ textarea,
+.JSLINT_ ul {
     border: 0;
     box-sizing: border-box;
     margin: 0;
     padding: 0;
 }
+/* disable text inflation algorithm used on some smartphones and tablets */
 .JSLINT_ {
     -ms-text-size-adjust: none;
     -webkit-text-size-adjust: none;
     text-size-adjust: none;
+}
+#JSLINT_REPORT_HTML div {
+    box-sizing: border-box;
 }
 /*csslint ignore:end*/
 
@@ -10402,9 +10419,19 @@ async function v8CoverageReportCreate({
 <style>
 /* jslint utility2:true */
 /*csslint ignore:start*/
-* {
-box-sizing: border-box;
-    font-family: consolas, menlo, monospace;
+.coverage,
+.coverage a,
+.coverage div,
+.coverage pre,
+.coverage span,
+.coverage table,
+.coverage tbody,
+.coverage td,
+.coverage th,
+.coverage thead,
+.coverage tr {
+    box-sizing: border-box;
+    font-family: monospace;
 }
 /*csslint ignore:end*/
 

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -9023,7 +9023,7 @@ function jslint_report({
         );
     }
 
-    html += "<div class=\"JSLINT_\" id=\"JSLINT_REPORT_HTML\">\n";
+    html += "<div class=\"JSLINT_ JSLINT_REPORT_HTML\">\n";
     html += String(`
 <style class="JSLINT_REPORT_STYLE">
 /* jslint utility2:true */
@@ -9201,7 +9201,7 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
     -webkit-text-size-adjust: none;
     text-size-adjust: none;
 }
-#JSLINT_REPORT_HTML div {
+.JSLINT_REPORT_HTML div {
     box-sizing: border-box;
 }
 /*csslint ignore:end*/

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -1901,7 +1901,7 @@ async function jslint_cli({
     });
     if (mode_report) {
         result = jslint.jslint_report(result);
-        result = `<body class="JSLINT_">\n${result}\n</body>\n`;
+        result = `<body class="JSLINT_ JSLINT_REPORT_">\n${result}</body>\n`;
         await fsWriteFileWithParents(mode_report, result);
     }
     process_exit(exit_code);
@@ -9023,7 +9023,6 @@ function jslint_report({
         );
     }
 
-    html += "<div class=\"JSLINT_ JSLINT_REPORT_HTML\">\n";
     html += String(`
 <style class="JSLINT_REPORT_STYLE">
 /* jslint utility2:true */
@@ -9201,7 +9200,7 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
     -webkit-text-size-adjust: none;
     text-size-adjust: none;
 }
-.JSLINT_REPORT_HTML div {
+.JSLINT_REPORT_ div {
     box-sizing: border-box;
 }
 /*csslint ignore:end*/
@@ -9574,7 +9573,6 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
     });
     html += "</div>\n";
     html += "</fieldset>\n";
-    html += "</div>\n";
     return html;
 }
 

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -1065,6 +1065,13 @@ import moduleUrl from "url";
         ".xml": "application/xml; charset=utf-8",
         "/": "text/html; charset=utf-8"
     };
+    // exit after given timeout
+    if (process.env.npm_config_timeout_exit) {
+        setTimeout(
+            process.exit,
+            process.env.npm_config_timeout_exit
+        );
+    }
     if (process.argv[1]) {
         await import("file://" + modulePath.resolve(process.argv[1]));
     }

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -2324,9 +2324,19 @@ async function v8CoverageReportCreate({
 <style>
 /* jslint utility2:true */
 /*csslint ignore:start*/
-* {
-box-sizing: border-box;
-  font-family: consolas, menlo, monospace;
+.coverage,
+.coverage a,
+.coverage div,
+.coverage pre,
+.coverage span,
+.coverage table,
+.coverage tbody,
+.coverage td,
+.coverage th,
+.coverage thead,
+.coverage tr {
+  box-sizing: border-box;
+  font-family: monospace;
 }
 /*csslint ignore:end*/
 

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -280,10 +280,21 @@ shCiArtifactUpload() {(set -e
     git config --local user.name "github-actions"
     # init $GITHUB_BRANCH0
     git pull --unshallow origin "$GITHUB_BRANCH0"
-    # init $UPSTREAM_OWNER
-    export UPSTREAM_OWNER="${UPSTREAM_OWNER:-jslint-org}"
-    # init $UPSTREAM_REPO
-    export UPSTREAM_REPO="${UPSTREAM_REPO:-jslint}"
+    # init $UPSTREAM_REPOSITORY
+    export UPSTREAM_REPOSITORY="$(node -p '(
+    /^https:\/\/github\.com\/([^\/]*?\/[^.]*?)\.git$/
+).exec(require("./package.json").repository.url)[1]
+')" # '
+    # init $UPSTREAM_GITHUB_IO
+    export UPSTREAM_GITHUB_IO="$(
+        printf "$UPSTREAM_REPOSITORY" | sed -e "s|/|.github.io/|"
+    )"
+    # init $GITHUB_REPOSITORY
+    export GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-$UPSTREAM_REPOSITORY}"
+    # init $GITHUB_GITHUB_IO
+    export GITHUB_GITHUB_IO="$(
+        printf "$GITHUB_REPOSITORY" | sed -e "s|/|.github.io/|"
+    )"
     # screenshot changelog and files
     node --input-type=module --eval '
 import moduleChildProcess from "child_process";
@@ -356,11 +367,10 @@ import moduleChildProcess from "child_process";
     fi
     # update README.md with branch-$GITHUB_BRANCH0 and $GITHUB_REPOSITORY
     sed -i \
-        -e "s|/branch-[0-9A-Z_a-z]*/|/branch-$GITHUB_BRANCH0/|g" \
-        -e "s|\b$UPSTREAM_OWNER/$UPSTREAM_REPO\b|$GITHUB_REPOSITORY|g" \
-        -e "s|\b$UPSTREAM_OWNER\.github\.io/$UPSTREAM_REPO\b|$(
-            printf "$GITHUB_REPOSITORY" | sed -e "s|/|.github.io/|"
-        )|g" \
+        -e "s|/branch-[a-z]*/|/branch-$GITHUB_BRANCH0/|g" \
+        -e "s|\\b$UPSTREAM_GITHUB_IO\\b|$GITHUB_GITHUB_IO|g" \
+        -e "s|\\b$UPSTREAM_REPOSITORY\\b|$GITHUB_REPOSITORY|g" \
+        -e "s|_2fbranch-[a-z]*_2f|_2fbranch-${GITHUB_BRANCH0}_2f|g" \
         "branch-$GITHUB_BRANCH0/README.md"
     git status
     git commit -am "update dir branch-$GITHUB_BRANCH0" || true
@@ -573,11 +583,32 @@ shDiffFileFromDir() {(set -e
 
 shDirHttplinkValidate() {(set -e
 # this function will validate http-links embedded in .html and .md files
+    # init $UPSTREAM_REPOSITORY
+    export UPSTREAM_REPOSITORY="$(node -p '(
+    /^https:\/\/github\.com\/([^\/]*?\/[^.]*?)\.git$/
+).exec(require("./package.json").repository.url)[1]
+')" # '
+    # init $UPSTREAM_GITHUB_IO
+    export UPSTREAM_GITHUB_IO="$(
+        printf "$UPSTREAM_REPOSITORY" | sed -e "s|/|.github.io/|"
+    )"
+    # init $GITHUB_REPOSITORY
+    export GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-$UPSTREAM_REPOSITORY}"
+    # init $GITHUB_GITHUB_IO
+    export GITHUB_GITHUB_IO="$(
+        printf "$GITHUB_REPOSITORY" | sed -e "s|/|.github.io/|"
+    )"
     node --input-type=module --eval '
 import moduleFs from "fs";
 import moduleHttps from "https";
 import moduleUrl from "url";
 (async function () {
+    let {
+        GITHUB_GITHUB_IO,
+        GITHUB_REPOSITORY,
+        UPSTREAM_GITHUB_IO,
+        UPSTREAM_REPOSITORY
+    } = process.env;
     let dict = {};
     Array.from(
         await moduleFs.promises.readdir(".")
@@ -596,14 +627,14 @@ import moduleUrl from "url";
             url = url.slice(0, -1).replace((
                 /[\u0022\u0027]/g
             ), "").replace((
-                /\/branch-\w+?\//g
-            ), "/branch-alpha/").replace((
-                /\bjslint-org\/jslint\b/g
-            ), process.env.GITHUB_REPOSITORY || "jslint-org/jslint").replace((
-                /\bjslint-org\.github\.io\/jslint\b/g
-            ), String(
-                process.env.GITHUB_REPOSITORY || "jslint-org/jslint"
-            ).replace("/", ".github.io/"));
+                /\/branch-[a-z]*?\//g
+            ), "/branch-alpha/").replace(new RegExp(
+                `\\b${UPSTREAM_REPOSITORY}\\b`,
+                "g"
+            ), GITHUB_REPOSITORY).replace(new RegExp(
+                `\\b${UPSTREAM_GITHUB_IO}\\b`,
+                "g"
+            ), GITHUB_GITHUB_IO);
             if (url.startsWith("http://")) {
                 throw new Error(
                     `shDirHttplinkValidate - ${file} - insecure link - ${url}`

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -842,18 +842,10 @@ shGithubFileUpload() {(set -e
 # example use:
 # shGithubFileUpload octocat/hello-worId/master/hello.txt hello.txt
     node --input-type=module --eval '
+import moduleAssert from "assert";
 import moduleFs from "fs";
 import moduleHttps from "https";
 import modulePath from "path";
-function assertOrThrow(condition, message) {
-    if (!condition) {
-        throw (
-            (!message || typeof message === "string")
-            ? new Error(String(message).slice(0, 2048))
-            : message
-        );
-    }
-}
 (async function () {
     let branch;
     let content = process.argv[2];
@@ -880,7 +872,7 @@ function assertOrThrow(condition, message) {
                     responseText += chunk;
                 });
                 res.on("end", function () {
-                    assertOrThrow(res.statusCode === 200, (
+                    moduleAssert(res.statusCode === 200, (
                         "shGithubFileUpload"
                         + `- failed to download/upload file ${url} - `
                         + responseText

--- a/jslint_wrapper_codemirror.html
+++ b/jslint_wrapper_codemirror.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>CodeMirror: JSLint Demo</title>
+
+<!-- Assets from codemirror. -->
+
+    <link rel="stylesheet" href="https://codemirror.net/lib/codemirror.css">
+    <link rel="stylesheet" href="https://codemirror.net/addon/lint/lint.css">
+    <script defer src="https://codemirror.net/lib/codemirror.js"></script>
+    <script defer
+        src="https://codemirror.net/mode/javascript/javascript.js"></script>
+    <script defer src="https://codemirror.net/addon/lint/lint.js"></script>
+
+<!-- Assets from jslint. -->
+
+    <script type="module" src="./jslint.mjs?window_jslint=1"></script>
+    <script defer src="./jslint_wrapper_codemirror.js"></script>
+<style>
+body {
+    background: #bbb;
+    color: #333;
+    font-family: sans-serif;
+    margin: 20px;
+}
+.JSLINT_.JSLINT_REPORT_ {
+    margin-top: 20px;
+}
+</style>
+</head>
+<body>
+    <h1>CodeMirror: JSLint Demo</h1>
+    <h3>
+This demo will auto-lint the code below, and auto-generate a report as you type.
+    </h3>
+
+<!-- Container for codemirror-editor. -->
+
+    <textarea id="editor1">console.log('hello world');</textarea>
+
+<!-- Container for jslint-report. -->
+
+    <div class="JSLINT_ JSLINT_REPORT_"></div>
+<script type=module>
+window.addEventListener("load", function () {
+
+// Initialize codemirror-editor.
+
+    let editor = window.CodeMirror.fromTextArea(document.getElementById(
+        "editor1"
+    ), {
+        gutters: [
+            "CodeMirror-lint-markers"
+        ],
+        indentUnit: 4,
+        lineNumbers: true,
+        lint: {
+
+// Enable auto-lint.
+
+            lintOnChange: true,
+
+// Initialize jslint-options here.
+
+            options: {
+                // browser: true,
+                // node: true
+
+// Initialize jslint-globals here.
+
+                globals: [
+                    // "caches",
+                    // "indexedDb"
+                ]
+            }
+        },
+        mode: "javascript"
+    });
+
+// Initialize event-handling before linter is run.
+
+    editor.on("lintJslintBefore", function (/* options */) {
+
+// Modify jslint-options here.
+
+        // options.browser = true;
+        // options.node = true;
+
+// Modify jslint-globals here.
+
+        // options.globals = [
+        //     "caches",
+        //     "indexedDb"
+        // ];
+        return;
+    });
+
+// Initialize event-handling after linter is run.
+
+    editor.on("lintJslintAfter", function (options) {
+
+// Generate jslint-report from options.result.
+
+        document.querySelector(
+            ".JSLINT_REPORT_"
+        ).innerHTML = window.jslint.jslint_report(options.result);
+    });
+
+// Manually trigger linter.
+
+    editor.performLint();
+});
+</script>
+</body>
+</html>

--- a/jslint_wrapper_codemirror.html
+++ b/jslint_wrapper_codemirror.html
@@ -29,6 +29,8 @@ body {
 }
 </style>
 </head>
+
+
 <body>
     <h1>CodeMirror: JSLint Demo</h1>
     <h3>
@@ -42,11 +44,10 @@ This demo will auto-lint the code below, and auto-generate a report as you type.
 <!-- Container for jslint-report. -->
 
     <div class="JSLINT_ JSLINT_REPORT_"></div>
+
+
 <script type=module>
 window.addEventListener("load", function () {
-
-// Initialize codemirror-editor.
-
     let editor = window.CodeMirror.fromTextArea(document.getElementById(
         "editor1"
     ), {
@@ -56,19 +57,10 @@ window.addEventListener("load", function () {
         indentUnit: 4,
         lineNumbers: true,
         lint: {
-
-// Enable auto-lint.
-
-            lintOnChange: true,
-
-// Initialize jslint-options here.
-
+            lintOnChange: true, // Enable auto-lint.
             options: {
                 // browser: true,
                 // node: true
-
-// Initialize jslint-globals here.
-
                 globals: [
                     // "caches",
                     // "indexedDb"
@@ -81,14 +73,8 @@ window.addEventListener("load", function () {
 // Initialize event-handling before linter is run.
 
     editor.on("lintJslintBefore", function (/* options */) {
-
-// Modify jslint-options here.
-
         // options.browser = true;
         // options.node = true;
-
-// Modify jslint-globals here.
-
         // options.globals = [
         //     "caches",
         //     "indexedDb"

--- a/jslint_wrapper_codemirror.js
+++ b/jslint_wrapper_codemirror.js
@@ -30,29 +30,24 @@
 // Example usage:
 /*
 <!DOCTYPE html>
-<link rel="stylesheet" href="https://codemirror.net/lib/codemirror.css">
-<link rel="stylesheet" href="https://codemirror.net/addon/lint/lint.css">
+    <link rel="stylesheet" href="https://codemirror.net/lib/codemirror.css">
+    <link rel="stylesheet" href="https://codemirror.net/addon/lint/lint.css">
+    <script defer src="https://codemirror.net/lib/codemirror.js"></script>
+    <script defer
+        src="https://codemirror.net/mode/javascript/javascript.js"></script>
+    <script defer src="https://codemirror.net/addon/lint/lint.js"></script>
+    <script type="module" src="./jslint.mjs?window_jslint=1"></script>
+    <script defer src="./jslint_wrapper_codemirror.js"></script>
 <textarea id="editor1">console.log('hello world');</textarea>
-<script defer
-    src="https://codemirror.net/lib/codemirror.js"></script>
-<script defer
-    src="https://codemirror.net/mode/javascript/javascript.js"></script>
-<script defer
-    src="https://codemirror.net/addon/lint/lint.js"></script>
-<script type="module"
-    src="./jslint.mjs?jslint_export_global=1"></script>
-<script defer
-    src="./jslint_wrapper_codemirror.js"></script>
-<script>
+<script type=module>
 window.addEventListener("load", function () {
     window.CodeMirror.fromTextArea(document.getElementById(
         "editor1"
     ), {
         gutters: ["CodeMirror-lint-markers"],
+        indentUnit: 4,
         lineNumbers: true,
-        lint: {
-            lintOnChange: true
-        },
+        lint: {lintOnChange: true},
         mode: "javascript"
     });
 });
@@ -95,6 +90,7 @@ window.addEventListener("load", function () {
         return [];
     }
     CodeMirror.registerHelper("lint", "javascript", function (text, options) {
+        let result = jslint.jslint(text, options, options.globals);
 
 // Save JSLint result to global-object, in case its needed again
 // to generate reports.
@@ -103,12 +99,8 @@ window.addEventListener("load", function () {
 //  cm.performLint();
 //  divReport.outerHTML = jslint.jslint_report(window.jslint_result);
 
-        window.jslint_result = jslint.jslint(
-            text,
-            options,
-            options.globals
-        );
-        return window.jslint_result.warnings.map(function ({
+        window.jslint_result = result;
+        return result.warnings.map(function ({
             column,
             line,
             message,

--- a/jslint_wrapper_codemirror.js
+++ b/jslint_wrapper_codemirror.js
@@ -1,0 +1,129 @@
+// This is free and unencumbered software released into the public domain.
+
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+
+// In jurisdictions that recognize copyright laws, the author or authors
+// of this software dedicate any and all copyright interest in the
+// software to the public domain. We make this dedication for the benefit
+// of the public at large and to the detriment of our heirs and
+// successors. We intend this dedication to be an overt act of
+// relinquishment in perpetuity of all present and future rights to this
+// software under copyright law.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+// For more information, please refer to <https://unlicense.org/>
+
+
+// This wrapper will integrate JSLint with CodeMirror's lint.js addon.
+// Requires CodeMirror and JSLint.
+//
+// Example usage:
+/*
+<!DOCTYPE html>
+<link rel="stylesheet" href="https://codemirror.net/lib/codemirror.css">
+<link rel="stylesheet" href="https://codemirror.net/addon/lint/lint.css">
+<textarea id="editor1">console.log('hello world');</textarea>
+<script defer
+    src="https://codemirror.net/lib/codemirror.js"></script>
+<script defer
+    src="https://codemirror.net/mode/javascript/javascript.js"></script>
+<script defer
+    src="https://codemirror.net/addon/lint/lint.js"></script>
+<script type="module"
+    src="./jslint.mjs?jslint_export_global=1"></script>
+<script defer
+    src="./jslint_wrapper_codemirror.js"></script>
+<script>
+window.addEventListener("load", function () {
+    window.CodeMirror.fromTextArea(document.getElementById(
+        "editor1"
+    ), {
+        gutters: ["CodeMirror-lint-markers"],
+        lineNumbers: true,
+        lint: {
+            lintOnChange: true
+        },
+        mode: "javascript"
+    });
+});
+</script>
+</html>
+*/
+
+/*jslint browser devel*/
+/*global CodeMirror define exports jslint module require*/
+/*property
+    Pos, amd, column, error, from, globals, jslint, jslint_result, line, map,
+    message, mode_stop, registerHelper, severity, to, warnings
+*/
+
+(function (mod) {
+    "use strict";
+
+// CommonJS
+
+    if (typeof exports === "object" && typeof module === "object") {
+        mod(require("../../lib/codemirror"));
+
+// AMD
+
+    } else if (typeof define === "function" && define.amd) {
+        define(["../../lib/codemirror"], mod);
+
+// Plain browser env
+
+    } else {
+        mod(CodeMirror);
+    }
+}(function (CodeMirror) {
+    "use strict";
+    if (!window.jslint) {
+        console.error(
+            "Error: window.jslint not defined,"
+            + " CodeMirror JavaScript linting cannot run."
+        );
+        return [];
+    }
+    CodeMirror.registerHelper("lint", "javascript", function (text, options) {
+
+// Save JSLint result to global-object, in case its needed again
+// to generate reports.
+//
+// E.g.:
+//  cm.performLint();
+//  divReport.outerHTML = jslint.jslint_report(window.jslint_result);
+
+        window.jslint_result = jslint.jslint(
+            text,
+            options,
+            options.globals
+        );
+        return window.jslint_result.warnings.map(function ({
+            column,
+            line,
+            message,
+            mode_stop
+        }) {
+            return {
+                from: CodeMirror.Pos(line - 1, column - 1), //jslint-quiet
+                message,
+                severity: (
+                    mode_stop
+                    ? "error"
+                    : "warning"
+                ),
+                to: CodeMirror.Pos(line - 1, column) //jslint-quiet
+            };
+        });
+    });
+}));

--- a/jslint_wrapper_codemirror.js
+++ b/jslint_wrapper_codemirror.js
@@ -96,7 +96,15 @@ window.addEventListener("load", function () {
     ) {
         let result;
 
-// Emit <options> in case its needs updating before being passed to jslint.
+// Emit <options> before linter is run, so it can be modified
+// before passing to jslint.
+//
+// Example usage:
+//  editor.on("lintJslintBefore", function (options) {
+//      options.browser = true;
+//      options.node = true;
+//      options.globals = ["caches", "indexedDb"];
+//  });
 
         options.source = source;
         CodeMirror.signal(editor, "lintJslintBefore", options);
@@ -105,13 +113,11 @@ window.addEventListener("load", function () {
 
         result = jslint.jslint(source, options, options.globals);
 
-// Emit <result> in case its needed again to generate reports.
+// Emit <result> after linter is run, so it can be used to generate reports.
 //
-// E.g.:
-//  editor.on("lintJslintAfter", function ({
-//      result
-//  }) {
-//      divReport.innerHTML = jslint.jslint_report(result);
+// Example usage:
+//  editor.on("lintJslintAfter", function (options) {
+//      divReport.innerHTML = jslint.jslint_report(options.result);
 //  });
 
         options.result = result;

--- a/jslint_wrapper_vscode.js
+++ b/jslint_wrapper_vscode.js
@@ -24,7 +24,15 @@
 // For more information, please refer to <https://unlicense.org/>
 
 
-/*jslint beta node*/
+/*jslint beta, node*/
+/*property
+    Diagnostic, DiagnosticSeverity, ProgressLocation, Warning, Window, activate,
+    cancellable, character, clear, column, commands, createDiagnosticCollection,
+    document, end, exports, getText, increment, jslint, languages, line,
+    location, map, message, module, push, readFileSync,
+    registerTextEditorCommand, replace, report, runInNewContext, set, slice,
+    start, subscriptions, title, uri, warnings, window, withProgress
+*/
 
 "use strict";
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "default": "./jslint_wrapper_cjs.cjs",
         "import": "./jslint.mjs"
     },
-    "fileCount": 32,
+    "fileCount": 33,
     "keywords": [
         "coverage-report",
         "javascript",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "default": "./jslint_wrapper_cjs.cjs",
         "import": "./jslint.mjs"
     },
-    "fileCount": 33,
+    "fileCount": 34,
     "keywords": [
         "coverage-report",
         "javascript",

--- a/test.mjs
+++ b/test.mjs
@@ -90,6 +90,41 @@ jstestDescribe((
         });
     });
     jstestIt((
+        "test cli-export-global handling-behavior"
+    ), function () {
+        [
+            "&jslint_export_global=",
+            "&jslint_export_global=12",
+            "&jslint_export_global=1?",
+            "&jslint_export_global=?",
+            "?jslint_export_global=",
+            "?jslint_export_global=12",
+            "?jslint_export_global=1?",
+            "?jslint_export_global=?",
+            "jslint_export_global=1",
+            "jslint_export_global=1&",
+            "jslint_export_global=12",
+            "jslint_export_global=1?"
+        ].forEach(function (import_meta_url) {
+            jslint.jslint_cli({
+                import_meta_url
+            });
+            assertOrThrow(globalThis.jslint === undefined);
+        });
+        [
+            "&jslint_export_global=1",
+            "&jslint_export_global=1&",
+            "?jslint_export_global=1",
+            "?jslint_export_global=1&"
+        ].forEach(function (import_meta_url) {
+            jslint.jslint_cli({
+                import_meta_url
+            });
+            assertOrThrow(globalThis.jslint === jslint);
+            delete globalThis.jslint;
+        });
+    });
+    jstestIt((
         "test cli-cjs-and-invalid-file handling-behavior"
     ), async function () {
         await fsWriteFileWithParents(".test_dir.cjs/touch.txt", "");

--- a/test.mjs
+++ b/test.mjs
@@ -90,21 +90,21 @@ jstestDescribe((
         });
     });
     jstestIt((
-        "test cli-export-global handling-behavior"
+        "test cli-window-jslint handling-behavior"
     ), function () {
         [
-            "&jslint_export_global=",
-            "&jslint_export_global=12",
-            "&jslint_export_global=1?",
-            "&jslint_export_global=?",
-            "?jslint_export_global=",
-            "?jslint_export_global=12",
-            "?jslint_export_global=1?",
-            "?jslint_export_global=?",
-            "jslint_export_global=1",
-            "jslint_export_global=1&",
-            "jslint_export_global=12",
-            "jslint_export_global=1?"
+            "&window_jslint=",
+            "&window_jslint=12",
+            "&window_jslint=1?",
+            "&window_jslint=?",
+            "?window_jslint=",
+            "?window_jslint=12",
+            "?window_jslint=1?",
+            "?window_jslint=?",
+            "window_jslint=1",
+            "window_jslint=1&",
+            "window_jslint=12",
+            "window_jslint=1?"
         ].forEach(function (import_meta_url) {
             jslint.jslint_cli({
                 import_meta_url
@@ -112,10 +112,10 @@ jstestDescribe((
             assertOrThrow(globalThis.jslint === undefined);
         });
         [
-            "&jslint_export_global=1",
-            "&jslint_export_global=1&",
-            "?jslint_export_global=1",
-            "?jslint_export_global=1&"
+            "&window_jslint=1",
+            "&window_jslint=1&",
+            "?window_jslint=1",
+            "?window_jslint=1&"
         ].forEach(function (import_meta_url) {
             jslint.jslint_cli({
                 import_meta_url


### PR DESCRIPTION
1. this pr exposes the internal code used by jslint to integrate with codemirror editor, for public use

# Quickstart JSLint in CodeMirror
1. Download and save [`jslint.mjs`](https://www.jslint.com/jslint.mjs), [`jslint_wrapper_codemirror.js`](https://www.jslint.com/jslint_wrapper_codemirror.js)
2. Create and serve static html-page below:
```shell <!-- shRunWithScreenshotTxt .artifact/screenshot_sh_jslint_wrapper_codemirror.svg -->
#!/bin/sh

# Copy jslint files.

mkdir -p .artifact/
cp jslint.mjs .artifact/
cp jslint_wrapper_codemirror.js .artifact/

# Create static html-page jslint_wrapper_codemirror.html.

printf '
<!DOCTYPE html>
<html lang="en">
<head>
    <title>CodeMirror: JSLint Demo</title>
    <link rel="stylesheet" href="https://codemirror.net/lib/codemirror.css">
    <link rel="stylesheet" href="https://codemirror.net/addon/lint/lint.css">
    <style>
    body {
        background: lightgray;
        color: darkslategray;
        font-family: sans-serif;
        margin: 0;
        padding: 0 20px;
    }
    body > * {
        margin: 20px 0 0 0;
        padding: 0;
    }
    </style>
</head>
<body>
    <h1>CodeMirror: JSLint Demo</h1>
    <h2>
        This demo will automatically lint code below,
        and generate report as you type.
    </h2>
    <textarea id="editor1">console.log('"'"'hello world'"'"');</textarea>
    <div><div id="JSLINT_REPORT_HTML"></div></div>
    <script defer
        src="https://codemirror.net/lib/codemirror.js"></script>
    <script defer
        src="https://codemirror.net/mode/javascript/javascript.js"></script>
    <script defer
        src="https://codemirror.net/addon/lint/lint.js"></script>
    <script type="module"
        src="./jslint.mjs?jslint_export_global=1"></script>
    <script defer
        src="./jslint_wrapper_codemirror.js"></script>
<script type=module>
window.addEventListener("load", function () {
    let editor = window.CodeMirror.fromTextArea(document.getElementById(
        "editor1"
    ), {
        gutters: ["CodeMirror-lint-markers"],
        indentUnit: 4,
        indentWithTabs: false,
        lineNumbers: true,
        lint: {
            lintOnChange: false
        },
        mode: "javascript"
    });
    function onChange() {
        let state = editor.state.lint;
        if (!state) {
            return;
        }
        clearTimeout(state.timeout);
        state.timeout = setTimeout(function () {
            editor.performLint();
            document.getElementById(
                "JSLINT_REPORT_HTML"
            ).outerHTML = window.jslint.jslint_report(window.jslint_result);
        }, state.options.delay);
    }
    editor.on("change", onChange);
    onChange();
});
</script>
</body>
</html>
' > .artifact/jslint_wrapper_codemirror.html

```
- screenshot

![image](https://user-images.githubusercontent.com/280571/166131618-38c71b5b-8551-4ebe-b2e4-fb6c99813c3b.png)


2.
- allow jslint.mjs to auto-export itself to globalThis when given search-param `?jslint_export_global=1`
This is useful for pre-ESM-era browser-scripts that rely on window.jslint
