### PR TITLE
coverage-report - add function globPathExclude() to revamp coverage-report to exclude files using glob-pattern-matching

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -242,9 +242,7 @@ import moduleFs from "fs";
                     + [
                         jslint.assertOrThrow,
                         jslint.fsWriteFileWithParents,
-                        jslint.globPathExclude,
-                        jslint.globPathInclude,
-                        jslint.globPathToRegexp,
+                        jslint.globExclude,
                         jslint.htmlEscape,
                         jslint.moduleFsInit,
                         jslint.v8CoverageListMerge,

--- a/.ci.sh
+++ b/.ci.sh
@@ -242,6 +242,9 @@ import moduleFs from "fs";
                     + [
                         jslint.assertOrThrow,
                         jslint.fsWriteFileWithParents,
+                        jslint.globPathExclude,
+                        jslint.globPathInclude,
+                        jslint.globPathToRegexp,
                         jslint.htmlEscape,
                         jslint.moduleFsInit,
                         jslint.v8CoverageListMerge,

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ package-lock.json
 temp*
 tmp
 undefined
-
 !.gitconfig
 !.github
 !.gitignore

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 *
 .*
 node_modules
-
 !.npmignore
 !CHANGELOG.md
 !LICENSE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - perf - improve performance by hoisting inlined regexps out of loops and subfunctions
 
 # v2022.5.1-beta
+- coverage-report - add functions globPathExclude(), globPathInclude(), globPathToRegexp() to revamp coverage-report to exclude files using glob-pattern-matching
 - add codemirror-example-file jslint_wrapper_codemirror.html
 - update codemirror-editor to v5.65.3
 - wrapper - add jslint-addon for codemirror

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - perf - improve performance by hoisting inlined regexps out of loops and subfunctions
 
 # v2022.5.1-beta
+- coverage-report - disable default-coverage of directory `node_modules`, but allow override with cli-option `--include-node-modules=1`
 - coverage-report - add function globExclude() to revamp coverage-report to exclude files using glob-pattern-matching
 - add codemirror-example-file jslint_wrapper_codemirror.html
 - update codemirror-editor to v5.65.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - perf - improve performance by hoisting inlined regexps out of loops and subfunctions
 
 # v2022.5.1-beta
-- coverage-report - add functions globPathExclude(), globPathInclude(), globPathToRegexp() to revamp coverage-report to exclude files using glob-pattern-matching
+- coverage-report - add function globExclude() to revamp coverage-report to exclude files using glob-pattern-matching
 - add codemirror-example-file jslint_wrapper_codemirror.html
 - update codemirror-editor to v5.65.3
 - wrapper - add jslint-addon for codemirror

--- a/README.md
+++ b/README.md
@@ -269,21 +269,25 @@ npm install
 
 node ../jslint.mjs \
     v8_coverage_report=../.artifact/coverage_sqlite3_sh/ \
-    --exclude=**/node_modules/**/* \
-    --exclude=node_modules/**/* \
-    --exclude=tes[!0-9A-Z_a-z-]/**/* \
-    --exclude=tes[0-9A-Z_a-z-]/**/* \
-    --exclude=tes[^0-9A-Z_a-z-]/**/* \
-    --exclude=test/**/* \
+    --exclude=**/node_modules/ \
+    --exclude=node_modules/ \
+    --exclude=tes?/ \
+    --exclude=tes[!0-9A-Z_a-z-]/ \
+    --exclude=tes[0-9A-Z_a-z-]/ \
+    --exclude=tes[^0-9A-Z_a-z-]/ \
     --exclude=test/**/*.js \
     --exclude=test/suppor*/*elper.js \
     --exclude=test/suppor?/?elper.js \
     --exclude=test/support/helper.js \
-    --include=** \
-    --include=li*/* \
-    --include=li?/* \
+    --include=**/*.cjs \
+    --include=**/*.js \
+    --include=**/*.mjs \
+    --include=li*/*.js \
+    --include=li?/*.js \
     --include=lib/* \
+    --include=lib/**/*.js \
     --include=lib/*.js \
+    --include=lib/sqlite3.js \
     npm run test
 ```
 - shell output
@@ -323,21 +327,25 @@ import jslint from "../jslint.mjs";
     await jslint.v8CoverageReportCreate({
         coverageDir: "../.artifact/coverage_sqlite3_js/",
         processArgv: [
-            "--exclude=**/node_modules/**/*",
-            "--exclude=node_modules/**/*",
-            "--exclude=tes[!0-9A-Z_a-z-]/**/*",
-            "--exclude=tes[0-9A-Z_a-z-]/**/*",
-            "--exclude=tes[^0-9A-Z_a-z-]/**/*",
-            "--exclude=test/**/*",
+            "--exclude=**/node_modules/",
+            "--exclude=node_modules/",
+            "--exclude=tes?/",
+            "--exclude=tes[!0-9A-Z_a-z-]/",
+            "--exclude=tes[0-9A-Z_a-z-]/",
+            "--exclude=tes[^0-9A-Z_a-z-]/",
             "--exclude=test/**/*.js",
             "--exclude=test/suppor*/*elper.js",
             "--exclude=test/suppor?/?elper.js",
             "--exclude=test/support/helper.js",
-            "--include=**",
-            "--include=li*/*",
-            "--include=li?/*",
+            "--include=**/*.cjs",
+            "--include=**/*.js",
+            "--include=**/*.mjs",
+            "--include=li*/*.js",
+            "--include=li?/*.js",
             "--include=lib/*",
+            "--include=lib/**/*.js",
             "--include=lib/*.js",
+            "--include=lib/sqlite3.js",
             "npm", "run", "test"
         ]
     });

--- a/README.md
+++ b/README.md
@@ -269,25 +269,23 @@ npm install
 
 node ../jslint.mjs \
     v8_coverage_report=../.artifact/coverage_sqlite3_sh/ \
-    --exclude=**/node_modules/ \
-    --exclude=node_modules/ \
-    --exclude=tes?/ \
-    --exclude=tes[!0-9A-Z_a-z-]/ \
-    --exclude=tes[0-9A-Z_a-z-]/ \
-    --exclude=tes[^0-9A-Z_a-z-]/ \
-    --exclude=test/**/*.js \
-    --exclude=test/suppor*/*elper.js \
-    --exclude=test/suppor?/?elper.js \
-    --exclude=test/support/helper.js \
-    --include=**/*.cjs \
-    --include=**/*.js \
-    --include=**/*.mjs \
-    --include=li*/*.js \
-    --include=li?/*.js \
-    --include=lib/* \
-    --include=lib/**/*.js \
-    --include=lib/*.js \
-    --include=lib/sqlite3.js \
+        --exclude=tes?/ \
+        --exclude=tes[!0-9A-Z_a-z-]/ \
+        --exclude=tes[0-9A-Z_a-z-]/ \
+        --exclude=tes[^0-9A-Z_a-z-]/ \
+        --exclude=test/**/*.js \
+        --exclude=test/suppor*/*elper.js \
+        --exclude=test/suppor?/?elper.js \
+        --exclude=test/support/helper.js \
+        --include=**/*.cjs \
+        --include=**/*.js \
+        --include=**/*.mjs \
+        --include=li*/*.js \
+        --include=li?/*.js \
+        --include=lib/ \
+        --include=lib/**/*.js \
+        --include=lib/*.js \
+        --include=lib/sqlite3.js \
     npm run test
 ```
 - shell output
@@ -327,8 +325,6 @@ import jslint from "../jslint.mjs";
     await jslint.v8CoverageReportCreate({
         coverageDir: "../.artifact/coverage_sqlite3_js/",
         processArgv: [
-            "--exclude=**/node_modules/",
-            "--exclude=node_modules/",
             "--exclude=tes?/",
             "--exclude=tes[!0-9A-Z_a-z-]/",
             "--exclude=tes[0-9A-Z_a-z-]/",
@@ -342,7 +338,7 @@ import jslint from "../jslint.mjs";
             "--include=**/*.mjs",
             "--include=li*/*.js",
             "--include=li?/*.js",
-            "--include=lib/*",
+            "--include=lib/",
             "--include=lib/**/*.js",
             "--include=lib/*.js",
             "--include=lib/sqlite3.js",

--- a/README.md
+++ b/README.md
@@ -269,9 +269,21 @@ npm install
 
 node ../jslint.mjs \
     v8_coverage_report=../.artifact/coverage_sqlite3_sh/ \
-    --exclude-node-modules=true \
-    --exclude=test/foo.js,test/bar.js \
-    --exclude=test/baz.js \
+    --exclude=**/node_modules/**/* \
+    --exclude=node_modules/**/* \
+    --exclude=tes[!0-9A-Z_a-z-]/**/* \
+    --exclude=tes[0-9A-Z_a-z-]/**/* \
+    --exclude=tes[^0-9A-Z_a-z-]/**/* \
+    --exclude=test/**/* \
+    --exclude=test/**/*.js \
+    --exclude=test/suppor*/*elper.js \
+    --exclude=test/suppor?/?elper.js \
+    --exclude=test/support/helper.js \
+    --include=** \
+    --include=li*/* \
+    --include=li?/* \
+    --include=lib/* \
+    --include=lib/*.js \
     npm run test
 ```
 - shell output
@@ -311,8 +323,21 @@ import jslint from "../jslint.mjs";
     await jslint.v8CoverageReportCreate({
         coverageDir: "../.artifact/coverage_sqlite3_js/",
         processArgv: [
-            "--include=lib/sqlite3-binding.js,lib/sqlite3.js",
-            "--include=lib/trace.js",
+            "--exclude=**/node_modules/**/*",
+            "--exclude=node_modules/**/*",
+            "--exclude=tes[!0-9A-Z_a-z-]/**/*",
+            "--exclude=tes[0-9A-Z_a-z-]/**/*",
+            "--exclude=tes[^0-9A-Z_a-z-]/**/*",
+            "--exclude=test/**/*",
+            "--exclude=test/**/*.js",
+            "--exclude=test/suppor*/*elper.js",
+            "--exclude=test/suppor?/?elper.js",
+            "--exclude=test/support/helper.js",
+            "--include=**",
+            "--include=li*/*",
+            "--include=li?/*",
+            "--include=lib/*",
+            "--include=lib/*.js",
             "npm", "run", "test"
         ]
     });

--- a/index.html
+++ b/index.html
@@ -1196,15 +1196,16 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
 <div class="JSLINT_ JSLINT_REPORT_"></div>
 <script type="module">
 // browser.mjs
-// Original Author: Douglas Crockford (https://www.jslint.com).
 
+// The Unlicense
+//
 // This is free and unencumbered software released into the public domain.
-
+//
 // Anyone is free to copy, modify, publish, use, compile, sell, or
 // distribute this software, either in source code form or as a compiled
 // binary, for any purpose, commercial or non-commercial, and by any
 // means.
-
+//
 // In jurisdictions that recognize copyright laws, the author or authors
 // of this software dedicate any and all copyright interest in the
 // software to the public domain. We make this dedication for the benefit
@@ -1212,7 +1213,7 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
 // successors. We intend this dedication to be an overt act of
 // relinquishment in perpetuity of all present and future rights to this
 // software under copyright law.
-
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -1220,7 +1221,7 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
 // OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
-
+//
 // For more information, please refer to <https://unlicense.org/>
 
 

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -1,13 +1,15 @@
 // #!/usr/bin/env node
 // JSLint
 
+// The Unlicense
+//
 // This is free and unencumbered software released into the public domain.
-
+//
 // Anyone is free to copy, modify, publish, use, compile, sell, or
 // distribute this software, either in source code form or as a compiled
 // binary, for any purpose, commercial or non-commercial, and by any
 // means.
-
+//
 // In jurisdictions that recognize copyright laws, the author or authors
 // of this software dedicate any and all copyright interest in the
 // software to the public domain. We make this dedication for the benefit
@@ -15,7 +17,7 @@
 // successors. We intend this dedication to be an overt act of
 // relinquishment in perpetuity of all present and future rights to this
 // software under copyright law.
-
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -23,7 +25,7 @@
 // OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
-
+//
 // For more information, please refer to <https://unlicense.org/>
 
 

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -1,6 +1,5 @@
 // #!/usr/bin/env node
 // JSLint
-// Original Author: Douglas Crockford (https://www.jslint.com).
 
 // This is free and unencumbered software released into the public domain.
 
@@ -93,7 +92,9 @@
 
 /*jslint beta, node*/
 /*property
+    globPathExclude, globPathInclude, globPathToRegexp,
     import_meta_url,
+    values,
     JSLINT_BETA, NODE_V8_COVERAGE, a, all, argv, arity, artifact,
     assertErrorThrownAsync, assertJsonEqual, assertOrThrow, assign, async, b,
     beta, bitwise, block, body, browser, c, calls, catch, catch_list,
@@ -350,6 +351,199 @@ async function fsWriteFileWithParents(pathname, data) {
         await moduleFs.promises.writeFile(pathname, data);
     }
     console.error("wrote file " + pathname);
+}
+
+function globPathExclude(patternList, pathList, mode) {
+
+// This function will exclude paths in <pathList> that match glob-patterns in
+// <patternList>.
+
+    pathList.forEach(function (path) {
+        path.replace((
+            /[\u0000-\u0007]/g
+        ), function (chr) {
+            throw new Error(
+                "Weird character "
+                + JSON.stringify(chr)
+                + " found in path "
+                + JSON.stringify(path)
+            );
+        });
+    });
+    pathList = pathList.join("\n");
+
+// Exclude paths in <pathList> that don't match glob-patterns in <patternList>.
+
+    if (mode === "include") {
+        patternList.forEach(function (pattern) {
+            pathList = pathList.replace(globPathToRegexp(pattern), "\u0000$&");
+        });
+        pathList = pathList.replace((
+            /^[^\u0000].*/gm
+        ), "");
+        pathList = pathList.replace((
+            /^\u0000*/gm
+        ), "");
+
+// Exclude paths in <pathList> that match glob-patterns in <patternList>.
+
+    } else {
+        patternList.forEach(function (pattern) {
+            pathList = pathList.replace(globPathToRegexp(pattern), "");
+        });
+    }
+    pathList = pathList.split("\n").filter(function (elem) {
+        return elem;
+    });
+    return pathList;
+}
+
+function globPathInclude(patternList, pathList) {
+
+// This function will exclude paths in <pathList> that don't match
+// glob-patterns in <patternList>.
+
+    return globPathExclude(patternList, pathList, "include");
+}
+
+function globPathToRegexp(pattern) {
+
+// This function will translate glob <pattern> into regexp that javascript can
+// then use to "glob" paths.
+//
+// E.g.:
+//  "*"                         -> /^[^\/]*?$/gm
+//  "**"                        -> /^.*?$/gm
+//  "**/*"                      -> /^.*?$/gm
+//  "**/node_modules/**/*"      -> /^.*?\/node_modules\/.*?$/gm
+//  "?"                         -> /^[^\/]$/gm
+//  "[!0-9A-Za-z-]"             -> /^[^0-9A-Za-z\-]$/gm
+//  "[0-9A-Za-z-]"              -> /^[0-9A-Za-z\-]$/gm
+//  "[^0-9A-Za-z-]"             -> /^[^0-9A-Za-z\-]$/gm
+//  "tes[!0-9A-Z_a-z-]/**/*"    -> /^tes[^0-9A-Z_a-z\-]\/.*?$/gm
+//  "test/suppor?/?elper.js"    -> /^test\/suppor[^\/]\/[^\/]elper\.js$/gm
+//  "test/suppor*/*elper.js"    -> /^test\/suppor[^\/]*?\/[^\/]*?elper\.js$/gm
+//  "test/support/helper.js"    -> /^test\/support\/helper\.js$/gm
+
+    let ii = 0;
+    let isClass = false;
+    let strClass = "";
+    let strRegex = "";
+    pattern.replace((
+        /[\u0000-\u0007]/g
+    ), function (chr) {
+        throw new Error(
+            "Weird character "
+            + JSON.stringify(chr)
+            + " found in pattern "
+            + JSON.stringify(pattern)
+        );
+    });
+    pattern = pattern.replace((
+        /\/{2,}/g
+    ), "/");
+    pattern = pattern.replace((
+        /\*{3,}/g
+    ), "**");
+    pattern.replace((
+        /\\\\|\\\[|\\\]|\[|\]|./g
+    ), function (match0) {
+        switch (match0) {
+        case "[":
+            if (isClass) {
+                strClass += "[";
+                return;
+            }
+            strClass += "\u0000";
+            strRegex += "\u0000";
+            isClass = true;
+            return;
+        case "]":
+            if (isClass) {
+                isClass = false;
+                return;
+            }
+            strRegex += "]";
+            return;
+        default:
+            if (isClass) {
+                strClass += match0;
+                return;
+            }
+            strRegex += match0;
+        }
+        return "";
+    });
+    strClass += "\u0000";
+
+// An expression "[!...]" matches a single character, namely any character that
+// is not matched by the expression obtained by removing the first '!' from it.
+// (Thus, "[!a-]" matches any single character except 'a', and '-'.)
+
+    strClass = strClass.replace((
+        /\u0000!/g
+    ), "\u0000^");
+
+// One may include '-' in its literal meaning by making it the first or last
+// character between the brackets.
+
+    strClass = strClass.replace((
+        /\u0000-/g
+    ), "\u0000\\-");
+    strClass = strClass.replace((
+        /-\u0000/g
+    ), "\\-\u0000");
+
+// Escape brackets '[', ']' in character class.
+
+    strClass = strClass.replace((
+        /[\[\]]/g
+    ), "\\$&");
+
+// https://stackoverflow.com/questions/3561493
+// /is-there-a-regexp-escape-function-in-javascript
+// $()*+-./?[\]^{|}
+
+    strRegex = strRegex.replace((
+        // /[$()*+-.\/?\[\\\]\^{|}]/g
+        /[$()*+.?\[\\\]\^{|}]/g
+    ), "\\$&");
+
+// Escape path-delimiter '/'.
+
+// Expand wildcards '*', '*', '?'.
+
+    strRegex = strRegex.replace((
+        /(?:\\\*){2,}\/(?:\\\*){1,}/gm
+    ), ".*?");
+    strRegex = strRegex.replace((
+        /(^|\/)\\\*\\\*(\/|$)/gm
+    ), "$1.*?$2");
+    strRegex = strRegex.replace((
+        /(?:\\\*){1,}/g
+    ), "[^\\/]*?");
+    strRegex = strRegex.replace((
+        /\\\?/g
+    ), "[^\\/]");
+
+// Merge strClass into strRegex.
+
+    ii = 0;
+    strClass = strClass.split("\u0000");
+    strRegex = strRegex.replace((
+        /\u0000/g
+    ), function () {
+        ii += 1;
+        if (strClass[ii] === "") {
+            return "";
+        }
+        return "[" + strClass[ii] + "]";
+    });
+
+// Change strRegex from text to regexp.
+
+    strRegex = new RegExp("^" + strRegex + "$", "gm");
+    return strRegex;
 }
 
 function htmlEscape(str) {
@@ -10390,9 +10584,8 @@ async function v8CoverageReportCreate({
     let cwd;
     let exitCode = 0;
     let fileDict;
-    let fileExcludeList = [];
-    let fileIncludeList = [];
-    let fileIncludeNodeModules;
+    let pathExcludeList = [];
+    let pathIncludeList = [];
     let processArgElem;
     let promiseList = [];
     let v8CoverageObj;
@@ -10575,6 +10768,7 @@ body {
         }
         txtBorder = (
             "+" + "-".repeat(padPathname + 2) + "+"
+            + "-".repeat(padLines + 2) + "+"
             + "-".repeat(padLines + 2) + "+\n"
         );
         txt = "";
@@ -10582,7 +10776,8 @@ body {
         txt += txtBorder;
         txt += (
             "| " + String("Files covered").padEnd(padPathname, " ") + " | "
-            + String("Lines").padStart(padLines, " ") + " |\n"
+            + String("Lines").padStart(padLines, " ") + " | "
+            + String("Remaining").padStart(padLines, " ") + " |\n"
         );
         txt += txtBorder;
         fileList.forEach(function ({
@@ -10662,7 +10857,8 @@ body {
                 + String("./" + pathname).padEnd(padPathname, " ") + " | "
                 + String(
                     modeCoverageIgnoreFile + " " + coveragePct + " %"
-                ).padStart(padLines, " ") + " |\n"
+                ).padStart(padLines, " ") + " | "
+                + " ".repeat(padLines) + " |\n"
             );
             txt += (
                 "| " + "*".repeat(
@@ -10670,6 +10866,9 @@ body {
                 ).padEnd(padPathname, "_") + " | "
                 + String(
                     linesCovered + " / " + linesTotal
+                ).padStart(padLines, " ") + " | "
+                + String(
+                    (linesTotal - linesCovered) + " / " + linesTotal
                 ).padStart(padLines, " ") + " |\n"
             );
             txt += txtBorder;
@@ -10833,21 +11032,6 @@ ${String(count || "-0").padStart(7, " ")}
         ), txt));
     }
 
-    function pathnameRelativeCwd(pathname) {
-
-// This function will if <pathname> is inside <cwd>,
-// return it relative to <cwd>, else empty-string.
-
-        pathname = modulePath.resolve(pathname).replace((
-            /\\/g
-        ), "/");
-        if (!pathname.startsWith(cwd)) {
-            return;
-        }
-        pathname = pathname.slice(cwd.length);
-        return pathname;
-    }
-
 /*
 function sentinel() {}
 */
@@ -10879,28 +11063,18 @@ function sentinel() {}
         processArgElem[1] = processArgElem.slice(1).join("=");
         switch (processArgElem[0]) {
 
-// PR-371 - add cli-option `--exclude=aa,bb`
+// PR-371
+// Add cli-option `--exclude=aa,bb`.
 
         case "--exclude":
-            fileExcludeList = fileExcludeList.concat(
-                processArgElem[1].split(",")
-            );
+            pathExcludeList.push(processArgElem[1]);
             break;
 
-// PR-371 - add cli-option `--exclude-node-modules=false`
-
-        case "--exclude-node-modules":
-            fileIncludeNodeModules = (
-                /0|false|null|undefined/
-            ).test(processArgElem[1]);
-            break;
-
-// PR-371 - add cli-option `--include=aa,bb`
+// PR-371
+// Add cli-option `--include=aa,bb`
 
         case "--include":
-            fileIncludeList = fileIncludeList.concat(
-                processArgElem[1].split(",")
-            );
+            pathIncludeList.push(processArgElem[1]);
             break;
         }
     }
@@ -10954,51 +11128,47 @@ function sentinel() {}
         ).test(file);
     });
     v8CoverageObj = await Promise.all(v8CoverageObj.map(async function (file) {
-        let data = await moduleFs.promises.readFile(coverageDir + file, "utf8");
+        let data;
+        let pathDict = Object.create(null);
+        let pathList = [];
+        data = await moduleFs.promises.readFile(coverageDir + file, "utf8");
         data = JSON.parse(data);
-        data.result = data.result.filter(function (scriptCov) {
+        data.result.forEach(function (scriptCov) {
             let pathname = scriptCov.url;
-
-// Filter out internal coverages.
-
             if (!pathname.startsWith("file:///")) {
                 return;
             }
 
 // Normalize pathname.
 
-            pathname = pathnameRelativeCwd(moduleUrl.fileURLToPath(pathname));
-            if (
+            pathname = moduleUrl.fileURLToPath(pathname);
+            pathname = modulePath.resolve(pathname).replace((
+                /\\/g
+            ), "/");
 
 // Filter files outside of cwd.
 
-                !pathname
-                || pathname.startsWith("[")
-
-// PR-371 - Filter directory node_modules.
-
-                || (
-                    !fileIncludeNodeModules
-                    && (
-                        /(?:^|\/)node_modules\//m
-                    ).test(pathname)
-                )
-
-// PR-371 - Filter fileExcludeList.
-
-                || fileExcludeList.indexOf(pathname) >= 0
-
-// PR-371 - Filter fileIncludeList.
-
-                || (
-                    fileIncludeList.length > 0
-                    && fileIncludeList.indexOf(pathname) === -1
-                )
-            ) {
+            if (!pathname.startsWith(cwd)) {
                 return;
             }
+
+// Normalize pathname relative to cwd.
+
+            pathname = pathname.slice(cwd.length);
             scriptCov.url = pathname;
-            return true;
+            pathDict[pathname] = scriptCov;
+        });
+
+// PR-xxx
+// Filter files by glob-patterns in pathExcludeList, pathIncludeList.
+
+        pathList = Object.keys(pathDict);
+        if (pathIncludeList.length > 0) {
+            pathList = globPathInclude(pathIncludeList, pathList);
+        }
+        pathList = globPathExclude(pathExcludeList, pathList);
+        data.result = pathList.map(function (pathname) {
+            return pathDict[pathname];
         });
         return data;
     }));
@@ -11007,7 +11177,7 @@ function sentinel() {}
 
     v8CoverageObj = v8CoverageListMerge(v8CoverageObj);
 
-// debug v8CoverageObj.
+// Debug v8CoverageObj.
 
     await fsWriteFileWithParents(
         coverageDir + "v8_coverage_merged.json",
@@ -11147,6 +11317,9 @@ jslint_export = Object.freeze(Object.assign(jslint, {
     assertOrThrow,
     debugInline,
     fsWriteFileWithParents,
+    globPathExclude,
+    globPathInclude,
+    globPathToRegexp,
     htmlEscape,
     jslint,
     jslint_apidoc,

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
 
+## The Unlicense
+##
 ## This is free and unencumbered software released into the public domain.
-
+##
 ## Anyone is free to copy, modify, publish, use, compile, sell, or
 ## distribute this software, either in source code form or as a compiled
 ## binary, for any purpose, commercial or non-commercial, and by any
 ## means.
-
+##
 ## In jurisdictions that recognize copyright laws, the author or authors
 ## of this software dedicate any and all copyright interest in the
 ## software to the public domain. We make this dedication for the benefit
@@ -14,7 +16,7 @@
 ## successors. We intend this dedication to be an overt act of
 ## relinquishment in perpetuity of all present and future rights to this
 ## software under copyright law.
-
+##
 ## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 ## EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 ## MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -22,7 +24,7 @@
 ## OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ## ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 ## OTHER DEALINGS IN THE SOFTWARE.
-
+##
 ## For more information, please refer to <https://unlicense.org/>
 
 

--- a/jslint_wrapper_cjs.cjs
+++ b/jslint_wrapper_cjs.cjs
@@ -1,10 +1,12 @@
+// The Unlicense
+//
 // This is free and unencumbered software released into the public domain.
-
+//
 // Anyone is free to copy, modify, publish, use, compile, sell, or
 // distribute this software, either in source code form or as a compiled
 // binary, for any purpose, commercial or non-commercial, and by any
 // means.
-
+//
 // In jurisdictions that recognize copyright laws, the author or authors
 // of this software dedicate any and all copyright interest in the
 // software to the public domain. We make this dedication for the benefit
@@ -12,7 +14,7 @@
 // successors. We intend this dedication to be an overt act of
 // relinquishment in perpetuity of all present and future rights to this
 // software under copyright law.
-
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -20,7 +22,7 @@
 // OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
-
+//
 // For more information, please refer to <https://unlicense.org/>
 
 

--- a/jslint_wrapper_codemirror.js
+++ b/jslint_wrapper_codemirror.js
@@ -1,10 +1,12 @@
+// The Unlicense
+//
 // This is free and unencumbered software released into the public domain.
-
+//
 // Anyone is free to copy, modify, publish, use, compile, sell, or
 // distribute this software, either in source code form or as a compiled
 // binary, for any purpose, commercial or non-commercial, and by any
 // means.
-
+//
 // In jurisdictions that recognize copyright laws, the author or authors
 // of this software dedicate any and all copyright interest in the
 // software to the public domain. We make this dedication for the benefit
@@ -12,7 +14,7 @@
 // successors. We intend this dedication to be an overt act of
 // relinquishment in perpetuity of all present and future rights to this
 // software under copyright law.
-
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -20,7 +22,7 @@
 // OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
-
+//
 // For more information, please refer to <https://unlicense.org/>
 
 

--- a/jslint_wrapper_vim.vim
+++ b/jslint_wrapper_vim.vim
@@ -1,10 +1,12 @@
+"" The Unlicense
+""
 "" This is free and unencumbered software released into the public domain.
-
+""
 "" Anyone is free to copy, modify, publish, use, compile, sell, or
 "" distribute this software, either in source code form or as a compiled
 "" binary, for any purpose, commercial or non-commercial, and by any
 "" means.
-
+""
 "" In jurisdictions that recognize copyright laws, the author or authors
 "" of this software dedicate any and all copyright interest in the
 "" software to the public domain. We make this dedication for the benefit
@@ -12,7 +14,7 @@
 "" successors. We intend this dedication to be an overt act of
 "" relinquishment in perpetuity of all present and future rights to this
 "" software under copyright law.
-
+""
 "" THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 "" EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 "" MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -20,7 +22,7 @@
 "" OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 "" ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 "" OTHER DEALINGS IN THE SOFTWARE.
-
+""
 "" For more information, please refer to <https://unlicense.org/>
 
 

--- a/jslint_wrapper_vscode.js
+++ b/jslint_wrapper_vscode.js
@@ -1,10 +1,12 @@
+// The Unlicense
+//
 // This is free and unencumbered software released into the public domain.
-
+//
 // Anyone is free to copy, modify, publish, use, compile, sell, or
 // distribute this software, either in source code form or as a compiled
 // binary, for any purpose, commercial or non-commercial, and by any
 // means.
-
+//
 // In jurisdictions that recognize copyright laws, the author or authors
 // of this software dedicate any and all copyright interest in the
 // software to the public domain. We make this dedication for the benefit
@@ -12,7 +14,7 @@
 // successors. We intend this dedication to be an overt act of
 // relinquishment in perpetuity of all present and future rights to this
 // software under copyright law.
-
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -20,7 +22,7 @@
 // OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
-
+//
 // For more information, please refer to <https://unlicense.org/>
 
 

--- a/test.mjs
+++ b/test.mjs
@@ -10,8 +10,7 @@ let {
     assertOrThrow,
     debugInline,
     fsWriteFileWithParents,
-    globPathExclude,
-    globPathToRegexp,
+    globExclude,
     jstestDescribe,
     jstestIt,
     jstestOnExit,
@@ -75,22 +74,166 @@ jstestDescribe((
 });
 
 jstestDescribe((
-    "test globPathXxx handling-behavior"
-), function testBehaviorGlobPathXxx() {
+    "test globXxx handling-behavior"
+), function testBehaviorGlobXxx() {
     jstestIt((
-        "test globPathExclude-error handling-behavior"
+        "test globAssertNotWeird-error handling-behavior"
     ), async function () {
         await assertErrorThrownAsync(function () {
-            return globPathExclude(
-                [],
-                [
-                    "\u0000"
+            return globExclude({
+                pathnameList: [
+                    "aa",
+                    "cc/\u0000/dd",
+                    "bb"
                 ]
-            );
-        }, "Weird character \"\\\\u0000\" found in path");
+            });
+        }, `Weird character "\\\\u0000" found in pathname "cc/\\\\u0000/dd"`);
     });
     jstestIt((
-        "test globPathToRegexp handling-behavior"
+        "test globExclude handling-behavior"
+    ), function () {
+        let pathnameList = [
+            ".dockerignore",
+            ".eslintrc.js",
+            ".gitignore",
+            ".npmignore",
+            ".travis.yml",
+            "CHANGELOG.md",
+            "CONTRIBUTING.md",
+            "Dockerfile",
+            "LICENSE",
+            "Makefile",
+            "README.md",
+            "appveyor.yml",
+            "benchmark/insert-transaction.sql",
+            "benchmark/insert.js",
+            "binding.gyp",
+            "cloudformation/ci.template.js",
+            "deps/common-sqlite.gypi",
+            "deps/extract.py",
+            "deps/sqlite-autoconf-3340000.tar.gz",
+            "deps/sqlite3.gyp",
+            "examples/simple-chaining.js",
+            "lib/index.js",
+            "lib/sqlite3-binding.js",
+            "lib/sqlite3.js",
+            "lib/trace.js",
+            "package.json",
+            "scripts/build-appveyor.bat",
+            "scripts/build-local.bat",
+            "scripts/build_against_electron.sh",
+            "scripts/build_against_node.sh",
+            "scripts/build_against_node_webkit.sh",
+            "scripts/build_for_node_webkit.cmd",
+            "scripts/install_node.sh",
+            "scripts/validate_tag.sh",
+            "sqlite3.js",
+            "src/async.h",
+            "src/backup.cc",
+            "src/backup.h",
+            "src/database.cc",
+            "src/database.h",
+            "src/gcc-preinclude.h",
+            "src/macros.h",
+            "src/node_sqlite3.cc",
+            "src/statement.cc",
+            "src/statement.h",
+            "src/threading.h",
+            "test/affected.test.js",
+            "test/backup.test.js",
+            "test/blob.test.js",
+            "test/cache.test.js",
+            "test/constants.test.js",
+            "test/database_fail.test.js",
+            "test/each.test.js",
+            "test/exec.test.js",
+            "test/extension.test.js",
+            "test/fts-content.test.js",
+            "test/interrupt.test.js",
+            "test/issue-108.test.js",
+            "test/json.test.js",
+            "test/map.test.js",
+            "test/named_columns.test.js",
+            "test/named_params.test.js",
+            "test/null_error.test.js",
+            "test/nw/.gitignore",
+            "test/nw/Makefile",
+            "test/nw/index.html",
+            "test/nw/package.json",
+            "test/open_close.test.js",
+            "test/other_objects.test.js",
+            "test/parallel_insert.test.js",
+            "test/prepare.test.js",
+            "test/profile.test.js",
+            "test/rerun.test.js",
+            "test/scheduling.test.js",
+            "test/serialization.test.js",
+            "test/support/createdb-electron.js",
+            "test/support/createdb.js",
+            "test/support/elmo.png",
+            "test/support/helper.js",
+            "test/support/prepare.db",
+            "test/support/script.sql",
+            "test/trace.test.js",
+            "test/unicode.test.js",
+            "test/upsert.test.js",
+            "test/verbose.test.js",
+            "tools/docker/architecture/linux-arm/Dockerfile",
+            "tools/docker/architecture/linux-arm/run.sh",
+            "tools/docker/architecture/linux-arm64/Dockerfile",
+            "tools/docker/architecture/linux-arm64/run.sh"
+        ];
+        [
+            "tes?/",
+            "tes[-t-]/",
+            "tes[-t]/",
+            "tes[0-9A-Z_a-z-]/",
+            "tes[t-]/",
+            "test/**/*.js"
+        ].forEach(function (aa) {
+            [
+                "li*/*.js",
+                "li?/*.js",
+                "lib/*",
+                "lib/**/*.js",
+                "lib/*.js"
+            ].forEach(function (bb) {
+                assertJsonEqual(
+                    globExclude({
+                        excludeList: [
+                            "**/node_modules/",
+                            "node_modules/",
+                            "tes[!0-9A-Z_a-z-]/",
+                            "tes[^0-9A-Z_a-z-]/",
+                            "test/suppor*/*elper.js",
+                            "test/suppor?/?elper.js",
+                            "test/support/helper.js"
+                        ].concat(aa),
+                        includeList: [
+                            "**/*.cjs",
+                            "**/*.js",
+                            "**/*.mjs",
+                            "lib/sqlite3.js"
+                        ].concat(bb),
+                        pathnameList
+                    }).pathnameList,
+                    [
+                        ".eslintrc.js",
+                        "benchmark/insert.js",
+                        "cloudformation/ci.template.js",
+                        "examples/simple-chaining.js",
+                        "lib/index.js",
+                        "lib/sqlite3-binding.js",
+                        "lib/sqlite3.js",
+                        "lib/trace.js",
+                        "sqlite3.js"
+                    ]
+                );
+            });
+        });
+    });
+    jstestIt((
+        "test globToRegexp handling-behavior"
     ), function () {
         Object.entries({
             "*": (
@@ -99,8 +242,23 @@ jstestDescribe((
             "**": (
                 /^.*?$/gm
             ),
+            "***": (
+                /^.*?$/gm
+            ),
+            "****": (
+                /^.*?$/gm
+            ),
+            "****////****": (
+                /^.*?$/gm
+            ),
+            "***///***": (
+                /^.*?$/gm
+            ),
             "**/*": (
                 /^.*?$/gm
+            ),
+            "**/node_modules/": (
+                /^.*?\/node_modules\/.*?$/gm
             ),
             "**/node_modules/**/*": (
                 /^.*?\/node_modules\/.*?$/gm
@@ -126,17 +284,26 @@ jstestDescribe((
             "aa/bb/cc": (
                 /^aa\/bb\/cc$/gm
             ),
+            "aa/bb/cc/": (
+                /^aa\/bb\/cc\/.*?$/gm
+            ),
             "li*/*": (
                 /^li[^\/]*?\/[^\/]*?$/gm
             ),
             "li?/*": (
                 /^li[^\/]\/[^\/]*?$/gm
             ),
+            "lib/": (
+                /^lib\/.*?$/gm
+            ),
             "lib/*": (
                 /^lib\/[^\/]*?$/gm
             ),
             "lib/*.js": (
                 /^lib\/[^\/]*?\.js$/gm
+            ),
+            "node_modules/": (
+                /^node_modules\/.*?$/gm
             ),
             "node_modules/**/*": (
                 /^node_modules\/.*?$/gm
@@ -168,15 +335,23 @@ jstestDescribe((
         }).forEach(function ([
             pattern, rgx
         ]) {
-            assertJsonEqual(globPathToRegexp(pattern).source, rgx.source);
+            assertJsonEqual(
+                globExclude({
+                    excludeList: [
+                        pattern
+                    ]
+                }).excludeList[0].source,
+                rgx.source
+            );
+            assertJsonEqual(
+                globExclude({
+                    includeList: [
+                        pattern
+                    ]
+                }).includeList[0].source,
+                rgx.source
+            );
         });
-    });
-    jstestIt((
-        "test globPathToRegexp-error handling-behavior"
-    ), async function () {
-        await assertErrorThrownAsync(function () {
-            return globPathToRegexp("/\u0000/");
-        }, "Weird character \"\\\\u0000\" found in pattern");
     });
 });
 

--- a/test.mjs
+++ b/test.mjs
@@ -10,6 +10,8 @@ let {
     assertOrThrow,
     debugInline,
     fsWriteFileWithParents,
+    globPathExclude,
+    globPathToRegexp,
     jstestDescribe,
     jstestIt,
     jstestOnExit,
@@ -69,6 +71,112 @@ jstestDescribe((
             ),
             "aa"
         );
+    });
+});
+
+jstestDescribe((
+    "test globPathXxx handling-behavior"
+), function testBehaviorGlobPathXxx() {
+    jstestIt((
+        "test globPathExclude-error handling-behavior"
+    ), async function () {
+        await assertErrorThrownAsync(function () {
+            return globPathExclude(
+                [],
+                [
+                    "\u0000"
+                ]
+            );
+        }, "Weird character \"\\\\u0000\" found in path");
+    });
+    jstestIt((
+        "test globPathToRegexp handling-behavior"
+    ), function () {
+        Object.entries({
+            "*": (
+                /^[^\/]*?$/gm
+            ),
+            "**": (
+                /^.*?$/gm
+            ),
+            "**/*": (
+                /^.*?$/gm
+            ),
+            "**/node_modules/**/*": (
+                /^.*?\/node_modules\/.*?$/gm
+            ),
+            "?": (
+                /^[^\/]$/gm
+            ),
+            "[!0-9A-Za-z-]": (
+                /^[^0-9A-Za-z\-]$/gm
+            ),
+            "[0-9A-Za-z-]": (
+                /^[0-9A-Za-z\-]$/gm
+            ),
+            "[[]] ]][[": (
+                /^[\[]\] \]\][\[]$/gm
+            ),
+            "[]": (
+                /^$/gm
+            ),
+            "[^0-9A-Za-z-]": (
+                /^[^0-9A-Za-z\-]$/gm
+            ),
+            "aa/bb/cc": (
+                /^aa\/bb\/cc$/gm
+            ),
+            "li*/*": (
+                /^li[^\/]*?\/[^\/]*?$/gm
+            ),
+            "li?/*": (
+                /^li[^\/]\/[^\/]*?$/gm
+            ),
+            "lib/*": (
+                /^lib\/[^\/]*?$/gm
+            ),
+            "lib/*.js": (
+                /^lib\/[^\/]*?\.js$/gm
+            ),
+            "node_modules/**/*": (
+                /^node_modules\/.*?$/gm
+            ),
+            "tes[!0-9A-Z_a-z-]/**/*": (
+                /^tes[^0-9A-Z_a-z\-]\/.*?$/gm
+            ),
+            "tes[0-9A-Z_a-z-]/**/*": (
+                /^tes[0-9A-Z_a-z\-]\/.*?$/gm
+            ),
+            "tes[^0-9A-Z_a-z-]/**/*": (
+                /^tes[^0-9A-Z_a-z\-]\/.*?$/gm
+            ),
+            "test/**/*": (
+                /^test\/.*?$/gm
+            ),
+            "test/**/*.js": (
+                /^test\/.*?\.js$/gm
+            ),
+            "test/suppor*/*elper.js": (
+                /^test\/suppor[^\/]*?\/[^\/]*?elper\.js$/gm
+            ),
+            "test/suppor?/?elper.js": (
+                /^test\/suppor[^\/]\/[^\/]elper\.js$/gm
+            ),
+            "test/support/helper.js": (
+                /^test\/support\/helper\.js$/gm
+            )
+        }).forEach(function ([
+            pattern, rgx
+        ]) {
+            assertJsonEqual(globPathToRegexp(pattern).source, rgx.source);
+        });
+    });
+    jstestIt((
+        "test globPathToRegexp-error handling-behavior"
+    ), async function () {
+        await assertErrorThrownAsync(function () {
+            return globPathToRegexp("/\u0000/");
+        }, "Weird character \"\\\\u0000\" found in pattern");
     });
 });
 
@@ -1057,12 +1165,11 @@ jstestDescribe((
             ""
         );
         await jslint.jslint_cli({
-            console_error: noop, // uncomment to debug
+            console_error: noop, // comment to debug
             mode_cli: true,
             process_argv: [
                 "node", "jslint.mjs",
                 "v8_coverage_report=.tmp/coverage_jslint",
-                "--exclude-node-modules=0",
                 "--exclude=aa.js",
                 "--include=jslint.mjs",
                 "node", "jslint.mjs"
@@ -1109,7 +1216,7 @@ jstestDescribe((
             file = dir + file;
             await fsWriteFileWithParents(file, data);
             await jslint.jslint_cli({
-                console_error: noop, // uncomment to debug
+                console_error: noop, // comment to debug
                 mode_cli: true,
                 process_argv: [
                     "node", "jslint.mjs",
@@ -1124,7 +1231,7 @@ jstestDescribe((
         "test npm handling-behavior"
     ), async function () {
         await jslint.jslint_cli({
-            console_error: noop, // uncomment to debug
+            console_error: noop, // comment to debug
             mode_cli: true,
             process_argv: [
                 "node", "jslint.mjs",
@@ -1190,7 +1297,7 @@ jstestDescribe((
             await fsWriteFileWithParents(file, data);
         }));
         await jslint.jslint_cli({
-            console_error: noop, // uncomment to debug
+            console_error: noop, // comment to debug
             mode_cli: true,
             process_argv: [
                 "node", "jslint.mjs",


### PR DESCRIPTION
this pr revamps jslint's v8-coverage-report functionality to use glob-pattern-matching when excluding coverage-files, rather than list of explicit filenames:

```shell
node ../jslint.mjs \
    v8_coverage_report=../.artifact/coverage_sqlite3_sh/ \
    --exclude=**/node_modules/ \
    --exclude=node_modules/ \
    --exclude=tes?/ \
    --exclude=tes[!0-9A-Z_a-z-]/ \
    --exclude=tes[0-9A-Z_a-z-]/ \
    --exclude=tes[^0-9A-Z_a-z-]/ \
    --exclude=test/**/*.js \
    --exclude=test/suppor*/*elper.js \
    --exclude=test/suppor?/?elper.js \
    --exclude=test/support/helper.js \
    --include=**/*.cjs \
    --include=**/*.js \
    --include=**/*.mjs \
    --include=li*/*.js \
    --include=li?/*.js \
    --include=lib/* \
    --include=lib/**/*.js \
    --include=lib/*.js \
    --include=lib/sqlite3.js \
    npm run test
```

![image](https://camo.githubusercontent.com/f76156e3996a9ca2435a7793e5fa036a40ba790575709433f584e2a5805e005d/68747470733a2f2f6b61697a68753235362e6769746875622e696f2f6a736c696e742f6272616e63682d616c7068612f2e61727469666163742f73637265656e73686f745f62726f777365725f5f32662e61727469666163745f3266636f7665726167655f73716c697465335f73685f3266696e6465782e68746d6c2e706e67)

![image](https://camo.githubusercontent.com/d12384e302d9c013f738fccb722afddf198e23e6e3e75de40b35176aa4d36d22/68747470733a2f2f6b61697a68753235362e6769746875622e696f2f6a736c696e742f6272616e63682d616c7068612f2e61727469666163742f73637265656e73686f745f62726f777365725f5f32662e61727469666163745f3266636f7665726167655f73716c697465335f73685f32666c69625f326673716c697465332e6a732e68746d6c2e706e67)
