### PR TITLE
- test - Update test-function jstestDescribe() to wait awhile for imports to initialize before running tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
 
 # v2024.3.1-beta
+- test - Update test-function jstestDescribe() to wait awhile for imports to initialize before running tests.
 - ci - Fix tmpdir in shell-function shBrowserScreenshot().
 - vim - Allow installing vim-plugin to any directory, instead of hardcoded to ~/.vim/.
 - ci - Update github-ci for actions/cache, actions/setup-python from nodejs v16 to nodejs v20.

--- a/README.md
+++ b/README.md
@@ -981,7 +981,7 @@ git push upstream beta:master
 
 <br><br>
 ### pull-request merge
-- find highest issue-number at https://github.com/jslint-org/jslint/issues/, and add +1 to it for PR-xxx
+- find highest issue-number at https://github.com/jslint-org/jslint/issues/, https://github.com/jslint-org/jslint/pulls/, and add +1 to it for PR-xxx
 ```shell
 git push origin alpha:branch_xxx
 git push upstream alpha

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -9952,6 +9952,12 @@ async function jstestDescribe(description, testFunction) {
         process.on("exit", jstestOnExit);
     }
 
+// PR-457 - Wait awhile for imports to initialize.
+
+    await new Promise(function (resolve) {
+        setTimeout(resolve);
+    });
+
 // Init jstestItList.
 
     jstestItList = [];
@@ -10005,9 +10011,7 @@ function jstestIt(description, testFunction, mode) {
         } catch (errCaught) {
             err = errCaught;
         }
-        resolve([
-            err, description, mode
-        ]);
+        resolve([err, description, mode]);
     }));
 }
 

--- a/jslint_wrapper_vim.vim
+++ b/jslint_wrapper_vim.vim
@@ -34,6 +34,8 @@
 ""    - with vim-command ":SaveAndJslint"
 ""    - with vim-key-combo "<Ctrl-S> <Ctrl-J>"
 
+let s:dir = expand("<sfile>:p:h")
+
 "" this function will save current file and jslint it (via nodejs)
 function! SaveAndJslint(bang)
     "" save file
@@ -42,7 +44,8 @@ function! SaveAndJslint(bang)
     let &l:errorformat =
         \ "%f.<node -e>.js:%n:%l:%c:%m," .
         \ "%f:%n:%l:%c:%m"
-    let &l:makeprg = "node \"" . expand("<sfile>:p:h") . "/jslint.mjs\""
+    let &l:makeprg = "node"
+        \ . " \"" . s:dir . "/jslint.mjs\""
         \ . " jslint_wrapper_vim"
         \ . " \"" . fnamemodify(bufname("%"), ":p") . "\""
     silent make! | cwindow | redraw!


### PR DESCRIPTION
this PR will additionally fix #455 (2nd attempt):
- vim - Allow installing vim-plugin to any directory, instead of hardcoded to ~/.vim/. - part2