### PR TITLE
Branch vim windows install

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -441,7 +441,7 @@ import moduleFs from "fs";
                     "type": "git",
                     "url": "https://github.com/jslint-org/jslint.git"
                 },
-                "version": "2023.10.24"
+                "version": "2023.11.1"
             }, undefined, 4)
         }
     ].map(async function ({

--- a/.ci.sh
+++ b/.ci.sh
@@ -441,7 +441,7 @@ import moduleFs from "fs";
                     "type": "git",
                     "url": "https://github.com/jslint-org/jslint.git"
                 },
-                "version": "2023.11.1"
+                "version": "2024.2.1"
             }, undefined, 4)
         }
     ].map(async function ({

--- a/.ci.sh
+++ b/.ci.sh
@@ -441,7 +441,7 @@ import moduleFs from "fs";
                     "type": "git",
                     "url": "https://github.com/jslint-org/jslint.git"
                 },
-                "version": "2024.2.1"
+                "version": "2024.3.1"
             }, undefined, 4)
         }
     ].map(async function ({

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,11 @@ jobs:
           architecture: ${{ matrix.architecture }}
           node-version: ${{ matrix.node_version }}
       # https://github.com/actions/setup-python
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
       # https://github.com/actions/cache
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           key: >
             ${{ hashFiles('./package.json') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - jslint - add new warning requiring paren around plus-separated concatenations.
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
 
+# v2023.11.1-beta
+- ci - bugfix - Fix google-chrome unable to create screenshot because user-data-dir is /dev/null.
+
 # v2023.10.24
 - jslint - bugfix - Update file jslint_wrapper_vim.vim to fix broken vim-link when linting shell-files.
 - ci - add custom-shell-ci hooks to script jslint_ci.sh:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - jslint - add new warning requiring paren around plus-separated concatenations.
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
 
-# v2024.2.1-beta
+# v2024.3.1-beta
+- vim - Allow installing vim-plugin to any directory, instead of hardcoded to ~/.vim/.
 - ci - Update github-ci for actions/cache, actions/setup-python from nodejs v16 to nodejs v20.
 - ci - Update shell-function shRollupFetch() to fix blank date-committed.
 - ci - bugfix - Fix google-chrome unable to create screenshot because user-data-dir is /dev/null.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 - jslint - add new warning requiring paren around plus-separated concatenations.
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
 
-# v2023.11.1-beta
+# v2024.2.1-beta
+- ci - Update github-ci for actions/cache, actions/setup-python from nodejs v16 to nodejs v20.
+- ci - Update shell-function shRollupFetch() to fix blank date-committed.
 - ci - bugfix - Fix google-chrome unable to create screenshot because user-data-dir is /dev/null.
 
 # v2023.10.24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
 
 # v2024.3.1-beta
+- ci - Fix tmpdir in shell-function shBrowserScreenshot().
 - vim - Allow installing vim-plugin to any directory, instead of hardcoded to ~/.vim/.
 - ci - Update github-ci for actions/cache, actions/setup-python from nodejs v16 to nodejs v20.
 - ci - Update shell-function shRollupFetch() to fix blank date-committed.

--- a/README.md
+++ b/README.md
@@ -506,6 +506,9 @@ window.addEventListener("load", function () {
 # Quickstart JSLint in Vim
 1. Download and save [`jslint.mjs`](https://www.jslint.com/jslint.mjs), [`jslint_wrapper_vim.vim`](https://www.jslint.com/jslint_wrapper_vim.vim) to directory `~/.vim/`
 2. Add vim-command `:source ~/.vim/jslint_wrapper_vim.vim` to file `~/.vimrc`
+    - If above files were saved to custom-directory, then use that directory instead, e.g.:
+        - save [`jslint.mjs`](https://www.jslint.com/jslint.mjs), [`jslint_wrapper_vim.vim`](https://www.jslint.com/jslint_wrapper_vim.vim) to directory `~/vimfiles/`
+        - vim-command `:source ~/vimfiles/jslint_wrapper_vim.vim`
 3. Vim can now jslint files (via nodejs):
     - with vim-command `:SaveAndJslint`
     - with vim-key-combo `<Ctrl-S> <Ctrl-J>`
@@ -979,6 +982,26 @@ git push upstream beta:master
 <br><br>
 ### pull-request merge
 - find highest issue-number at https://github.com/jslint-org/jslint/issues/, and add +1 to it for PR-xxx
+```shell
+git push origin alpha:branch_xxx
+git push upstream alpha
+```
+- goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch_xxx
+- select branch to merge
+- click `Create pull request`
+- `Add a description` template:
+```
+Fixes #xxx.
+- <primary-commit-message>
+
+This PR ...
+
+Additionally, this PR will:
+- <secondary-commit-messages>
+...
+
+<screenshot>
+```
 - verify `commit into jslint-org:beta`
 - click `Create pull request`
 - verify ci-success for pull-request

--- a/README.md
+++ b/README.md
@@ -986,7 +986,7 @@ git push upstream beta:master
 git push origin alpha:branch_xxx
 git push upstream alpha
 ```
-- goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch_xxx
+- goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:alpha
 - select branch to merge
 - click `Create pull request`
 - `Add a description` template:
@@ -994,9 +994,9 @@ git push upstream alpha
 Fixes #xxx.
 - <primary-commit-message>
 
-This PR ...
+This PR will ...
 
-Additionally, this PR will:
+this PR will additionally:
 - <secondary-commit-messages>
 ...
 

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -163,7 +163,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2023.11.1-beta";
+let jslint_edition = "v2024.2.1-beta";
 let jslint_export;                      // The jslint object to be exported.
 let jslint_fudge = 1;                   // Fudge starting line and starting
                                         // ... column to 1.

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -163,7 +163,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2024.2.1-beta";
+let jslint_edition = "v2024.3.1-beta";
 let jslint_export;                      // The jslint object to be exported.
 let jslint_fudge = 1;                   // Fudge starting line and starting
                                         // ... column to 1.

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -163,7 +163,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2023.10.24";
+let jslint_edition = "v2023.11.1-beta";
 let jslint_export;                      // The jslint object to be exported.
 let jslint_fudge = 1;                   // Fudge starting line and starting
                                         // ... column to 1.

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -204,6 +204,7 @@ shBrowserScreenshot() {(set -e
 # window-size $2
     node --input-type=module --eval '
 import moduleChildProcess from "child_process";
+import moduleOs from "os";
 import modulePath from "path";
 import moduleUrl from "url";
 // init debugInline
@@ -257,7 +258,7 @@ import moduleUrl from "url";
             "--incognito",
             "--screenshot",
             "--timeout=30000",
-            "--user-data-dir=/dev/null",
+            "--user-data-dir=" + moduleOs.tmpdir(),
             "--window-size=800x600",
             "-screenshot=" + file,
             (

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -188,12 +188,12 @@ shBashrcWindowsInit() {
         ;;
     esac
     # alias curl.exe
-    # if (! alias curl &>/dev/null) && [ -f c:/windows/system32/curl.exe ]
+    # if (! alias curl 2>/dev/null) && [ -f c:/windows/system32/curl.exe ]
     # then
     #     alias curl=c:/windows/system32/curl.exe
     # fi
     # alias node.exe
-    if (! alias node &>/dev/null)
+    if (! alias node 2>/dev/null)
     then
         alias node=node.exe
     fi
@@ -212,7 +212,7 @@ import moduleUrl from "url";
     let consoleError = console.error;
     globalThis.debugInline = globalThis.debugInline || function (...argList) {
 
-// this function will both print <argList> to stderr and return <argList>[0]
+// This function will print <argv> to stderr and then return <argv>[0].
 
         consoleError("\n\ndebugInline");
         consoleError(...argList);
@@ -873,7 +873,7 @@ COMMIT_LIMIT=$COMMIT_LIMIT MODE_SQUASH=$MODE_SQUASH\n"
     fi
     # squash commits
     COMMIT_MESSAGE="[squashed $COMMIT_COUNT commits] $COMMIT_MESSAGE"
-    git branch -D __tmp1 &>/dev/null || true
+    git branch -D __tmp1 2>/dev/null || true
     git checkout --orphan __tmp1
     git commit --quiet -am "$COMMIT_MESSAGE" || true
     # reset branch to squashed-commit
@@ -1013,7 +1013,7 @@ shGithubCheckoutRemote() {(set -e
         # branch - */*/*
         git fetch origin alpha
         # assert latest ci
-        if (git rev-parse "$GITHUB_REF_NAME" &>/dev/null) \
+        if (git rev-parse "$GITHUB_REF_NAME" 2>/dev/null) \
             && [ "$(git rev-parse "$GITHUB_REF_NAME")" \
             != "$(git rev-parse origin/alpha)" ]
         then
@@ -1113,8 +1113,8 @@ import modulePath from "path";
     }
     console.error(
         mode === "download"
-        ? `shGithubFileDownload - ${process.argv[1]}`
-        : `shGithubFileUpload - ${process.argv[1]}`
+        ? `shGithubFileDownload - ${process.argv[2]}`
+        : `shGithubFileUpload - ${process.argv[2]}`
     );
     path = path.split("/");
     repo = path.slice(0, 2).join("/");
@@ -1284,7 +1284,7 @@ import moduleUrl from "url";
     let consoleError = console.error;
     globalThis.debugInline = globalThis.debugInline || function (...argList) {
 
-// this function will both print <argList> to stderr and return <argList>[0]
+// This function will print <argv> to stderr and then return <argv>[0].
 
         consoleError("\n\ndebugInline");
         consoleError(...argList);
@@ -1759,7 +1759,7 @@ import modulePath from "path";
     let consoleError = console.error;
     globalThis.debugInline = globalThis.debugInline || function (...argList) {
 
-// this function will both print <argList> to stderr and return <argList>[0]
+// This function will print <argv> to stderr and then return <argv>[0].
 
         consoleError("\n\ndebugInline");
         consoleError(...argList);
@@ -1844,6 +1844,7 @@ function replaceListReplace(replaceList, data) {
     let fetchCount = 0;
     let fetchList;
     let matchObj;
+    let promiseList = [];
     let repoDict;
     function pipeToBuffer(res, dict, key) {
 
@@ -1876,13 +1877,16 @@ function replaceListReplace(replaceList, data) {
         elem.prefix = elem.url.split("/").slice(0, 7).join("/");
         // fetch dateCommitted
         if (!repoDict.hasOwnProperty(elem.prefix)) {
-            repoDict[elem.prefix] = true;
-            moduleHttps.request(elem.prefix.replace(
-                "/blob/",
-                "/commits/"
-            ), function (res) {
-                pipeToBuffer(res, elem, "dateCommitted");
-            }).end();
+            promiseList.push(new Promise(function (resolve) {
+                repoDict[elem.prefix] = true;
+                moduleHttps.request(elem.prefix.replace(
+                    "/blob/",
+                    "/commits/"
+                ), function (res) {
+                    pipeToBuffer(res, elem, "dateCommitted");
+                    res.on("end", resolve);
+                }).end();
+            }));
         }
         // fetch file
         if (elem.node) {
@@ -1921,6 +1925,7 @@ function replaceListReplace(replaceList, data) {
             pipeToBuffer(res, elem, "data");
         });
     });
+    await Promise.all(promiseList);
     // parse fetched data
     process.on("exit", function () {
         let header;
@@ -1972,9 +1977,11 @@ function replaceListReplace(replaceList, data) {
                 result += (
                     "\n\n\n/*\n"
                     + "repo " + prefix.replace("/blob/", "/tree/") + "\n"
-                    + "committed " + (
-                        /\b\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ\b|$/
-                    ).exec(dateCommitted.toString())[0] + "\n"
+                    + "committed " + new Date(
+                        (
+                            /"(\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d[^"]*?)"/
+                        ).exec(dateCommitted.toString())[1]
+                    ).toISOString().replace((/\.\d*?Z/), "Z") + "\n"
                     + "*/"
                 );
             }

--- a/jslint_wrapper_vim.vim
+++ b/jslint_wrapper_vim.vim
@@ -42,7 +42,8 @@ function! SaveAndJslint(bang)
     let &l:errorformat =
         \ "%f.<node -e>.js:%n:%l:%c:%m," .
         \ "%f:%n:%l:%c:%m"
-    let &l:makeprg = "node \"" . $HOME . "/.vim/jslint.mjs\" jslint_wrapper_vim"
+    let &l:makeprg = "node \"" . expand("<sfile>:p:h") . "/jslint.mjs\""
+        \ . " jslint_wrapper_vim"
         \ . " \"" . fnamemodify(bufname("%"), ":p") . "\""
     silent make! | cwindow | redraw!
 endfunction

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "shCiArtifactUpload": 1,
     "shCiPublishNpm": 1,
     "type": "module",
-    "version": "2023.10.24"
+    "version": "2023.11.1-beta"
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "shCiArtifactUpload": 1,
     "shCiPublishNpm": 1,
     "type": "module",
-    "version": "2023.11.1-beta"
+    "version": "2024.2.1-beta"
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "shCiArtifactUpload": 1,
     "shCiPublishNpm": 1,
     "type": "module",
-    "version": "2024.2.1-beta"
+    "version": "2024.3.1-beta"
 }


### PR DESCRIPTION
Fixes #455 .
- vim - Allow installing vim-plugin to any directory, instead of hardcoded to ~/.vim/.

This PR will allow you to install vim-plugin to custom-directory, e.g:
        - save [`jslint.mjs`](https://www.jslint.com/jslint.mjs), [`jslint_wrapper_vim.vim`](https://www.jslint.com/jslint_wrapper_vim.vim) to directory `~/vimfiles/`
        - vim-command `:source ~/vimfiles/jslint_wrapper_vim.vim`

Additionally, this PR will:
- ci - Update github-ci for actions/cache, actions/setup-python from nodejs v16 to nodejs v20.
- ci - Update shell-function shRollupFetch() to fix blank date-committed.
- ci - bugfix - Fix google-chrome unable to create screenshot because user-data-dir is /dev/null.
