### PR TITLE
Open links in new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -1054,7 +1054,7 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
 <!-- The page does not contain a heading, skip link, or landmark region -->
 <a class="skip-link" href="#JSLINT_INPUT">Skip to main</a>
 <div id="bannerFork1">
-    <div><a href="https://github.com/jslint-org/jslint">Fork on github</a></div>
+    <div><a href="https://github.com/jslint-org/jslint" target="_blank">Fork on github</a></div>
 </div>
 <div id="uiLoader1">
     <div>Loading modules</div>
@@ -1072,9 +1072,9 @@ pyNj+JctcQLXenBOCms46aMkenIx45WpXqxxVJQLz/vgpmAVa0fmDv6Pue9xVTBPfVxCUGfj\
     <div id="JSLINT_EDITION" style="font-size: 14px;">&nbsp;</div>
     </div>
     <ul style="float: right; font-size: 14.5px; margin-top: -10px;">
-    <li><a href="https://github.com/jslint-org/jslint#directive-jslint">Read the instructions.</a></li>
-    <li><a href="https://www.amazon.com/dp/1949815005/wrrrldwideweb"><i>How JavaScript Works</i> by Douglas Crockford.</a></li>
-    <li><a href="https://github.com/jslint-org/jslint/issues">Report a bug or issue.</a></li>
+    <li><a href="https://github.com/jslint-org/jslint#directive-jslint" target="_blank">Read the instructions.</a></li>
+    <li><a href="https://www.amazon.com/dp/1949815005/wrrrldwideweb" target="_blank"><i>How JavaScript Works</i> by Douglas Crockford.</a></li>
+    <li><a href="https://github.com/jslint-org/jslint/issues" target="_blank">Report a bug or issue.</a></li>
     </ul>
 </div>
 <fieldset id="JSLINT_SOURCE">


### PR DESCRIPTION
Open links in new tabs to prevent textarea content from getting wiped.

Closes #345 