### PR TITLE
- directive - add new directive `subscript` for linting of scripts targeting Google Closure Compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 # Todo
-- jslint - allow alias `nomen` for jslint-directive `name`
 - wrapper - add vscode-command to suppress minor warnings on given line
 - doc - document jslint directives and supported/unsupported es6+ features
 - cli - remove cli-option `--mode-vim-plugin`
@@ -16,6 +15,10 @@
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 
 # v2022.6.1-beta
+- directive - add new directive `subscript` allowing JSLint to be used with scripts targeting Google Closure Compiler
+- warning - relax warning about missing `catch` in `try...finally` statement
+- jslint - allow aliases `evil, nomen` for jslint-directives `eval, name`, respectively
+- bugfix - fix broken codemirror example
 - bugfix - fix jslint not-recognizing option-chaining when comparing operands of binary operator
 - allow array-literals to directly call [...].flat() and [...].flatMap()
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 
 # v2022.6.1-beta
-- directive - add new directive `subscript` allowing JSLint to be used with scripts targeting Google Closure Compiler
+- directive - add new directive `subscript` for linting of scripts targeting Google Closure Compiler
 - warning - relax warning about missing `catch` in `try...finally` statement
-- jslint - allow aliases `evil, nomen` for jslint-directives `eval, name`, respectively
+- jslint - allow aliases `evil, nomen` for jslint-directives `eval, name`, respectively for backwards-compat
 - bugfix - fix broken codemirror example
 - bugfix - fix jslint not-recognizing option-chaining when comparing operands of binary operator
 - allow array-literals to directly call [...].flat() and [...].flatMap()

--- a/README.md
+++ b/README.md
@@ -376,12 +376,11 @@ import jslint from "../jslint.mjs";
 
 <!-- Assets from codemirror. -->
 
-    <link rel="stylesheet" href="https://codemirror.net/lib/codemirror.css">
-    <link rel="stylesheet" href="https://codemirror.net/addon/lint/lint.css">
-    <script defer src="https://codemirror.net/lib/codemirror.js"></script>
-    <script defer
-        src="https://codemirror.net/mode/javascript/javascript.js"></script>
-    <script defer src="https://codemirror.net/addon/lint/lint.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/codemirror.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/addon/lint/lint.css">
+    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/codemirror.js"></script>
+    <script defer src="https://codemirror.net/mode/javascript/javascript.js"></script>
+    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/addon/lint/lint.js"></script>
 
 <!-- Assets from jslint. -->
 
@@ -396,6 +395,10 @@ body {
 }
 .JSLINT_.JSLINT_REPORT_ {
     margin-top: 20px;
+}
+#editor1 {
+    height: 300px;
+    width: 100%;
 }
 </style>
 </head>

--- a/asset_codemirror_rollup.js
+++ b/asset_codemirror_rollup.js
@@ -5,26 +5,26 @@ shRawLibFetch
     "fetchList": [
         {
             "comment": true,
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.65.3/LICENSE"
+            "url": "https://github.com/codemirror/CodeMirror5/blob/5.65.5/LICENSE"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.65.3/codemirror.js",
-            "url2": "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.3/codemirror.js"
+            "url": "https://github.com/codemirror/CodeMirror5/blob/5.65.5/codemirror.js",
+            "url2": "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/codemirror.js"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/edit/matchbrackets.js"
+            "url": "https://github.com/codemirror/CodeMirror5/blob/5.65.5/addon/edit/matchbrackets.js"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/edit/trailingspace.js"
+            "url": "https://github.com/codemirror/CodeMirror5/blob/5.65.5/addon/edit/trailingspace.js"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/lint/lint.js"
+            "url": "https://github.com/codemirror/CodeMirror5/blob/5.65.5/addon/lint/lint.js"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/selection/active-line.js"
+            "url": "https://github.com/codemirror/CodeMirror5/blob/5.65.5/addon/selection/active-line.js"
         },
         {
-            "url": "https://github.com/codemirror/CodeMirror/blob/5.65.3/mode/javascript/javascript.js"
+            "url": "https://github.com/codemirror/CodeMirror5/blob/5.65.5/mode/javascript/javascript.js"
         }
     ],
     "replaceList": []
@@ -33,13 +33,13 @@ shRawLibFetch
 
 
 /*
-repo https://github.com/codemirror/CodeMirror/tree/5.65.3
-committed 2022-04-20T09:49:25Z
+repo https://github.com/codemirror/CodeMirror5/tree/5.65.5
+committed 2022-05-30T09:58:15Z
 */
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.65.3/LICENSE
+file https://github.com/codemirror/CodeMirror5/blob/5.65.5/LICENSE
 */
 /*
 MIT License
@@ -67,7 +67,7 @@ THE SOFTWARE.
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.65.3/codemirror.js
+file https://github.com/codemirror/CodeMirror5/blob/5.65.5/codemirror.js
 */
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
@@ -97,7 +97,8 @@ file https://github.com/codemirror/CodeMirror/blob/5.65.3/codemirror.js
   var ie_version = ie && (ie_upto10 ? document.documentMode || 6 : +(edge || ie_11up)[1]);
   var webkit = !edge && /WebKit\//.test(userAgent);
   var qtwebkit = webkit && /Qt\/\d+\.\d+/.test(userAgent);
-  var chrome = !edge && /Chrome\//.test(userAgent);
+  var chrome = !edge && /Chrome\/(\d+)/.exec(userAgent);
+  var chrome_version = chrome && +chrome[1];
   var presto = /Opera\//.test(userAgent);
   var safari = /Apple Computer/.test(navigator.vendor);
   var mac_geMountainLion = /Mac OS X 1\d\D([8-9]|\d\d)\D/.test(userAgent);
@@ -4580,6 +4581,17 @@ file https://github.com/codemirror/CodeMirror/blob/5.65.3/codemirror.js
   }
 
   function onScrollWheel(cm, e) {
+    // On Chrome 102, viewport updates somehow stop wheel-based
+    // scrolling. Turning off pointer events during the scroll seems
+    // to avoid the issue.
+    if (chrome && chrome_version >= 102) {
+      if (cm.display.chromeScrollHack == null) { cm.display.sizer.style.pointerEvents = "none"; }
+      else { clearTimeout(cm.display.chromeScrollHack); }
+      cm.display.chromeScrollHack = setTimeout(function () {
+        cm.display.chromeScrollHack = null;
+        cm.display.sizer.style.pointerEvents = "";
+      }, 100);
+    }
     var delta = wheelEventDelta(e), dx = delta.x, dy = delta.y;
     var pixelsPerUnit = wheelPixelsPerUnit;
     if (e.deltaMode === 0) {
@@ -8268,7 +8280,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.65.3/codemirror.js
     var pasted = e.clipboardData && e.clipboardData.getData("Text");
     if (pasted) {
       e.preventDefault();
-      if (!cm.isReadOnly() && !cm.options.disableInput)
+      if (!cm.isReadOnly() && !cm.options.disableInput && cm.hasFocus())
         { runInOp(cm, function () { return applyTextInput(cm, pasted, 0, null, "paste"); }); }
       return true
     }
@@ -9912,14 +9924,14 @@ file https://github.com/codemirror/CodeMirror/blob/5.65.3/codemirror.js
 
   addLegacyProps(CodeMirror);
 
-  CodeMirror.version = "5.65.3";
+  CodeMirror.version = "5.65.5";
 
   return CodeMirror;
 })));
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/edit/matchbrackets.js
+file https://github.com/codemirror/CodeMirror5/blob/5.65.5/addon/edit/matchbrackets.js
 */
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
@@ -10084,7 +10096,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/edit/matchbracke
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/edit/trailingspace.js
+file https://github.com/codemirror/CodeMirror5/blob/5.65.5/addon/edit/trailingspace.js
 */
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
@@ -10116,7 +10128,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/edit/trailingspa
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/lint/lint.js
+file https://github.com/codemirror/CodeMirror5/blob/5.65.5/addon/lint/lint.js
 */
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
@@ -10412,7 +10424,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/lint/lint.js
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/selection/active-line.js
+file https://github.com/codemirror/CodeMirror5/blob/5.65.5/addon/selection/active-line.js
 */
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE
@@ -10489,7 +10501,7 @@ file https://github.com/codemirror/CodeMirror/blob/5.65.3/addon/selection/active
 
 
 /*
-file https://github.com/codemirror/CodeMirror/blob/5.65.3/mode/javascript/javascript.js
+file https://github.com/codemirror/CodeMirror5/blob/5.65.5/mode/javascript/javascript.js
 */
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/LICENSE

--- a/help.html
+++ b/help.html
@@ -72,10 +72,11 @@ th {
 td {
     background-color: white;
 }
-button {
+.button,
+.button:hover {
     background-color: lightsteelblue;
     border: 0;
-    color: black;
+    color: black !important;
     cursor: pointer;
     font-family: "Daley", serif;
     font-size: 100%;
@@ -87,6 +88,7 @@ button {
     padding-left: 1em;
     padding-right: 1em;
     text-align: center;
+    text-decoration: none;
 }
 s {
     display: inline-block;
@@ -144,7 +146,9 @@ ul {
 }
 table {
     border: 0;
-    margin: 1em;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
     max-width: 76%;
 }
 th, td {
@@ -186,16 +190,16 @@ a:active {
   </a></li>
 </ul>
 <div id=title>Help</div>
-<br clear=all>
+<br>
 <blockquote>Il semble que la perfection soit atteinte non quand il n&#8217;y a
     plus rien &agrave; ajouter, mais quand il n&#8217;y a plus rien &agrave;
     retrancher.</blockquote>
-<center>
+<div style="text-align: center;">
     Antoine de Saint-Exupéry
-</center>
-<center>
+</div>
+<div style="text-align: center;">
     <i>Terre des Hommes</i> (1939)
-</center>
+</div>
 <h1 id=good>Good Parts</h1>
 <p>The Principle of the Good Parts is</p>
 <blockquote> If a feature is sometimes useful and sometimes dangerous and if
@@ -330,7 +334,6 @@ a:active {
     options. These options can also be set from the
     <a href="https://www.jslint.com/">jslint.com</a> user interface.</p>
 
-<center>
 <table>
     <tbody>
         <tr>
@@ -339,17 +342,34 @@ a:active {
             <th>Meaning</th>
         </tr>
         <tr>
-            <td id="bitwise">Tolerate bitwise operators</td>
+            <td id="beta">Enable experimental warnings.</td>
+            <td><code>beta</code></td>
+            <td><code>true</code> will enable the following additional warnings:
+            <ul style="margin-left: 0; margin-right: 0;">
+                <li>Warn if global variables are redefined.</li>
+                <li>Warn if <code>const / let</code> statements are not declared
+                at top of function or script,
+                similar to <code>var</code> statements.</li>
+                <li>Warn if <code>const / let / var</code> statements
+                are not declared in ascii-order.</li>
+                <li>Warn if named-functions
+                are not declared in ascii-order.</li>
+            </ul>
+            </td>
+        </tr>
+        <tr>
+            <td id="bitwise">Allow bitwise operators.</td>
             <td><code>bitwise</code></td>
             <td><code>true</code> if bitwise operators should  be allowed. The
                 bitwise operators are rarely used in JavaScript programs, so it
                 is usually more likely that <code>&amp;</code> is a mistyping of
-                <code>&amp;&amp;</code> than that it indicates a bitwise <i>and</i>.
+                <code>&amp;&amp;</code> than that it indicates a bitwise
+                <i>and</i>.
                 JSLint will give warnings on the bitwise operators
                 unless this option is selected.</td>
         </tr>
         <tr>
-            <td id="browser">Assume a browser </td>
+            <td id="browser">Assume browser environment.</td>
             <td><code>browser</code></td>
             <td><code>true</code> if the standard browser globals should be
                 predefined. This option will reject the use of
@@ -370,7 +390,7 @@ a:active {
             </td>
         </tr>
         <tr>
-            <td id="convert">Tolerate conversion operators</td>
+            <td id="convert">Allow conversion operators.</td>
             <td><code>convert</code></td>
             <td><code>true</code> if <code>!!</code>, <code>+</code> prefix,
                 and concatenation with <code>&quot;&quot;</code> are allowed.
@@ -378,7 +398,8 @@ a:active {
                 <code>String</code> functions are preferred</td>
         </tr>
         <tr>
-            <td id="couch">Assume <a href="https://couchdb.apache.org/">CouchDB</a></td>
+            <td id="couch">Assume
+            <a href="https://couchdb.apache.org/">CouchDB</a> environment.</td>
             <td><code>couch</code></td>
             <td><code>true</code> if
                 <a href="https://couchdb.apache.org/">Couch DB</a>
@@ -390,7 +411,7 @@ a:active {
     <code> */</code></blockquote></td>
         </tr>
         <tr>
-            <td id="devel">Assume in development</td>
+            <td id="devel">Assume in development.</td>
             <td><code>devel</code></td>
             <td><code>true</code> if browser globals that are useful in
                 development should be predefined, and if <code>debugger</code>
@@ -403,40 +424,39 @@ a:active {
         into production.</td>
         </tr>
         <tr>
-            <td id="eval">Tolerate <code>eval</code></td>
+            <td id="eval">Allow <code>eval</code>.</td>
             <td><code>eval</code></td>
             <td><code>true</code> if <code>eval</code> should be allowed. In the
                 past, the <code>eval</code> function was the most misused
                 feature of the language.</td>
         </tr>
         <tr>
-            <td>Tolerate <code>for</code> statement</td>
+            <td>Allow <code>for</code> statement.</td>
             <td><code>for</code></td>
             <td><code>true</code> if the <code>for</code> statement should be
                 allowed. It is almost always better to use the array methods
                 instead.</td>
         </tr>
         <tr>
-            <td id="getsest">Tolerate <code>get</code> and <code>set</code></td>
+            <td id="getsest">Allow <code>get</code> and <code>set</code>.</td>
             <td><code>getset</code></td>
-            <td><code>true</code> if accessor properties are allowed in object literals.</td>
+            <td><code>true</code> if accessor properties are allowed in object
+            literals.</td>
         </tr>
         <tr>
-            <td id="long">Tolerate long source lines</td>
+            <td id="indent2">Use 2-space indent.</td>
+            <td><code>indent2</code></td>
+            <td><code>true</code> if using 2-space indent.</td>
+        </tr>
+        <tr>
+            <td id="long">Allow long lines.</td>
             <td><code>long</code></td>
-            <td><code>true</code> if a line can contain more than 80 characters.</td>
-        </tr>
-        <tr>
-            <td id="name">Tolerate bad property names</td>
-            <td><code>name</code></td>
-            <td>
-                <code>true</code> if bad property names like
-                <code>$, _foo, fooSync, foo_</code>
-                are allowed.
+            <td><code>true</code> if a line can contain more than 80 characters.
             </td>
         </tr>
         <tr>
-            <td id="node">Assume <a href="https://nodejs.org/">Node.js</a></td>
+            <td id="node">Assume <a href="https://nodejs.org/">Node.js</a>
+            environment.</td>
             <td><code>node</code></td>
             <td><code>true</code> if Node.js globals should be predefined. It
                 will predefine globals that are used in the Node.js environment.
@@ -451,29 +471,54 @@ a:active {
     <code>*/</code></blockquote></td>
         </tr>
         <tr>
-            <td id="single">Tolerate single quote strings</td>
+            <td id="nomen">Allow weird property names.</td>
+            <td><code>nomen</code></td>
+            <td>
+                <code>true</code> if weird property names like
+                <code>$, _foo, fooSync, foo_</code>
+                are allowed.
+            </td>
+        </tr>
+        <tr>
+            <td id="single">Allow single quote strings.</td>
             <td><code>single</code></td>
             <td><code>true</code> if <code>'</code><small>single quote</small>
-                should be allowed to enclose string literals. </td>
+                should be allowed to enclose string literals.</td>
         </tr>
         <tr>
-            <td>Tolerate <code>this</code><br></td>
+            <td id="subscript">Allow identifiers in subscript-notation.</td>
+            <td><code>subscript</code></td>
+            <td><code>true</code> to allow identifiers in
+            subscript-notation, e.g.: <code>foo["bar"] = 1;</code>.
+            This allows linting of scripts targeting Google Closure Compiler,
+            where subscript-notation is commonly used to prevent renaming of
+            properties.</td>
+        </tr>
+        <tr>
+            <td>Allow <code>this</code>.<br></td>
             <td><code>this</code></td>
-            <td><code>true</code> if <code>this</code> should be allowed. </td>
+            <td><code>true</code> if <code>this</code> should be allowed.</td>
         </tr>
         <tr>
-            <td id="unordered">Tolerate unordered case-statements, params, properties.</td>
+            <td id="trace">Include jslint stack-trace in warnings.<br></td>
+            <td><code>trace</code></td>
+            <td><code>true</code> is used by developers to debug JSLint.</td>
+        </tr>
+        <tr>
+            <td id="unordered">Allow unordered case-statements, params,
+            properties.</td>
             <td><code>unordered</code></td>
-            <td><code>true</code> if objects and functions are allowed to declare properties and params in non-alphabetical order.</td>
+            <td><code>true</code> if objects and functions are allowed
+            to declare properties and params in non-ascii order.</td>
         </tr>
         <tr>
-            <td id="white">Tolerate whitespace mess</td>
+            <td id="white">Allow messy whitespace.</td>
             <td><code>white</code></td>
-            <td><code>true</code> if the whitespace rules should be ignored.</td>
+            <td><code>true</code> if the whitespace rules should be ignored.
+            </td>
         </tr>
     </tbody>
 </table>
-</center>
 
 <p>For example:</p>
 <pre>/*jslint
@@ -497,8 +542,8 @@ a:active {
     names against the list. That way, you can have JSLint look for
     misspellings for you.</p>
 <p>For example,</p>
-<blockquote><code>/*property
-    <div>charAt, slice, _$_</div>
+<blockquote><code>/*property<br>
+    &nbsp;&nbsp;&nbsp;&nbsp;charAt, slice, _$_<br>
     */</code></blockquote>
 <h1 id=ignore><code>ignore</code></h1>
 <p>JSLint introduces a new reserved word: <code>ignore</code>. It
@@ -525,7 +570,7 @@ a:active {
     parameter in an outer function. Do not mix <code>var</code> and
     <code>let</code>. Declare one name per statement.</p>
 <h1 id=eq><code>= == ===</code></h1>
-<p><span style="asset_font_variant: small-caps;">Fortran</span> made a terrible
+<p>FORTRAN made a terrible
     mistake in using the equality operator as its assignment operator. That
     mistake has been replicated in most languages since then. C compounded that
     mistake by making <code>==</code> its equality operator. The visual
@@ -783,7 +828,7 @@ a:active {
 <h1 id=try>Try it</h1>
 <p><a href="https://www.jslint.com/">Try it.</a> Paste your script
     into the window and click the
-    <a href="https://www.jslint.com/"><button>JSLint</button></a>
+    <a class="button" href="https://www.jslint.com/">JSLint</a>
     button. The analysis is done by a script running on your machine.
     Your script is not sent over the network. You can set the options used.</p>
 <p>JSLint is written entirely in JavaScript, so it can run
@@ -807,7 +852,7 @@ a:active {
 
 <h1 id=jslint>JSLint</h1>
 <p>JSLint is delivered as a set of files:</p>
-<center><table align="center">
+<table style="max-width: 450px;">
 <tr><th>Filename</th><th>Content</th></tr>
 <tr><td><code>help.html</code></td>
 <td>Using <code>jslint</code> as a single page JSLint application.</td></tr>
@@ -816,12 +861,12 @@ a:active {
         <code>js</code> files.</td></tr>
 <tr><td><code>jslint.mjs</code></td>
 <td>The <code>jslint</code> function.</td></tr>
-</table></center>
+</table>
 <h1><code>function jslint</code></h1>
 <p>The <code>jslint</code> function is written in ES6 JavaScript. It has no
     dependence on other files.</p>
 <p>The <code>jslint</code> function has three arguments:</p>
-<center><table>
+<table>
 <tr>
     <th>Parameter name</th>
     <th>Type</th>
@@ -841,11 +886,11 @@ a:active {
         may be used by the program. Listing names here will silence warnings
         about the names. It will not introduce the names into the runtime
         environment.</td></tr>
-</table></center>
+</table>
 <p>The <code>jslint</code> function will not modify any of its arguments.</p>
 <p>The <code>jslint</code> function will return a result object contain the
     following properties:</p>
-<center><table>
+<table>
 <tr>
     <th>Property name</th>
     <th>Type</th>
@@ -1218,15 +1263,14 @@ a:active {
         </tr>
     </table>
     <p>&nbsp;</p>
-</center>
 
 <h1 id=reading>Further Reading</h1>
-<center>
+<div style="text-align: center">
     <p><a href="https://www.crockford.com/javascript/code.html">
         Code Conventions for the JavaScript Programming Language.</a></p>
-    <a href="https://www.jslint.com/"><img src="asset_image_logo_512.svg" height="20"></a>
-    <a href="https://github.com/jslint-org/jslint"><img src="asset_image_github_brands.svg" height="20"></a>
-    <a href="https://www.json.org/"><img src="asset_image_json_160.svg" height="20"></a>
-</center>
+    <a href="https://www.jslint.com/"><img alt="jslint" src="asset_image_logo_512.svg" height="20"></a>
+    <a href="https://github.com/jslint-org/jslint"><img alt="github" src="asset_image_github_brands.svg" height="20"></a>
+    <a href="https://www.json.org/"><img alt="json" src="asset_image_json_160.svg" height="20"></a>
+</div>
 </body>
 </html>

--- a/help.html
+++ b/help.html
@@ -486,9 +486,9 @@ a:active {
                 should be allowed to enclose string literals.</td>
         </tr>
         <tr>
-            <td id="subscript">Allow identifiers in subscript-notation.</td>
+            <td id="subscript">Allow identifier in subscript-notation.</td>
             <td><code>subscript</code></td>
-            <td><code>true</code> to allow identifiers in
+            <td><code>true</code> to allow identifier in
             subscript-notation, e.g.: <code>foo["bar"] = 1;</code>.
             This allows linting of scripts targeting Google Closure Compiler,
             where subscript-notation is commonly used to prevent renaming of

--- a/index.html
+++ b/index.html
@@ -1172,7 +1172,7 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
         <div title="Allow single-quote strings.">
         <label><input type="checkbox" value="single">single</label>
         </div>
-        <div title="Allow identifiers in subscript-notation.">
+        <div title="Allow identifier in subscript-notation.">
         <label><input type="checkbox" value="subscript">subscript</label>
         </div>
         <div title="Allow 'this'.">
@@ -1443,7 +1443,7 @@ document.querySelector(
 }) {
     switch (target.tagName) {
 
-// PR-368 - website
+// PR-368 - Website
 // Add clickable-links to editor-code in report-warnings and report-functions.
 
     case "ADDRESS":
@@ -1642,7 +1642,7 @@ eval("console.log(\\"hello world\\");");
 // .... /*jslint node*/ .......... Assume Node.js environment.
 // .... /*jslint nomen*/ ......... Allow weird property names.
 // .... /*jslint single*/ ........ Allow single-quote strings.
-// .... /*jslint subscript*/ ..... Allow identifiers in subscript-notation.
+// .... /*jslint subscript*/ ..... Allow identifier in subscript-notation.
 // .... /*jslint this*/ .......... Allow 'this'.
 // .... /*jslint trace*/ ......... Include jslint stack-trace in warnings.
 // .... /*jslint unordered*/ ..... Allow unordered cases, params, properties,

--- a/index.html
+++ b/index.html
@@ -1147,11 +1147,14 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
         <div title="Allow conversion operators.">
         <label><input type="checkbox" value="convert">convert</label>
         </div>
-        <div title="Allow for-statement.">
-        <label><input type="checkbox" value="for">for</label>
+        <div title="Allow eval().">
+        <label><input type="checkbox" value="eval">eval</label>
         </div>
     </div>
     <div>&nbsp;
+        <div title="Allow for-statement.">
+        <label><input type="checkbox" value="for">for</label>
+        </div>
         <div title="Allow get() and set().">
         <label><input type="checkbox" value="getset">getset</label>
         </div>
@@ -1161,25 +1164,28 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
         <div title="Allow long lines.">
         <label><input type="checkbox" value="long">long</label>
         </div>
-        <div title="Allow weird property names.">
-        <label><input type="checkbox" value="name">name</label>
-        </div>
     </div>
     <div>&nbsp;
+        <div title="Allow weird property names.">
+        <label><input type="checkbox" value="nomen">nomen</label>
+        </div>
         <div title="Allow single-quote strings.">
         <label><input type="checkbox" value="single">single</label>
+        </div>
+        <div title="Allow identifiers in subscript-notation.">
+        <label><input type="checkbox" value="subscript">subscript</label>
         </div>
         <div title="Allow 'this'.">
         <label><input type="checkbox" value="this">this</label>
         </div>
+    </div>
+    <div>&nbsp;
         <div title="Allow unordered cases, params, properties, and variables.">
         <label><input type="checkbox" value="unordered">unordered</label>
         </div>
         <div title="Allow unordered const and let declarations that are not at top of function-scope.">
         <label><input type="checkbox" value="variable">variable</label>
         </div>
-    </div>
-    <div>&nbsp;
         <div title="Allow messy whitespace.">
         <label><input type="checkbox" value="white">white</label>
         </div>
@@ -1626,14 +1632,17 @@ eval("console.log(\\"hello world\\");");
 // .... /*jslint bitwise*/ ....... Allow bitwise operators.
 // .... /*jslint browser*/ ....... Assume browser environment.
 // .... /*jslint convert*/ ....... Allow conversion operators.
+// .... /*jslint couch*/ ......... Assume CouchDb environment.
 // .... /*jslint devel*/ ......... Allow console.log() and friends.
+// .... /*jslint eval*/ .......... Allow eval().
 // .... /*jslint for*/ ........... Allow for-statement.
 // .... /*jslint getset*/ ........ Allow get() and set().
 // .... /*jslint indent2*/ ....... Use 2-space indent.
 // .... /*jslint long*/ .......... Allow long lines.
-// .... /*jslint name*/ .......... Allow weird property names.
 // .... /*jslint node*/ .......... Assume Node.js environment.
+// .... /*jslint nomen*/ ......... Allow weird property names.
 // .... /*jslint single*/ ........ Allow single-quote strings.
+// .... /*jslint subscript*/ ..... Allow identifiers in subscript-notation.
 // .... /*jslint this*/ .......... Allow 'this'.
 // .... /*jslint trace*/ ......... Include jslint stack-trace in warnings.
 // .... /*jslint unordered*/ ..... Allow unordered cases, params, properties,

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -469,7 +469,9 @@ function globExclude({
 // $()*+-./?[\]^{|}
 
         strRegex = strRegex.replace((
-            // ignore [-/]
+
+// Ignore [-/].
+
             /[$()*+.?\[\\\]\^{|}]/g
         ), "\\$&");
 
@@ -1256,7 +1258,7 @@ function jslint(
             mode_json: false,           // true if parsing JSON.
             mode_module: false,         // true if import or export was used.
             mode_property: false,       // true if directive /*property*/ is
-                                        // used.
+                                        // ... used.
             mode_shebang: false,        // true if #! is seen on the first line.
             option_dict,
             property_dict,
@@ -2471,6 +2473,7 @@ function jslint_phase2_lex(state) {
                 global_dict[key] = "user-defined";
 
 // PR-347 - Disable warning "unexpected_directive_a".
+//
 //                 state.mode_module = the_comment;
 
                 break;
@@ -3289,7 +3292,7 @@ function jslint_phase2_lex(state) {
         case "node":            // Assume Node.js environment.
         case "nomen":           // Allow weird property names.
         case "single":          // Allow single-quote strings.
-        case "subscript":       // Allow identifiers in subscript-notation.
+        case "subscript":       // Allow identifier in subscript-notation.
         case "test_cause":      // Test jslint's causes.
         case "test_internal_error":     // Test jslint's internal-error
                                         // ... handling-ability.
@@ -3302,10 +3305,14 @@ function jslint_phase2_lex(state) {
         case "white":           // Allow messy whitespace.
             option_dict[key] = val;
             break;
-        // alias for eval
+
+// PR-404 - Alias "evil" to jslint-directive "eval" for backwards-compat.
+
         case "evil":
             return option_set_item("eval", val);
-        // alias for nomen
+
+// PR-404 - Alias "nomen" to jslint-directive "name" for backwards-compat.
+
         case "name":
             return option_set_item("nomen", val);
         default:
@@ -4555,9 +4562,7 @@ function jslint_phase3_parse(state) {
         if (the_subscript.id === "(string)" || the_subscript.id === "`") {
             name = survey(the_subscript);
 
-// PR-xxx - directive
-// Add new directive "subscript" allowing JSLint to be used with scripts
-// targeting Google Closure Compiler.
+// PR-404 - Add new directive "subscript" to play nice with Google Closure.
 
             if (!option_dict.subscript && jslint_rgx_identifier.test(name)) {
 
@@ -6357,6 +6362,7 @@ function jslint_phase3_parse(state) {
         let names;
 
 // PR-347 - Disable warning "unexpected_directive_a".
+//
 //         if (typeof state.mode_module === "object") {
 //
 // // test_cause:
@@ -6715,8 +6721,7 @@ function jslint_phase3_parse(state) {
 
             catchage = catch_stack.pop();
 
-// PR-xxx - warning
-// Relax warning about missing `catch` in `try...finally` statement.
+// PR-404 - Relax warning about missing `catch` in `try...finally` statement.
 //
 //         } else {
 //
@@ -6845,12 +6850,14 @@ function jslint_phase3_parse(state) {
                             return stop("expected_identifier_a");
                         }
 
-// PR-363 - Bugfix - fix false-warning
-// <uninitialized 'bb'> in code '/*jslint node*/\nlet {aa:bb} = {}; bb();'
+// PR-363 - Bugfix
+// Add test against false-warning <uninitialized 'bb'> in code
+// '/*jslint node*/\nlet {aa:bb} = {}; bb();'.
+//
+//                         token_nxt.label = name;
+//                         the_variable.names.push(token_nxt);
+//                         enroll(token_nxt, "variable", mode_const);
 
-                        // token_nxt.label = name;
-                        // the_variable.names.push(token_nxt);
-                        // enroll(token_nxt, "variable", mode_const);
                         name = token_nxt;
                         the_variable.names.push(name);
                         survey(name);
@@ -11113,15 +11120,13 @@ function sentinel() {}
         processArgElem[1] = processArgElem.slice(1).join("=");
         switch (processArgElem[0]) {
 
-// PR-371
-// Add cli-option `--exclude=...`.
+// PR-371 - Add cli-option `--exclude=...`.
 
         case "--exclude":
             excludeList.push(processArgElem[1]);
             break;
 
-// PR-371
-// Add cli-option `--include=...`
+// PR-371 - Add cli-option `--include=...`
 
         case "--include":
             includeList.push(processArgElem[1]);
@@ -11221,15 +11226,13 @@ function sentinel() {}
             pathnameDict[pathname] = scriptCov;
         });
 
-// PR-400
-// Filter directory `node_modules`.
+// PR-400 - Filter directory `node_modules`.
 
         if (!modeIncludeNodeModules) {
             excludeList.push("node_modules/");
         }
 
-// PR-400
-// Filter files by glob-patterns in excludeList, includeList.
+// PR-400 - Filter files by glob-patterns in excludeList, includeList.
 
         data.result = globExclude({
             excludeList,

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -1944,7 +1944,6 @@ function globExclude({
       /[\[\]]/g
     ), "\\$&");
     strRegex = strRegex.replace((
-      // ignore [-/]
       /[$()*+.?\[\\\]\^{|}]/g
     ), "\\$&");
     strRegex = strRegex.replace((

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -1713,7 +1713,11 @@ function objectDeepCopyWithKeysSorted(obj) {
             flags
         }) {
             result0 = result;
-            result = result.replace(new RegExp(aa, flags), bb);
+            result = result.replace(new RegExp(aa, flags), bb.replace((
+                /\*\\\\\//g
+            ), "*/").replace((
+                /\/\\\\\*/g
+            ), "/*"));
             if (result0 === result) {
                 throw new Error(
                     "shRawLibFetch - cannot find-and-replace snippet "

--- a/jslint_wrapper_codemirror.html
+++ b/jslint_wrapper_codemirror.html
@@ -6,12 +6,11 @@
 
 <!-- Assets from codemirror. -->
 
-    <link rel="stylesheet" href="https://codemirror.net/lib/codemirror.css">
-    <link rel="stylesheet" href="https://codemirror.net/addon/lint/lint.css">
-    <script defer src="https://codemirror.net/lib/codemirror.js"></script>
-    <script defer
-        src="https://codemirror.net/mode/javascript/javascript.js"></script>
-    <script defer src="https://codemirror.net/addon/lint/lint.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/codemirror.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/addon/lint/lint.css">
+    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/codemirror.js"></script>
+    <script defer src="https://codemirror.net/mode/javascript/javascript.js"></script>
+    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/addon/lint/lint.js"></script>
 
 <!-- Assets from jslint. -->
 
@@ -26,6 +25,10 @@ body {
 }
 .JSLINT_.JSLINT_REPORT_ {
     margin-top: 20px;
+}
+#editor1 {
+    height: 300px;
+    width: 100%;
 }
 </style>
 </head>

--- a/jslint_wrapper_codemirror.js
+++ b/jslint_wrapper_codemirror.js
@@ -57,7 +57,7 @@ window.addEventListener("load", function () {
 </html>
 */
 
-/*jslint browser devel*/
+/*jslint browser, devel*/
 /*global CodeMirror define exports jslint module require*/
 /*property
     Pos, amd, column, error, from, globals, jslint, line, map, message,

--- a/test.mjs
+++ b/test.mjs
@@ -861,8 +861,9 @@ jstestDescribe((
             ],
             var: [
 
-// PR-363 - Bugfix - add test against false-warning
-// <uninitialized 'bb'> in code '/*jslint node*/\nlet {aa:bb} = {}; bb();'
+// PR-363 - Bugfix
+// Add test against false-warning <uninitialized 'bb'> in code
+// '/*jslint node*/\nlet {aa:bb} = {}; bb();'.
 
                 "/*jslint node*/\n",
                 ""
@@ -921,6 +922,9 @@ jstestDescribe((
         ], [
             "debugger;", {devel: true}, []
         ], [
+
+// PR-404 - Alias "evil" to jslint-directive "eval" for backwards-compat.
+
             "new Function();\neval();", {eval: true, evil: true}, []
         ], [
             (
@@ -943,12 +947,18 @@ jstestDescribe((
         ], [
             "/".repeat(100), {long: true}, []
         ], [
+
+// PR-404 - Alias "nomen" to jslint-directive "name" for backwards-compat.
+
             "let aa = aa._;", {name: true, nomen: true}, []
         ], [
             "require();", {node: true}, []
         ], [
             "let aa = 'aa';", {single: true}, []
         ], [
+
+// PR-404 - Add new directive "subscript" to play nice with Google Closure.
+
             "aa[\"aa\"] = 1;", {subscript: true}, ["aa"]
         ], [
             "", {test_internal_error: true}, []

--- a/test.mjs
+++ b/test.mjs
@@ -839,6 +839,16 @@ jstestDescribe((
                     + "aa();\n"
                 )
             ],
+            try_finally: [
+                (
+                    "let aa = 0;\n"
+                    + "try {\n"
+                    + "    aa();\n"
+                    + "} finally {\n"
+                    + "    aa();\n"
+                    + "}\n"
+                )
+            ],
             use_strict: [
                 (
                     "\"use strict\";\n"
@@ -911,7 +921,7 @@ jstestDescribe((
         ], [
             "debugger;", {devel: true}, []
         ], [
-            "new Function();\neval();", {eval: true}, []
+            "new Function();\neval();", {eval: true, evil: true}, []
         ], [
             (
                 "function aa(aa) {\n"
@@ -933,11 +943,13 @@ jstestDescribe((
         ], [
             "/".repeat(100), {long: true}, []
         ], [
-            "let aa = aa._;", {name: true}, []
+            "let aa = aa._;", {name: true, nomen: true}, []
         ], [
             "require();", {node: true}, []
         ], [
             "let aa = 'aa';", {single: true}, []
+        ], [
+            "aa[\"aa\"] = 1;", {subscript: true}, ["aa"]
         ], [
             "", {test_internal_error: true}, []
         ], [
@@ -1112,7 +1124,7 @@ jstestDescribe((
     });
 });
 
-await jstestDescribe((
+jstestDescribe((
     "test misc handling-behavior"
 ), function testBehaviorMisc() {
     jstestIt((


### PR DESCRIPTION
- directive - add new directive `subscript` for linting of scripts targeting Google Closure Compiler
```js
/*jslint subscript*/
let aa = {};
// allow identifier in subscript-notation to prevent Google Closure Compiler
// from over-optimizing/renaming/mangling property-name "bb"
aa["bb"] = 1;
```

- warning - relax warning about missing `catch` in `try...finally` statement
```js
/*jslint browser*/
/*global _free, _malloc, manipulatePointer*/

function webassemblyFoo() {
    let pointer;
    try {
        pointer = _malloc(1024);
        manipulatePointer(pointer);
    } finally {
        // we want to cleanup pointer to prevent memory-leak,
        // but want the error to continue being raised
        _free(pointer);
    }
}

function uiFoo() {
    try {
        webassemblyFoo();
    } catch (err) {
        window.alert(err);
    }
}
```

- jslint - allow aliases `evil, nomen` for jslint-directives `eval, name`, respectively for backwards-compatibility

- bugfix - fix broken codemirror example

