### PR TITLE
- bugfix - fix expression after "await" mis-identified as statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
 
 # v2022.6.1-beta
+- bugfix - fix expression after "await" mis-identified as statement
 - directive - add new directive `subscript` for linting of scripts targeting Google Closure Compiler
 - warning - relax warning about missing `catch` in `try...finally` statement
 - jslint - allow aliases `evil, nomen` for jslint-directives `eval, name`, respectively for backwards-compat

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -5293,10 +5293,13 @@ function jslint_phase3_parse(state) {
             functionage.async += 1;
         }
         if (the_await.arity === "statement") {
-            the_await.block = parse_expression();
+
+// PR-405 - Bugfix - fix expression after "await" mis-identified as statement.
+
+            the_await.expression = parse_expression(150);
             semicolon();
         } else {
-            the_await.expression = parse_expression();
+            the_await.expression = parse_expression(150);
         }
         return the_await;
     }
@@ -8493,9 +8496,6 @@ function jslint_phase4_walk(state) {
 // ["+[]", "walk_statement", "unexpected_expression_a", "+", 1]
 // ["+new aa()", "walk_statement", "unexpected_expression_a", "+", 1]
 // ["0", "walk_statement", "unexpected_expression_a", "0", 1]
-// ["
-// async function aa(){await 0;}
-// ", "walk_statement", "unexpected_expression_a", "0", 27]
 // ["typeof 0", "walk_statement", "unexpected_expression_a", "typeof", 1]
 
                     warn("unexpected_expression_a", thing);

--- a/test.mjs
+++ b/test.mjs
@@ -647,6 +647,10 @@ jstestDescribe((
             ],
             async_await: [
                 "async function aa() {\n    await aa();\n}",
+
+// PR-405 - Bugfix - fix expression after "await" mis-identified as statement.
+
+                "async function aa() {\n    await aa;\n}",
                 (
                     "async function aa() {\n"
                     + "    try {\n"


### PR DESCRIPTION
this pr fixes jslint misidentifying expression after await-keyword as a statement

![image](https://user-images.githubusercontent.com/280571/174671780-fc26d948-6101-402c-928b-ccd658fdf9aa.png)
