### PR TITLE
- jslint - Add grammar for regexp-named-capture-group and regexp-named-backreference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - jslint - unify analysis of variable-assignment/function-parameters into one function
 
 # v2023.5.1-beta
+- jslint - Add grammar for regexp-named-capture-group and regexp-named-backreference.
 - jslint - Add grammar for side-effect import-statement.
 - ci - Rename shell-function shRawLibFetch() to shRollupFetch().
 - doc - document devop procedures to maintain jslint-repo

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -295,7 +295,6 @@ shCiArtifactUpload() {(set -e
 # # this function will run custom-code to upload build-artifacts
 #     return
 # )}
-    local FILE
     if ! (shCiMatrixIsmainName \
         && [ -f package.json ] \
         && grep -q '^    "shCiArtifactUpload": 1,$' package.json)
@@ -789,7 +788,7 @@ shGitCmdWithGithubToken() {(set -e
         sed -i.bak "s|://.*@|://|g" .git/config
         rm -f .git/config.bak
     fi
-    local CMD="$1"
+    CMD="$1"
     case "$CMD" in
     clone)
         ;;
@@ -877,7 +876,6 @@ shGitGc() {(set -e
 
 shGitInitBase() {(set -e
 # this function will git init && create basic git-template from jslint-org/base
-    local BRANCH
     git init
     git config core.autocrlf input
     git remote remove base 2>/dev/null || true
@@ -1233,7 +1231,6 @@ shHttpFileServer() {(set -e
 # this function will run simple node http-file-server on port $PORT
     if [ ! "$npm_config_mode_auto_restart" ]
     then
-        local EXIT_CODE
         EXIT_CODE=0
         export npm_config_mode_auto_restart=1
         while true
@@ -1520,7 +1517,6 @@ shImageLogoCreate() {(set -e
         --window-size=512x512 \
         -screenshot=.artifact/asset_image_logo_512.png
     # create various smaller thumbnails
-    local SIZE
     for SIZE in 32 64 128 256
     do
         convert -resize "${SIZE}x${SIZE}" .artifact/asset_image_logo_512.png \
@@ -1632,7 +1628,6 @@ function objectDeepCopyWithKeysSorted(obj) {
 
 shNpmPublishV0() {(set -e
 # this function will npm-publish name $1 with bare package.json
-    local DIR
     DIR=/tmp/shNpmPublishV0
     rm -rf "$DIR" && mkdir -p "$DIR" && cd "$DIR"
     printf "{\"name\":\"$1\",\"version\":\"0.0.1\"}\n" > package.json
@@ -1642,9 +1637,9 @@ shNpmPublishV0() {(set -e
 
 shPidListWait() {
 # this will wait for all process-pid in $PID_LIST to exit
-    local EXIT_CODE=0
-    local PID_LIST="$2"
-    local TASK="$1"
+    EXIT_CODE=0
+    PID_LIST="$2"
+    TASK="$1"
     for PID in $PID_LIST
     do
         printf "$TASK - pid=$PID ...\n"
@@ -1658,7 +1653,6 @@ shPidListWait() {
 shRmDsStore() {(set -e
 # this function will recursively rm .DS_Store from current-dir
 # http://stackoverflow.com/questions/2016844/bash-recursively-remove-files
-    local NAME
     for NAME in "._*" ".DS_Store" "desktop.ini" "npm-debug.log" "*~"
     do
         find . -iname "$NAME" -print0 | xargs -0 rm -f || true
@@ -3335,8 +3329,8 @@ v8CoverageReportCreate({
 shRunWithScreenshotTxt() {(set -e
 # this function will run cmd $@ and screenshot text-output
 # https://www.cnx-software.com/2011/09/22/how-to-convert-a-command-line-result-into-an-image-in-linux/
-    local EXIT_CODE=0
-    local SCREENSHOT_SVG="$1"
+    EXIT_CODE=0
+    SCREENSHOT_SVG="$1"
     shift
     printf "0\n" > "$SCREENSHOT_SVG.exit_code"
     printf "shRunWithScreenshotTxt - ($* 2>&1)\n" 1>&2


### PR DESCRIPTION
fixes #417.

![image](https://github.com/jslint-org/jslint/assets/280571/71637ac0-6ff7-4f3b-91fb-d404c835524a)