### PR TITLE
# v2023.5.23

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -441,7 +441,7 @@ import moduleFs from "fs";
                     "type": "git",
                     "url": "https://github.com/jslint-org/jslint.git"
                 },
-                "version": "2023.5.1"
+                "version": "2023.5.23"
             }, undefined, 4)
         }
     ].map(async function ({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - jslint - add new warning requiring paren around plus-separated concatenations.
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
 
-# v2023.5.1-beta
+# v2023.5.23
 - jslint - Check exported properties are ordered.
 - jslint - Add grammar for "export async function ...".
 - python - Add shell-function shLintPython().

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Status
-| Branch | [master<br>(v2023.4.29)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
+| Branch | [master<br>(v2023.5.23)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
 |--:|:--:|:--:|:--:|
 | CI | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jslint-org/jslint/actions?query=branch%3Amaster) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/jslint-org/jslint/actions?query=branch%3Abeta) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/jslint-org/jslint/actions?query=branch%3Aalpha) |
 | Coverage | [![coverage](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/index.html) |
@@ -969,6 +969,14 @@ git push origin :branch-v20yy.mm.dd -f
 - click `Rebase and merge`
 - verify ci-success for upstream-branch-beta
     - https://github.com/jslint-org/jslint/actions/workflows/ci.yml
+```shell
+git fetch upstream beta
+git diff upstream/beta
+git reset upstream/beta
+git push -f origin alpha alpha:beta
+shMyciUpdate
+git push -f upstream alpha
+```
 
 
 <br><br>

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -165,7 +165,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2023.5.1-beta";
+let jslint_edition = "v2023.5.23";
 let jslint_export;                      // The jslint object to be exported.
 let jslint_fudge = 1;                   // Fudge starting line and starting
                                         // ... column to 1.

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "shCiArtifactUpload": 1,
     "shCiNpmPublish": 1,
     "type": "module",
-    "version": "2023.5.1-beta"
+    "version": "2023.5.23"
 }


### PR DESCRIPTION
- jslint - Check exported properties are ordered.
- jslint - Add grammar for "export async function ...".
- python - Add shell-function shLintPython().
- jslint - Add grammar for regexp-named-capture-group and regexp-named-backreference.
- jslint - Add grammar for side-effect import-statement.
- ci - Rename shell-function shRawLibFetch() to shRollupFetch().
- doc - document devop procedures to maintain jslint-repo