### PR TITLE
Branch export async function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - jslint - unify analysis of variable-assignment/function-parameters into one function
 
 # v2023.5.1-beta
+- python - Add shell-function shLintPython().
 - jslint - Add grammar for regexp-named-capture-group and regexp-named-backreference.
 - jslint - Add grammar for side-effect import-statement.
 - ci - Rename shell-function shRawLibFetch() to shRollupFetch().

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 - coverage - add macros `/*coverage-disable*/` and `/*coverage-enable*/`.
 - jslint - add html and css linting back into jslint.
 - jslint - add new warning requiring paren around plus-separated concatenations.
-- jslint - require regexp to use open-form.
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
-- jslint - unify analysis of variable-assignment/function-parameters into one function
 
 # v2023.5.1-beta
+- jslint - Check exported properties are ordered.
+- jslint - Add grammar for "export async function ...".
 - python - Add shell-function shLintPython().
 - jslint - Add grammar for regexp-named-capture-group and regexp-named-backreference.
 - jslint - Add grammar for side-effect import-statement.

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -1626,6 +1626,72 @@ function objectDeepCopyWithKeysSorted(obj) {
 ' "$@" # '
 )}
 
+shLintPython() {(set -e
+# this function will lint python file
+    FILE_LIST="$@"
+    (
+    printf "\n\nlint ruff\n"
+    OPTION=""
+    # autofix
+    OPTION="$OPTION --fix"
+    # ANN flake8-annotations
+    OPTION="$OPTION --ignore=ANN"
+    # obsolete - one-blank-line-before-class (D203)
+    # * 1 blank line required before class docstring
+    OPTION="$OPTION --ignore=D203"
+    # multi-line-summary-first-line (D212)
+    # * Multi-line docstring summary should start at the first line
+    OPTION="$OPTION --ignore=D212"
+    # non-imperative-mood (D401)
+    # * First line of docstring should be in imperative mood: "{first_line}"
+    OPTION="$OPTION --ignore=D401"
+    # docstring-starts-with-this (D404)
+    # * First word of the docstring should not be "This"
+    OPTION="$OPTION --ignore=D404"
+    # commented-out-code (ERA001)
+    # Commented-out code is dead code, and is often included inadvertently.
+    OPTION="$OPTION --ignore=ERA001"
+    # too-many-statements (PLR0915)
+    # * Too many statements ({statements} > {max_statements})
+    OPTION="$OPTION --ignore=PLR0915"
+    # subprocess-without-shell-equals-true (S603)
+    # * `subprocess` call: check for execution of untrusted input
+    OPTION="$OPTION --ignore=S603"
+    # start-process-with-partial-path (S607)
+    # * Starting a process with a partial executable path
+    OPTION="$OPTION --ignore=S607"
+    # hardcoded-sql-expression (S608)
+    # SQL injection is a common attack vector for web applications.
+    OPTION="$OPTION --ignore=S608"
+    # print (T201)
+    # * `print` found
+    OPTION="$OPTION --ignore=T201"
+    OPTION="$OPTION --select=ALL"
+    ruff check $OPTION $FILE_LIST
+    ) &
+    PID_LIST="$PID_LIST $!"
+    #
+    (
+    printf "lint pycodestyle\n"
+    OPTION="--ignore="
+    # Unexpected indentation (comment) (E116)
+    # Comments should be indented relative to the code in the block they are in.
+    OPTION="$OPTION,E116"
+    # At least two spaces before inline comment (E261)
+    # Inline comments should have two spaces before them.
+    OPTION="$OPTION,E261"
+    # Line break occurred before a binary operator (W503)
+    # Line breaks should occur after the binary operator to keep all variable
+    # names aligned.
+    OPTION="$OPTION,W503"
+    pycodestyle $OPTION $FILE_LIST
+    ) &
+    PID_LIST="$PID_LIST $!"
+    #
+    shPidListWait shLintPython "$PID_LIST"
+    printf "lint successful\n\n"
+)}
+
 shNpmPublishV0() {(set -e
 # this function will npm-publish name $1 with bare package.json
     DIR=/tmp/shNpmPublishV0

--- a/test.mjs
+++ b/test.mjs
@@ -747,6 +747,14 @@ jstestDescribe((
             ],
             module: [
                 "export default Object.freeze();",
+
+// PR-439 - Add grammar for "export async function ...".
+
+                (
+                    "export default Object.freeze(async function () {\n"
+                    + "    return await 0;\n"
+                    + "});\n"
+                ),
                 "import {aa, bb} from \"aa\";\naa(bb);",
                 "import {} from \"aa\";",
                 "import(\"aa\").then(function () {\n    return;\n});",


### PR DESCRIPTION
- Fixes #438.
  - fatal error due to no grammar for `export async function ...`.
- jslint will still warn about using `Object.freeze(...)` but at least its no longer a fatal error, and can be suppressed with `//jslint-ignore-line`
- This PR additionally adds warning/check that exported properties are sorted in ascii-order

![image](https://github.com/jslint-org/jslint/assets/280571/8318524b-8dcc-4d6d-8af3-51b6db356b49)
