### PR TITLE
- bugfix - fix jslint not-recognizing option-chaining when comparing operands of binary operator

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -189,6 +189,7 @@ import moduleFs from "fs";
     let versionBeta;
     let versionMaster;
     await Promise.all([
+        ".ci.sh",
         "CHANGELOG.md",
         "README.md",
         "index.html",
@@ -199,7 +200,7 @@ import moduleFs from "fs";
         fileDict[file] = await moduleFs.promises.readFile(file, "utf8");
     }));
     Array.from(fileDict["CHANGELOG.md"].matchAll(
-        /\n\n# (v\d\d\d\d\.\d\d?\.\d\d?(.*?)?)\n/g
+        /\n\n# v(\d\d\d\d\.\d\d?\.\d\d?(-.*?)?)\n/g
     )).slice(0, 2).forEach(function ([
         ignore, version, isBeta
     ]) {
@@ -208,6 +209,12 @@ import moduleFs from "fs";
     });
     await Promise.all([
         {
+            file: ".ci.sh",
+            // update version
+            src: fileDict[".ci.sh"].replace((
+                /    "version": "\d\d\d\d\.\d\d?\.\d\d?(?:-.*?)?"/
+            ), `    "version": "${versionBeta}"`)
+        }, {
             file: "README.md",
             src: fileDict["README.md"].replace((
                 /\n```html <!-- jslint_wrapper_codemirror.html -->\n[\S\s]*?\n```\n/
@@ -227,10 +234,10 @@ import moduleFs from "fs";
             })
         }, {
             file: "jslint.mjs",
-            // inline css-assets
+            // update version
             src: fileDict["jslint.mjs"].replace((
                 /^let jslint_edition = ".*?";$/m
-            ), `let jslint_edition = "${versionBeta}";`)
+            ), `let jslint_edition = "v${versionBeta}";`)
         }, {
             file: "jslint_ci.sh",
             // update coverage-code
@@ -405,7 +412,7 @@ import moduleFs from "fs";
                     "type": "git",
                     "url": "https://github.com/jslint-org/jslint.git"
                 },
-                "version": "2022.5.1"
+                "version": "2022.6.1-beta"
             }, undefined, 4)
         }
     ].map(async function ({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 # Todo
+- jslint - allow alias `nomen` for jslint-directive `name`
+- wrapper - add vscode-command to suppress minor warnings on given line
+- doc - document jslint directives and supported/unsupported es6+ features
 - cli - remove cli-option `--mode-vim-plugin`
 - coverage - add macros `/*coverage-disable*/` and `/*coverage-enable*/`.
 - jslint - add html and css linting back into jslint.
@@ -11,6 +14,10 @@
 - jslint - unify analysis of variable-assignment/function-parameters into one function
 - jslint - add new warning "Expected Object.create(null) instead of {}"
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
+
+# v2022.6.1-beta
+- bugfix - fix jslint not-recognizing option-chaining when comparing operands of binary operator
+- allow array-literals to directly call [...].flat() and [...].flatMap()
 
 # v2022.5.20
 - coverage-report - disable default-coverage of directory `node_modules`, but allow override with cli-option `--include-node-modules=1`

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -94,10 +94,6 @@
 
 /*jslint beta, node*/
 /*property
-    excludeList,
-    globExclude,
-    import_meta_url, includeList,
-    pathnameList,
     JSLINT_BETA, NODE_V8_COVERAGE, a, all, argv, arity, artifact,
     assertErrorThrownAsync, assertJsonEqual, assertOrThrow, assign, async, b,
     beta, bitwise, block, body, browser, c, calls, catch, catch_list,
@@ -106,39 +102,39 @@
     convert, count, coverageDir, create, cwd, d, dead, debugInline, default,
     delta, devel, directive, directive_list, directive_quiet, directives,
     dirname, disrupt, dot, edition, elem_list, ellipsis, else, end, endOffset,
-    endsWith, entries, env, error, eval, every, example_list, exec, execArgv,
-    exit, exitCode, export_dict, exports, expression, extra, file, fileList,
-    fileURLToPath, filter, finally, flag, floor, for, forEach,
+    endsWith, entries, env, error, eval, every, example_list, excludeList, exec,
+    execArgv, exit, exitCode, export_dict, exports, expression, extra, file,
+    fileList, fileURLToPath, filter, finally, flag, floor, for, forEach,
     formatted_message, free, freeze, from, froms, fsWriteFileWithParents,
     fud_stmt, functionName, function_list, function_stack, functions, get,
-    getset, github_repo, global, global_dict, global_list, holeList, htmlEscape,
-    id, identifier, import, import_list, inc, indent2, index, indexOf, init,
-    initial, isArray, isBlockCoverage, isHole, isNaN, is_equal, is_fart,
-    is_weird, join, jslint, jslint_apidoc, jslint_assert, jslint_charset_ascii,
-    jslint_cli, jslint_edition, jslint_phase1_split, jslint_phase2_lex,
-    jslint_phase3_parse, jslint_phase4_walk, jslint_phase5_whitage,
-    jslint_report, json, jstestDescribe, jstestIt, jstestOnExit, keys, label,
-    lbp, led_infix, length, level, line, lineList, line_list, line_offset,
-    line_source, lines, linesCovered, linesTotal, live, log, long, loop, m, map,
-    margin, match, max, message, meta, min, mkdir, modeCoverageIgnoreFile,
-    modeIndex, mode_cli, mode_conditional, mode_json, mode_module, mode_noop,
-    mode_property, mode_shebang, mode_stop, module, moduleFsInit, moduleName,
-    module_list, name, names, node, noop, now, nr, nud_prefix,
-    objectDeepCopyWithKeysSorted, ok, on, open, opening, option, option_dict,
-    order, package_name, padEnd, padStart, parameters, parent, parentIi, parse,
-    pathname, platform, pop, processArgv, process_argv, process_env,
-    process_exit, promises, property, property_dict, push, quote, ranges,
-    readFile, readdir, readonly, recursive, reduce, repeat, replace, resolve,
-    result, reverse, role, round, scriptId, search, set, shebang, shift,
-    signature, single, slice, some, sort, source, spawn, splice, split, stack,
-    stack_trace, start, startOffset, startsWith, statement, statement_prv,
-    stdio, stop, stop_at, stringify, switch, syntax_dict, tenure, test,
-    test_cause, test_internal_error, this, thru, toString, token, token_global,
-    token_list, token_nxt, token_tree, tokens, trace, tree, trim, trimEnd,
-    trimRight, try, type, unlink, unordered, unshift, url, used,
-    v8CoverageListMerge, v8CoverageReportCreate, value, variable, version,
-    versions, warn, warn_at, warning, warning_list, warnings, white, wrapped,
-    writeFile
+    getset, github_repo, globExclude, global, global_dict, global_list,
+    holeList, htmlEscape, id, identifier, import, import_list, import_meta_url,
+    inc, includeList, indent2, index, indexOf, init, initial, isArray,
+    isBlockCoverage, isHole, isNaN, is_equal, is_fart, is_weird, join, jslint,
+    jslint_apidoc, jslint_assert, jslint_charset_ascii, jslint_cli,
+    jslint_edition, jslint_phase1_split, jslint_phase2_lex, jslint_phase3_parse,
+    jslint_phase4_walk, jslint_phase5_whitage, jslint_report, json,
+    jstestDescribe, jstestIt, jstestOnExit, keys, label, lbp, led_infix, length,
+    level, line, lineList, line_list, line_offset, line_source, lines,
+    linesCovered, linesTotal, live, log, long, loop, m, map, margin, match, max,
+    message, meta, min, mkdir, modeCoverageIgnoreFile, modeIndex, mode_cli,
+    mode_conditional, mode_json, mode_module, mode_noop, mode_property,
+    mode_shebang, mode_stop, module, moduleFsInit, moduleName, module_list,
+    name, names, node, noop, now, nr, nud_prefix, objectDeepCopyWithKeysSorted,
+    ok, on, open, opening, option, option_dict, order, package_name, padEnd,
+    padStart, parameters, parent, parentIi, parse, pathname, pathnameList,
+    platform, pop, processArgv, process_argv, process_env, process_exit,
+    promises, property, property_dict, push, quote, ranges, readFile, readdir,
+    readonly, recursive, reduce, repeat, replace, resolve, result, reverse,
+    role, round, scriptId, search, set, shebang, shift, signature, single,
+    slice, some, sort, source, spawn, splice, split, stack, stack_trace, start,
+    startOffset, startsWith, statement, statement_prv, stdio, stop, stop_at,
+    stringify, switch, syntax_dict, tenure, test, test_cause,
+    test_internal_error, this, thru, toString, token, token_global, token_list,
+    token_nxt, token_tree, tokens, trace, tree, trim, trimEnd, trimRight, try,
+    type, unlink, unordered, unshift, url, used, v8CoverageListMerge,
+    v8CoverageReportCreate, value, variable, version, versions, warn, warn_at,
+    warning, warning_list, warnings, white, wrapped, writeFile
 */
 
 // init debugInline
@@ -168,7 +164,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2022.5.20";
+let jslint_edition = "v2022.6.1-beta";
 let jslint_export;                      // The jslint object to be exported.
 let jslint_fudge = 1;                   // Fudge starting line and starting
                                         // ... column to 1.
@@ -716,10 +712,11 @@ function jslint(
             return false;
         }
         if (aa.arity === bb.arity && aa.id === bb.id) {
-            if (aa.id === ".") {
+            if (aa.id === "." || aa.id === "?.") {
 
 // test_cause:
 // ["aa.bb&&aa.bb", "is_equal", "recurse_arity_id", "", 0]
+// ["aa?.bb&&aa?.bb", "is_equal", "recurse_arity_id", "", 0]
 
                 test_cause("recurse_arity_id");
                 return (
@@ -4487,6 +4484,8 @@ function jslint_phase3_parse(state) {
                 left.id !== "["
                 || (
                     name.id !== "concat"
+                    && name.id !== "flat"
+                    && name.id !== "flatMap"
                     && name.id !== "forEach"
                     && name.id !== "join"
                     && name.id !== "map"
@@ -9805,6 +9804,7 @@ async function jstestDescribe(description, testFunction) {
 
     let message;
     let result;
+    let timerTimeout;
 
 // Init jstestTimeStart.
 
@@ -9820,7 +9820,9 @@ async function jstestDescribe(description, testFunction) {
 
 // Wait for jstestItList to resolve.
 
+    timerTimeout = setTimeout(noop, 0x7fffffff);
     result = await Promise.all(jstestItList);
+    clearTimeout(timerTimeout);
 
 // Print test results.
 

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -437,7 +437,7 @@ import moduleFs from "fs";
         fileDict[file] = await moduleFs.promises.readFile(file, "utf8");
     }));
     Array.from(fileDict["CHANGELOG.md"].matchAll(
-        /\n\n# (v\d\d\d\d\.\d\d?\.\d\d?(.*?)?)\n/g
+        /\n\n# v(\d\d\d\d\.\d\d?\.\d\d?(-.*?)?)\n/g
     )).slice(0, 2).forEach(function ([
         ignore, version, isBeta
     ]) {
@@ -449,12 +449,12 @@ import moduleFs from "fs";
             file: "README.md",
             src: fileDict["README.md"].replace((
                 /\bv\d\d\d\d\.\d\d?\.\d\d?\b/m
-            ), versionMaster)
+            ), `v${versionMaster}`)
         }, {
             file: "package.json",
             src: fileDict["package.json"].replace((
-                /("version": )".*?"/
-            ), "$1" + JSON.stringify(versionBeta.slice(1)))
+                /    "version": "\d\d\d\d\.\d\d?\.\d\d?(?:-.*?)?"/
+            ), `    "version": "${versionBeta}"`)
         }
     ].map(async function ({
         file,

--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
         "test2": "sh jslint_ci.sh shCiBase"
     },
     "type": "module",
-    "version": "2022.5.20"
+    "version": "2022.6.1-beta"
 }


### PR DESCRIPTION
- allow array-literals to directly call [...].flat() and [...].flatMap()

this pr fixes jslint from crashing in screenshot below
![image](https://user-images.githubusercontent.com/280571/171077417-03488fae-ab21-4d9d-89d2-b5ccc08baaa3.png)
