### PR TITLE
# v2022.5.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         node_version:
           - 14
           - 16
-          # - 18
+          - 18
         os:
           - macos-latest
           - ubuntu-latest

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -16,7 +16,7 @@ jobs:
         node_version:
           - 14
           - 16
-          # - 18
+          - 18
         os:
           - macos-latest
           - ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 # Todo
 - cli - remove cli-option `--mode-vim-plugin`
 - coverage - add macros `/*coverage-disable*/` and `/*coverage-enable*/`.
-- coverage - support globbing `*` in cli-options `--exclude` and `--include`
 - jslint - add html and css linting back into jslint.
 - jslint - add new warning requiring paren around plus-separated concatenations.
 - jslint - relax warning against console.log and friends and deprecate directive `devel`
@@ -12,9 +11,8 @@
 - jslint - unify analysis of variable-assignment/function-parameters into one function
 - jslint - add new warning "Expected Object.create(null) instead of {}"
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
-- perf - improve performance by hoisting inlined regexps out of loops and subfunctions
 
-# v2022.5.1-beta
+# v2022.5.20
 - coverage-report - disable default-coverage of directory `node_modules`, but allow override with cli-option `--include-node-modules=1`
 - coverage-report - add function globExclude() to revamp coverage-report to exclude files using glob-pattern-matching
 - add codemirror-example-file jslint_wrapper_codemirror.html

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Status
-| Branch | [master<br>(v2022.3.30)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
+| Branch | [master<br>(v2022.5.20)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
 |--:|:--:|:--:|:--:|
 | CI | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jslint-org/jslint/actions?query=branch%3Amaster) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/jslint-org/jslint/actions?query=branch%3Abeta) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/jslint-org/jslint/actions?query=branch%3Aalpha) |
 | Coverage | [![coverage](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/index.html) |

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -168,7 +168,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2022.5.1-beta";
+let jslint_edition = "v2022.5.20";
 let jslint_export;                      // The jslint object to be exported.
 let jslint_fudge = 1;                   // Fudge starting line and starting
                                         // ... column to 1.

--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
         "test2": "sh jslint_ci.sh shCiBase"
     },
     "type": "module",
-    "version": "2022.5.1-beta"
+    "version": "2022.5.20"
 }


### PR DESCRIPTION
- coverage-report - disable default-coverage of directory `node_modules`, but allow override with cli-option `--include-node-modules=1`
- coverage-report - add function globExclude() to revamp coverage-report to exclude files using glob-pattern-matching
- add codemirror-example-file jslint_wrapper_codemirror.html
- update codemirror-editor to v5.65.3
- wrapper - add jslint-addon for codemirror
- allow jslint.mjs to auto-export itself to globalThis when given search-param `?window_jslint=1`
- wrapper - add jslint-extension for vscode
- bugfix - fix jslint falsely believing megastring literals `0` and `1` are similar
- bugfix - fix function jstestOnExit() from exiting prematurely and suppressing additional error-messages