### PR TITLE
- jslint - hide warning about unordered case-statements behind beta-flag

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -434,7 +434,7 @@ import moduleFs from "fs";
                     "type": "git",
                     "url": "https://github.com/jslint-org/jslint.git"
                 },
-                "version": "2022.11.20"
+                "version": "2022.12.1"
             }, undefined, 4)
         }
     ].map(async function ({

--- a/.ci.sh
+++ b/.ci.sh
@@ -434,7 +434,7 @@ import moduleFs from "fs";
                     "type": "git",
                     "url": "https://github.com/jslint-org/jslint.git"
                 },
-                "version": "2022.12.1"
+                "version": "2023.1.1"
             }, undefined, 4)
         }
     ].map(async function ({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - jslint - add new warning "Expected Object.create(null) instead of {}"
 
 # v2022.12.1-beta
+- ci - bugfix - update shell-function shCiBase() to handle undefined fileMain
 - ci - auto-update version-number in main mjs-module
 - ci - update shell-function shDirHttplinkValidate() to ignore insecure-links http://127.0.0.1, http://localhost
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - jslint - unify analysis of variable-assignment/function-parameters into one function
 - jslint - add new warning "Expected Object.create(null) instead of {}"
 
-# v2022.12.1-beta
+# v2023.1.1-beta
+- jslint - hide warning about unordered case-statements behind beta-flag
 - ci - bugfix - update shell-function shCiBase() to handle undefined fileMain
 - ci - auto-update version-number in main mjs-module
 - ci - update shell-function shDirHttplinkValidate() to ignore insecure-links http://127.0.0.1, http://localhost

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - jslint - unify analysis of variable-assignment/function-parameters into one function
 - jslint - add new warning "Expected Object.create(null) instead of {}"
 
+# v2022.12.1-beta
+- ci - update shell-function shDirHttplinkValidate() to ignore insecure-links http://127.0.0.1, http://localhost
+
 # v2022.11.20
 - ci - update ci from node-v16 to node-v18
 - cli - remove deprecated cli-option `--mode-vim-plugin`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - jslint - add new warning "Expected Object.create(null) instead of {}"
 
 # v2022.12.1-beta
+- ci - auto-update version-number in main mjs-module
 - ci - update shell-function shDirHttplinkValidate() to ignore insecure-links http://127.0.0.1, http://localhost
 
 # v2022.11.20

--- a/README.md
+++ b/README.md
@@ -567,6 +567,7 @@ right so that you can focus your creative energy where it is most needed.
 //    script, similar to var statements.
 // Warn if const / let / var statements are not declared in ascii-order.
 // Warn if named-functions are not declared in ascii-order.
+// Warn if cases in switch-statements are not in ascii-order.
 ```
 
 <br>

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -165,7 +165,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2022.11.20";
+let jslint_edition = "v2022.12.1-beta";
 let jslint_export;                      // The jslint object to be exported.
 let jslint_fudge = 1;                   // Fudge starting line and starting
                                         // ... column to 1.

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -165,7 +165,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2022.12.1-beta";
+let jslint_edition = "v2023.1.1-beta";
 let jslint_export;                      // The jslint object to be exported.
 let jslint_fudge = 1;                   // Fudge starting line and starting
                                         // ... column to 1.
@@ -4185,7 +4185,11 @@ function jslint_phase3_parse(state) {
             }
         }).reduce(function (aa, bb) {
             if (
-                !option_dict.unordered
+
+// PR-xxx - Hide warning about unordered case-statements behind beta-flag.
+
+                option_dict.beta
+                && !option_dict.unordered
                 && aa && bb
                 && (
                     aa.order > bb.order

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -439,7 +439,7 @@ import moduleFs from "fs";
         fileDict[file] = await moduleFs.promises.readFile(file, "utf8");
         if (file === "package.json") {
             packageJson = JSON.parse(fileDict[file]);
-            fileMain = packageJson.module || packageJson.main;
+            fileMain = packageJson.module || packageJson.main || "package.json";
             fileDict[fileMain] = (
                 await moduleFs.promises.readFile(fileMain, "utf8")
             );

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -638,6 +638,11 @@ import moduleUrl from "url";
                 `\\b${UPSTREAM_GITHUB_IO}\\b`,
                 "g"
             ), GITHUB_GITHUB_IO);
+            if ((
+                /^http:\/\/(?:127\.0\.0\.1|localhost)[\/:]/
+            ).test(url)) {
+                return;
+            }
             if (url.startsWith("http://")) {
                 throw new Error(
                     `shDirHttplinkValidate - ${file} - insecure link - ${url}`

--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
         "test2": "sh jslint_ci.sh shCiBase"
     },
     "type": "module",
-    "version": "2022.12.1-beta"
+    "version": "2023.1.1-beta"
 }

--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
         "test2": "sh jslint_ci.sh shCiBase"
     },
     "type": "module",
-    "version": "2022.11.20"
+    "version": "2022.12.1-beta"
 }


### PR DESCRIPTION
this pr relaxes warning about unordered cases in switch-statements (can be re-enabled with `/*jslint beta*/`):

```js
/*jslint beta*/
function baz(aa) {
    switch (aa) {
    case 2:
        return 2;
    case 1:
        return 1;
    default:
        return 0;
    }
}

/*
 1. Expected case-number '1' to be ordered before case-number '2'. // line 6, column 10
    case 1:
*/
```

additionally:
- ci - bugfix - update shell-function shCiBase() to handle undefined fileMain
- ci - auto-update version-number in main mjs-module
- ci - update shell-function shDirHttplinkValidate() to ignore insecure-links http://127.0.0.1, http://localhost
