### PR TITLE
- doc - document jslint directives

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -384,18 +384,6 @@ import moduleFs from "fs";
                             "when": "editorTextFocus"
                         },
                         {
-                            "command": "jslint.disableRegion",
-                            "key": "ctrl+shift+j d",
-                            "mac": "cmd+shift+j d",
-                            "when": "editorTextFocus"
-                        },
-                        {
-                            "command": "jslint.ignoreLine",
-                            "key": "ctrl+shift+j i",
-                            "mac": "cmd+shift+j i",
-                            "when": "editorTextFocus"
-                        },
-                        {
                             "command": "jslint.lint",
                             "key": "ctrl+shift+j l",
                             "mac": "cmd+shift+j l",
@@ -410,17 +398,17 @@ import moduleFs from "fs";
                                 "when": "resourceLangId == javascript"
                             },
                             {
-                                "command": "jslint.disableRegion",
+                                "command": "jslint.clear",
                                 "group": "7_modification@2",
                                 "when": "resourceLangId == javascript"
                             },
                             {
-                                "command": "jslint.ignoreLine",
+                                "command": "jslint.disableRegion",
                                 "group": "7_modification@3",
                                 "when": "resourceLangId == javascript"
                             },
                             {
-                                "command": "jslint.clear",
+                                "command": "jslint.ignoreLine",
                                 "group": "7_modification@4",
                                 "when": "resourceLangId == javascript"
                             }

--- a/.ci.sh
+++ b/.ci.sh
@@ -213,7 +213,7 @@ import moduleFs from "fs";
             // update version
             src: fileDict[".ci.sh"].replace((
                 /    "version": "\d\d\d\d\.\d\d?\.\d\d?(?:-.*?)?"/
-            ), `    "version": "${versionBeta}"`)
+            ), `    "version": "${versionBeta.split("-")[0]}"`)
         }, {
             file: "README.md",
             src: fileDict["README.md"].replace((
@@ -343,6 +343,8 @@ import moduleFs from "fs";
             src: JSON.stringify({
                 "activationEvents": [
                     "onCommand:jslint.clear",
+                    "onCommand:jslint.disableRegion",
+                    "onCommand:jslint.ignoreLine",
                     "onCommand:jslint.lint"
                 ],
                 "bugs": {
@@ -360,6 +362,16 @@ import moduleFs from "fs";
                         },
                         {
                             "category": "jslint",
+                            "command": "jslint.disableRegion",
+                            "title": "JSLint - Do Not Lint Selected Region"
+                        },
+                        {
+                            "category": "jslint",
+                            "command": "jslint.ignoreLine",
+                            "title": "JSLint - Ignore Current Line"
+                        },
+                        {
+                            "category": "jslint",
                             "command": "jslint.lint",
                             "title": "JSLint - Lint File"
                         }
@@ -372,6 +384,18 @@ import moduleFs from "fs";
                             "when": "editorTextFocus"
                         },
                         {
+                            "command": "jslint.disableRegion",
+                            "key": "ctrl+shift+j d",
+                            "mac": "cmd+shift+j d",
+                            "when": "editorTextFocus"
+                        },
+                        {
+                            "command": "jslint.ignoreLine",
+                            "key": "ctrl+shift+j i",
+                            "mac": "cmd+shift+j i",
+                            "when": "editorTextFocus"
+                        },
+                        {
                             "command": "jslint.lint",
                             "key": "ctrl+shift+j l",
                             "mac": "cmd+shift+j l",
@@ -381,13 +405,23 @@ import moduleFs from "fs";
                     "menus": {
                         "editor/context": [
                             {
-                                "command": "jslint.clear",
-                                "group": "7_modification",
+                                "command": "jslint.lint",
+                                "group": "7_modification@1",
                                 "when": "resourceLangId == javascript"
                             },
                             {
-                                "command": "jslint.lint",
-                                "group": "7_modification",
+                                "command": "jslint.disableRegion",
+                                "group": "7_modification@2",
+                                "when": "resourceLangId == javascript"
+                            },
+                            {
+                                "command": "jslint.ignoreLine",
+                                "group": "7_modification@3",
+                                "when": "resourceLangId == javascript"
+                            },
+                            {
+                                "command": "jslint.clear",
+                                "group": "7_modification@4",
                                 "when": "resourceLangId == javascript"
                             }
                         ]
@@ -412,7 +446,7 @@ import moduleFs from "fs";
                     "type": "git",
                     "url": "https://github.com/jslint-org/jslint.git"
                 },
-                "version": "2022.6.21"
+                "version": "2022.7.1"
             }, undefined, 4)
         }
     ].map(async function ({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 
 # Todo
-- wrapper - add vscode-command to suppress minor warnings on given line
-- doc - document jslint directives and supported/unsupported es6+ features
+- doc - document supported/unsupported es6+ features
 - cli - remove cli-option `--mode-vim-plugin`
 - coverage - add macros `/*coverage-disable*/` and `/*coverage-enable*/`.
 - jslint - add html and css linting back into jslint.
@@ -13,6 +12,10 @@
 - jslint - unify analysis of variable-assignment/function-parameters into one function
 - jslint - add new warning "Expected Object.create(null) instead of {}"
 - node - after node-v14 is deprecated, remove shell-code `export "NODE_OPTIONS=--unhandled-rejections=strict"`.
+
+# v2022.7.1-beta
+- doc - document jslint directives
+- vscode - add extra contextmenu commands "JSLint - Do Not Lint Selected Region", "JSLint - Ignore Current Line"
 
 # v2022.6.21
 - directive - add new directive `subscript` for linting of scripts targeting Google Closure Compiler

--- a/README.md
+++ b/README.md
@@ -18,36 +18,59 @@ Douglas Crockford <douglas@crockford.com>
 
 2. [Web Demo Archived](#web-demo-archived)
 
-3. [API Doc](#api-doc)
-
-4. [Quickstart Install](#quickstart-install)
+3. [Quickstart Install](#quickstart-install)
     - [To install, just download and save https://www.jslint.com/jslint.mjs to file:](#to-install-just-download-and-save-httpswwwjslintcomjslintmjs-to-file)
     - [To run `jslint.mjs` in shell:](#to-run-jslintmjs-in-shell)
     - [To import `jslint.mjs` in ES Module environment:](#to-import-jslintmjs-in-es-module-environment)
     - [To import `jslint.mjs` in CommonJS environment:](#to-import-jslintmjs-in-commonjs-environment)
     - [To JSLint entire directory in shell:](#to-jslint-entire-directory-in-shell)
 
-5. [Quickstart JSLint Report](#quickstart-jslint-report)
+4. [Quickstart JSLint Report](#quickstart-jslint-report)
     - [To create a JSLint report in shell:](#to-create-a-jslint-report-in-shell)
     - [To create a JSLint report in javascript:](#to-create-a-jslint-report-in-javascript)
 
-6. [Quickstart V8 Coverage Report](#quickstart-v8-coverage-report)
+5. [Quickstart V8 Coverage Report](#quickstart-v8-coverage-report)
     - [To create V8 coverage report from Node.js / Npm program in shell:](#to-create-v8-coverage-report-from-nodejs--npm-program-in-shell)
     - [To create V8 coverage report from Node.js / Npm program in javascript:](#to-create-v8-coverage-report-from-nodejs--npm-program-in-javascript)
 
-7. [Quickstart JSLint in CodeMirror](#quickstart-jslint-in-codemirror)
+6. [Quickstart JSLint in CodeMirror](#quickstart-jslint-in-codemirror)
 
-8. [Quickstart JSLint in Vim](#quickstart-jslint-in-vim)
+7. [Quickstart JSLint in Vim](#quickstart-jslint-in-vim)
 
-9. [Quickstart JSLint in VSCode](#quickstart-jslint-in-vscode)
+8. [Quickstart JSLint in VSCode](#quickstart-jslint-in-vscode)
 
-10. [Description](#description)
+9. [Documentation](#documentation)
+    - [API Doc](#api-doc)
+    - [Directive `/*jslint*/`](#directive-jslint)
+        - [`/*jslint beta*/`](#jslint-beta)
+        - [`/*jslint bitwise*/`](#jslint-bitwise)
+        - [`/*jslint browser*/`](#jslint-browser)
+        - [`/*jslint convert*/`](#jslint-convert)
+        - [`/*jslint couch*/`](#jslint-couch)
+        - [`/*jslint devel*/`](#jslint-devel)
+        - [`/*jslint eval*/`](#jslint-eval)
+        - [`/*jslint for*/`](#jslint-for)
+        - [`/*jslint getset*/`](#jslint-getset)
+        - [`/*jslint indent2*/`](#jslint-indent2)
+        - [`/*jslint long*/`](#jslint-long)
+        - [`/*jslint node*/`](#jslint-node)
+        - [`/*jslint nomen*/`](#jslint-nomen)
+        - [`/*jslint single*/`](#jslint-single)
+        - [`/*jslint subscript*/`](#jslint-subscript)
+        - [`/*jslint this*/`](#jslint-this)
+        - [`/*jslint trace*/`](#jslint-trace)
+        - [`/*jslint unordered*/`](#jslint-unordered)
+        - [`/*jslint white*/`](#jslint-white)
+    - [Directive `/*global*/`](#directive-global)
+    - [Directive `/*property*/`](#directive-property)
+    - [Directive `/*jslint-disable*/.../*jslint-enable*/`](#directive-jslint-disablejslint-enable)
+    - [Directive `//jslint-ignore-line`](#directive-jslint-ignore-line)
 
-11. [Package Listing](#package-listing)
+10. [Package Listing](#package-listing)
 
-12. [Changelog](#changelog)
+11. [Changelog](#changelog)
 
-13. [License](#license)
+12. [License](#license)
 
 
 <br><br>
@@ -62,13 +85,6 @@ Douglas Crockford <douglas@crockford.com>
 - [Web Demo 2020](https://www.jslint.com/branch-v2020.11.6/index.html)
 - [Web Demo 2014 (ES5 only)](https://www.jslint.com/branch-v2014.7.8/jslint.html)
 - [Web Demo 2013 (ES5, CSS, HTML)](https://www.jslint.com/branch-v2013.3.13/jslint.html)
-
-
-<br><br>
-# API Doc
-- https://www.jslint.com/apidoc.html
-
-[![screenshot](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_browser__2f.artifact_2fapidoc.html.png)](https://www.jslint.com/apidoc.html)
 
 
 <br><br>
@@ -504,7 +520,9 @@ window.addEventListener("load", function () {
 
 
 <br><br>
-# Description
+# Documentation
+
+
 - [jslint.mjs](jslint.mjs) contains the jslint function. It parses and analyzes a source file, returning an object with information about the file. It can also take an object that sets options.
 
 - [index.html](index.html) runs the jslint.mjs function in a web page.
@@ -526,6 +544,324 @@ This applies to programming as well. Conforming to a consistent style improves
 readability, and frees you to express yourself in ways that matter. JSLint here
 plays the part of a stern but benevolent editor, helping you to get the style
 right so that you can focus your creative energy where it is most needed.
+
+
+<br><br>
+### API Doc
+- https://www.jslint.com/apidoc.html
+
+[![screenshot](https://jslint-org.github.io/jslint/branch-beta/.artifact/screenshot_browser__2f.artifact_2fapidoc.html.png)](https://www.jslint.com/apidoc.html)
+
+
+<br><br>
+### Directive `/*jslint*/`
+
+<br>
+
+##### `/*jslint beta*/`
+
+```js
+/*jslint beta*/
+// Enable experimental warnings.
+// Warn if global variables are redefined.
+// Warn if const / let statements are not declared at top of function or
+//    script, similar to var statements.
+// Warn if const / let / var statements are not declared in ascii-order.
+// Warn if named-functions are not declared in ascii-order.
+```
+
+<br>
+
+##### `/*jslint bitwise*/`
+
+```js
+/*jslint bitwise*/
+// Allow bitwise operators.
+
+let foo = 0 | 1;
+```
+
+<br>
+
+##### `/*jslint browser*/`
+
+```js
+/*jslint browser*/
+// Assume browser environment.
+
+localStorage.getItem("foo");
+```
+
+<br>
+
+##### `/*jslint convert*/`
+
+```js
+/*jslint convert*/
+// Allow conversion operators.
+
+let foo = new Date() + "";
+let bar = !!0;
+```
+
+<br>
+
+##### `/*jslint couch*/`
+
+```js
+/*jslint couch*/
+// Assume CouchDb environment.
+
+registerType("text-json", "text/json");
+```
+
+<br>
+
+##### `/*jslint devel*/`
+
+```js
+/*jslint devel*/
+// Allow console.log() and friends.
+
+console.log("hello");
+```
+
+<br>
+
+##### `/*jslint eval*/`
+
+```js
+/*jslint eval*/
+// Allow eval().
+
+eval("1");
+```
+
+<br>
+
+##### `/*jslint for*/`
+
+```js
+/*jslint for*/
+// Allow for-loop.
+
+function foo() {
+    let ii;
+    for (ii = 0; ii < 10; ii += 1) {
+        foo();
+    }
+}
+```
+
+<br>
+
+##### `/*jslint getset*/`
+
+```js
+/*jslint getset, this, devel*/
+// Allow get() and set().
+
+let foo = {
+    bar: 0,
+    get getBar() {
+        return this.bar;
+    },
+    set setBar(value) {
+        this.bar = value;
+    }
+};
+console.log(foo.getBar); // 0
+foo.setBar = 1;
+console.log(foo.getBar); // 1
+```
+
+<br>
+
+##### `/*jslint indent2*/`
+
+```js
+/*jslint indent2*/
+// Use 2-space indent.
+
+function foo() {
+  return;
+}
+```
+
+<br>
+
+##### `/*jslint long*/`
+
+```js
+/*jslint long*/
+// Allow long lines.
+
+let foo = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+```
+
+<br>
+
+##### `/*jslint node*/`
+
+```js
+/*jslint node*/
+// Assume Node.js environment.
+
+require("fs");
+```
+
+<br>
+
+##### `/*jslint nomen*/`
+
+```js
+/*jslint nomen*/
+// Allow weird property names.
+
+let foo = {};
+foo._bar = 1;
+```
+
+<br>
+
+##### `/*jslint single*/`
+
+```js
+/*jslint single*/
+// Allow single-quote strings.
+
+let foo = '';
+```
+
+<br>
+
+##### `/*jslint subscript*/`
+
+```js
+/*jslint subscript*/
+// Allow identifiers in subscript-notation.
+
+let foo = {};
+foo["bar"] = 1;
+```
+
+<br>
+
+##### `/*jslint this*/`
+
+```js
+/*jslint this*/
+// Allow 'this'.
+
+function foo() {
+    return this;
+}
+```
+
+<br>
+
+##### `/*jslint trace*/`
+
+```js
+/*jslint trace*/
+// Include jslint stack-trace in warnings.
+
+console.log('hello world');
+/*
+1. Undeclared 'console'.
+console.log('hello world');
+Error
+    at warn_at (...)
+    at warn (...)
+    at lookup (...)
+    at pre_v (...)
+    at jslint.mjs
+2. Use double quotes, not single quotes.
+console.log(...);
+Error
+    at warn_at (...)
+    at lex_string (...)
+    at lex_token (...)
+    at jslint_phase2_lex (...)
+    at Function.jslint (...)
+    at jslint.mjs
+*/
+```
+
+<br>
+
+##### `/*jslint unordered*/`
+
+```js
+/*jslint unordered*/
+// Allow unordered cases, params, properties, and variables.
+
+let foo = {bb: 1, aa: 0};
+
+function bar({
+    bb = 1,
+    aa = 0
+}) {
+    return aa + bb;
+}
+```
+
+<br>
+
+##### `/*jslint white*/`
+
+```js
+/*jslint white*/
+// Allow messy whitespace.
+
+let foo = 1; let bar = 2;
+```
+
+
+<br><br>
+### Directive `/*global*/`
+
+```js
+/*global foo, bar*/
+// Declare global variables foo, bar.
+
+foo();
+bar();
+```
+
+
+<br><br>
+### Directive `/*property*/`
+
+```js
+/*property foo, bar*/
+// Restrict property-access to only .foo, .bar.
+
+let aa = {bar: 1, foo: 2};
+```
+
+
+<br><br>
+### Directive `/*jslint-disable*/.../*jslint-enable*/`
+
+```js
+/*jslint-disable*/
+
+JSLint will ignore and treat this region as blank-lines.
+Syntax error.
+
+/*jslint-enable*/
+```
+
+
+<br><br>
+### Directive `//jslint-ignore-line`
+
+```js
+// JSLint will ignore non-fatal warnings at given line.
+
+eval("1"); //jslint-ignore-line
+```
 
 
 <br><br>

--- a/index.html
+++ b/index.html
@@ -1271,7 +1271,7 @@ function dom_style_report_unmatched() {
             try {
                 ii = document.querySelectorAll(match1).length;
             } catch (err) {
-                console.error(match1 + "\n" + err); //jslint-quiet
+                console.error(match1 + "\n" + err); //jslint-ignore-line
             }
             if (ii <= 1 && !(
                 /^0 (?:(body > )?(?:\.button|\.readonly|\.styleColorError|\.textarea|\.uiAnimateSlide|a|base64|body|code|div|input|pre|textarea)(?:,| \{))|^[1-9]\d*? #/m
@@ -1282,7 +1282,7 @@ function dom_style_report_unmatched() {
         });
     });
     style_list.sort().reverse().forEach(function (elem, ii, list) {
-        console.error( //jslint-quiet
+        console.error( //jslint-ignore-line
             "dom_style_report_unmatched " + (list.length - ii) + ". " + elem
         );
     });
@@ -1329,7 +1329,7 @@ async function jslint_run() {
         ).innerHTML = jslint.jslint_report(jslint_option_dict.result);
         listener_window_onresize();
     } catch (err) {
-        console.error(err); //jslint-quiet
+        console.error(err); //jslint-ignore-line
     }
 
 // Hide ui-loader-animation.
@@ -1620,10 +1620,11 @@ import https from "https";
 import jslint from \u0022./jslint.mjs\u0022;
 
 /*jslint-disable*/
+    JSLint will ignore and treat this region as blank-lines.
     Syntax error.\u0020\u0020\u0020\u0020
 /*jslint-enable*/
 
-eval("console.log(\\"hello world\\");"); //jslint-quiet
+eval("console.log(\\"hello world\\");"); //jslint-ignore-line
 
 eval("console.log(\\"hello world\\");");
 
@@ -1647,11 +1648,9 @@ eval("console.log(\\"hello world\\");");
 // .... /*jslint trace*/ ......... Include jslint stack-trace in warnings.
 // .... /*jslint unordered*/ ..... Allow unordered cases, params, properties,
 // ................................... and variables.
-// .... /*jslint variable*/ ...... Allow unordered const and let declarations
-// ................................... that are not at top of function-scope.
 // .... /*jslint white*/ ......... Allow messy whitespace.
 
-(async function () {
+await (async function () {
     let result = await new Promise(function (resolve) {
         https.request("https://www.jslint.com/jslint.mjs", function (res) {
             result = "";

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -100,7 +100,7 @@
     catch_stack, causes, char, children, clear, closer, closure, code, column,
     concat, consoleError, console_error, console_log, constant, context,
     convert, count, coverageDir, create, cwd, d, dead, debugInline, default,
-    delta, devel, directive, directive_list, directive_quiet, directives,
+    delta, devel, directive, directive_ignore_line, directive_list, directives,
     dirname, disrupt, dot, edition, elem_list, ellipsis, else, end, endOffset,
     endsWith, entries, env, error, eval, every, example_list, excludeList, exec,
     execArgv, exit, exitCode, export_dict, exports, expression, extra, file,
@@ -165,7 +165,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2022.6.21";
+let jslint_edition = "v2022.7.1-beta";
 let jslint_export;                      // The jslint object to be exported.
 let jslint_fudge = 1;                   // Fudge starting line and starting
                                         // ... column to 1.
@@ -1219,12 +1219,12 @@ function jslint(
         if (option_dict.trace) {
             warning.stack_trace = new Error().stack;
         }
-        if (warning.directive_quiet) {
+        if (warning.directive_ignore_line) {
 
 // test_cause:
-// ["0 //jslint-quiet", "semicolon", "directive_quiet", "", 0]
+// ["0 //jslint-ignore-line", "semicolon", "directive_ignore_line", "", 0]
 
-            test_cause("directive_quiet");
+            test_cause("directive_ignore_line");
             return warning;
         }
         warning_list.push(warning);
@@ -2413,7 +2413,7 @@ function jslint_phase2_lex(state) {
         if (!option_dict.devel && jslint_rgx_todo.test(snippet)) {
 
 // test_cause:
-// ["//todo", "lex_comment", "todo_comment", "(comment)", 1] //jslint-quiet
+// ["//todo", "lex_comment", "todo_comment", "(comment)", 1] //jslint-ignore-line
 
             warn("todo_comment", the_comment);
         }
@@ -3658,7 +3658,7 @@ import moduleHttps from "https";
         ) {
 
 // test_cause:
-// ["/////////////////////////////////////////////////////////////////////////////////", "read_line", "too_long", "", 1] //jslint-quiet
+// ["/////////////////////////////////////////////////////////////////////////////////", "read_line", "too_long", "", 1] //jslint-ignore-line
 
             warn_at("too_long", line);
         }
@@ -3676,7 +3676,7 @@ import moduleHttps from "https";
 // Scan each line for following ignore-directives:
 // "/*jslint-disable*/"
 // "/*jslint-enable*/"
-// "//jslint-quiet"
+// "//jslint-ignore-line"
 
         if (line_source === "/*jslint-disable*/") {
 
@@ -3694,13 +3694,16 @@ import moduleHttps from "https";
                 stop_at("unopened_enable", line);
             }
             line_disable = undefined;
-        } else if (line_source.endsWith(" //jslint-quiet")) {
+        } else if (
+            line_source.endsWith(" //jslint-ignore-line")
+            || line_source.endsWith(" //jslint-quiet")
+        ) {
 
 // test_cause:
-// ["0 //jslint-quiet", "read_line", "jslint_quiet", "", 0]
+// ["0 //jslint-ignore-line", "read_line", "jslint_ignore_line", "", 0]
 
-            test_cause("jslint_quiet");
-            line_list[line].directive_quiet = true;
+            test_cause("jslint_ignore_line");
+            line_list[line].directive_ignore_line = true;
         }
         if (line_disable !== undefined) {
 
@@ -10214,7 +10217,7 @@ function v8CoverageListMerge(processCovs) {
             let resultTree;
             let rightChildren;
 
-// TODO(perf): Binary search (check overhead) //jslint-quiet
+// TODO(perf): Binary search (check overhead) //jslint-ignore-line
 
             while (ii < tree.children.length) {
                 child = tree.children[ii];
@@ -10292,7 +10295,7 @@ function v8CoverageListMerge(processCovs) {
 
 // This function will normalize-and-sort <funcCov>.ranges.
 // Sorts the ranges (pre-order sort).
-// TODO: Tree-based normalization of the ranges. //jslint-quiet
+// TODO: Tree-based normalization of the ranges. //jslint-ignore-line
 // @param funcCov Function coverage to normalize.
 
         funcCov.ranges = treeToRanges(treeFromSortedRanges(

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -414,7 +414,7 @@ shCiBase() {(set -e
 import moduleFs from "fs";
 globalThis.assert(
     JSON.parse(
-        moduleFs.readFileSync("package.json") //jslint-quiet
+        moduleFs.readFileSync("package.json") //jslint-ignore-line
     ).fileCount === Number(process.argv[1]),
     `package.json.fileCount !== ${process.argv[1]}`
 );
@@ -484,8 +484,7 @@ import moduleFs from "fs";
         let ii = -1;
         let toc = "\n# Table of Contents\n";
         data.replace((
-            // /(\n{3,}#|\n+?<br><br>\n#|\n+?###) (\S.*)/g
-            /((?:\n{3,}|\n+?(?:<br>)+?\n)(?:#|###)) (\S.*)/g
+            /((?:\n{3,}|\n+?(?:<br>)+?\n+?)(?:#|###|#####)) (\S.*)/g
         ), function (match0, level, title) {
             if (title === "Table of Contents") {
                 ii += 1;
@@ -495,6 +494,9 @@ import moduleFs from "fs";
                 return "";
             }
             switch (level) {
+            case "\n\n<br>\n\n#####":
+                toc += "        - [" + title + "](#";
+                break;
             case "\n\n\n<br><br>\n#":
                 ii += 1;
                 toc += "\n" + ii + ". [" + title + "](#";
@@ -1000,7 +1002,7 @@ import modulePath from "path";
     data = data.replace((
         /^(.+?):(\d+?):(.*?)$/gm
     ), function (ignore, file, lineno, str) {
-        dict[file] = dict[file] || moduleFs.readFileSync( //jslint-quiet
+        dict[file] = dict[file] || moduleFs.readFileSync( //jslint-ignore-line
             modulePath.resolve(file),
             "utf8"
         ).split("\n");
@@ -1248,7 +1250,7 @@ import moduleUrl from "url";
                 script = "\n";
                 break;
             // syntax-sugar - list obj-keys, sorted by item-type
-            // console.error(Object.keys(global).map(function(key){return(typeof global[key]===\u0027object\u0027&&global[key]&&global[key]===global[key]?\u0027global\u0027:typeof global[key])+\u0027 \u0027+key;}).sort().join(\u0027\n\u0027)) //jslint-quiet
+            // console.error(Object.keys(global).map(function(key){return(typeof global[key]===\u0027object\u0027&&global[key]&&global[key]===global[key]?\u0027global\u0027:typeof global[key])+\u0027 \u0027+key;}).sort().join(\u0027\n\u0027)) //jslint-ignore-line
             case "keys":
                 script = (
                     "console.error(Object.keys(" + match2
@@ -1702,7 +1704,7 @@ function objectDeepCopyWithKeysSorted(obj) {
             /\n+?(\n *?\})/g
         ), "$1");
         // eslint - no-multiple-empty-lines
-        // https://github.com/eslint/eslint/blob/v7.2.0/docs/rules/no-multiple-empty-lines.md //jslint-quiet
+        // https://github.com/eslint/eslint/blob/v7.2.0/docs/rules/no-multiple-empty-lines.md //jslint-ignore-line
         result = result.replace((
             /\n{4,}/g
         ), "\n\n\n");
@@ -1811,7 +1813,7 @@ function objectDeepCopyWithKeysSorted(obj) {
             result += "\n\n" + match1.trim() + "\n";
         });
         // write to file
-        moduleFs.writeFileSync(process.argv[1], result); //jslint-quiet
+        moduleFs.writeFileSync(process.argv[1], result); //jslint-ignore-line
     });
 }());
 ' "$@" # '

--- a/jslint_wrapper_codemirror.js
+++ b/jslint_wrapper_codemirror.js
@@ -134,14 +134,14 @@ window.addEventListener("load", function () {
             mode_stop
         }) {
             return {
-                from: CodeMirror.Pos(line - 1, column - 1), //jslint-quiet
+                from: CodeMirror.Pos(line - 1, column - 1), //jslint-ignore-line
                 message,
                 severity: (
                     mode_stop
                     ? "error"
                     : "warning"
                 ),
-                to: CodeMirror.Pos(line - 1, column) //jslint-quiet
+                to: CodeMirror.Pos(line - 1, column) //jslint-ignore-line
             };
         });
     });

--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
         "test2": "sh jslint_ci.sh shCiBase"
     },
     "type": "module",
-    "version": "2022.6.21"
+    "version": "2022.7.1-beta"
 }

--- a/test.mjs
+++ b/test.mjs
@@ -709,8 +709,8 @@ jstestDescribe((
             jslint_disable: [
                 "/*jslint-disable*/\n0\n/*jslint-enable*/"
             ],
-            jslint_quiet: [
-                "0 //jslint-quiet"
+            jslint_ignore_line: [
+                "0 //jslint-ignore-line"
             ],
             json: [
                 "{\"aa\":[[],-0,null]}"
@@ -1088,7 +1088,7 @@ jstestDescribe((
                 assertOrThrow(source.length > (80 - 3), source);
                 return source;
             }).replace((
-                / \/\/jslint-quiet$/gm
+                / \/\/jslint-ignore-line$/gm
             ), "");
             tmp = causeList.split("\n").map(function (cause) {
                 return (


### PR DESCRIPTION
- vscode - add extra contextmenu commands "JSLint - Do Not Lint Selected Region", "JSLint - Ignore Current Line"

1. this pr documents jslint's most common directives in README.md
    - directive `//jslint-quiet` is renamed to `//jslint-ignore-line`, but the old directive is kept as an alias for backwards-compat

![image](https://user-images.githubusercontent.com/280571/176814966-0e298523-198c-4255-8b54-878d436392a2.png)

3. update vscode-plugin with extra commands to disable jslint on per-region and per-line basis

![image](https://user-images.githubusercontent.com/280571/176814694-cf21055d-18d3-4c45-a85c-1ae7879de7c9.png)
