### PR TITLE
# v2023.1.29

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -432,7 +432,7 @@ import moduleFs from "fs";
                     "type": "git",
                     "url": "https://github.com/jslint-org/jslint.git"
                 },
-                "version": "2023.1.1"
+                "version": "2023.1.29"
             }, undefined, 4)
         }
     ].map(async function ({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
 - jslint - unify analysis of variable-assignment/function-parameters into one function
 
-# v2023.1.1-beta
+# v2023.1.29
+- ci - in windows-ci-env, alias node=node.exe instead of using winpty for pipes
 - ci - bugfix - fix ci-shell-function shGithubFileUpload unable to upload new asset
 - ci - auto-create asset_image_logo_512.png from asset_image_logo_512.html
 - bugfix - fix shell-function shGithubCheckoutRemote not able to checkout trusted-files in non-alpha branches

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Status
-| Branch | [master<br>(v2022.11.20)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
+| Branch | [master<br>(v2023.1.29)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
 |--:|:--:|:--:|:--:|
 | CI | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jslint-org/jslint/actions?query=branch%3Amaster) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/jslint-org/jslint/actions?query=branch%3Abeta) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/jslint-org/jslint/actions?query=branch%3Aalpha) |
 | Coverage | [![coverage](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/index.html) |

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -165,7 +165,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2023.1.1-beta";
+let jslint_edition = "v2023.1.29";
 let jslint_export;                      // The jslint object to be exported.
 let jslint_fudge = 1;                   // Fudge starting line and starting
                                         // ... column to 1.

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -3310,16 +3310,13 @@ shCiMain() {(set -e
     then
         return
     fi
-    # run "$@" with winpty
-    local CI_UNAME="${CI_UNAME:-$(uname)}"
-    case "$CI_UNAME" in
+    # alias node.exe
+    case "$(uname)" in
+    MINGW*)
+        if (! alias node &>/dev/null); then alias node=node.exe; fi
+        ;;
     MSYS*)
-        if [ ! "$CI_WINPTY" ] && [ "$1" != shHttpFileServer ]
-        then
-            export CI_WINPTY=1
-            winpty -Xallow-non-tty -Xplain sh "$0" "$@"
-            return
-        fi
+        if (! alias node &>/dev/null); then alias node=node.exe; fi
         ;;
     esac
     # run "$@"

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "shCiArtifactUpload": 1,
     "shCiNpmPublish": 1,
     "type": "module",
-    "version": "2023.1.1-beta"
+    "version": "2023.1.29"
 }


### PR DESCRIPTION
- ci - bugfix - fix ci-shell-function shGithubFileUpload unable to upload new asset
- ci - auto-create asset_image_logo_512.png from asset_image_logo_512.html
- bugfix - fix shell-function shGithubCheckoutRemote not able to checkout trusted-files in non-alpha branches
- jslint-ci - revamp auto-updating and add shell-function shGithubCheckoutRemote
- test - print time-finished after test-run
- jslint - hide warning about unordered case-statements behind beta-flag
- ci - bugfix - update shell-function shCiBase() to handle undefined fileMain
- ci - auto-update version-number in main mjs-module
- ci - update shell-function shDirHttplinkValidate() to ignore insecure-links http://127.0.0.1, http://localhost