### PR TITLE
# v2023.4.29

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -441,7 +441,7 @@ import moduleFs from "fs";
                     "type": "git",
                     "url": "https://github.com/jslint-org/jslint.git"
                 },
-                "version": "2022.4.2"
+                "version": "2023.4.29"
             }, undefined, 4)
         }
     ].map(async function ({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
 - jslint - unify analysis of variable-assignment/function-parameters into one function
 
-# v2022.4.2-beta
+# v2023.4.29
 - vscode - Add manual lint-on-save command to vscode-jslint extension.
 - ci - add custom-shell-ci hooks to script jslint_ci.sh:
     shCiArtifactUploadCustom()

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Status
-| Branch | [master<br>(v2023.1.29)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
+| Branch | [master<br>(v2023.4.29)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
 |--:|:--:|:--:|:--:|
 | CI | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jslint-org/jslint/actions?query=branch%3Amaster) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/jslint-org/jslint/actions?query=branch%3Abeta) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/jslint-org/jslint/actions?query=branch%3Aalpha) |
 | Coverage | [![coverage](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/index.html) |

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -165,7 +165,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2022.4.2-beta";
+let jslint_edition = "v2023.4.29";
 let jslint_export;                      // The jslint object to be exported.
 let jslint_fudge = 1;                   // Fudge starting line and starting
                                         // ... column to 1.

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "shCiArtifactUpload": 1,
     "shCiNpmPublish": 1,
     "type": "module",
-    "version": "2022.4.2-beta"
+    "version": "2023.4.29"
 }


### PR DESCRIPTION
- vscode - Add manual lint-on-save command to vscode-jslint extension.
- ci - add custom-shell-ci hooks to script jslint_ci.sh: shCiArtifactUploadCustom() shCiBaseCustom() shCiBaseCustom2() shCiLintCustom() shCiLintCustom2() shCiNpmPublishCustom() shCiPreCustom() shCiPreCustom2()
- ci - housekeeping of ci-file jslint_ci.sh
- ci - update shell-function shGitCommitPushOrSquash() to be able to save to specified filename
- ci - remove little-used shell-function shCiBranchPromote()