### PR TITLE
Branch destructure after function

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -452,7 +452,7 @@ import moduleFs from "fs";
     }));
 }());
 ' "$@" # '
-    npx vsce package
+    npx @vscode/vsce package
     rm -rf node_modules
     )
 )}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
 
 # v2024.3.1-beta
+- jslint - Allow destructuring-assignment after function-definition.
 - ci - Replace npm-package used to auto-build vscode-plugin, vsce to @vscode/vsce.
 - test - Update test-function jstestDescribe() to wait awhile for imports to initialize before running tests.
 - ci - Fix tmpdir in shell-function shBrowserScreenshot().

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
 
 # v2024.3.1-beta
+- ci - Replace npm-package used to auto-build vscode-plugin, vsce to @vscode/vsce.
 - test - Update test-function jstestDescribe() to wait awhile for imports to initialize before running tests.
 - ci - Fix tmpdir in shell-function shBrowserScreenshot().
 - vim - Allow installing vim-plugin to any directory, instead of hardcoded to ~/.vim/.

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -5487,13 +5487,15 @@ function jslint_phase3_parse(state) {
         if (
             token_nxt.id === "."
             || token_nxt.id === "?."
-            || token_nxt.id === "["
+
+// PR-459 - Allow destructuring-assignment after function-definition.
+
+            // || token_nxt.id === "["
         ) {
 
 // test_cause:
 // ["function aa(){}\n.aa", "prefix_function", "unexpected_a", ".", 1]
 // ["function aa(){}\n?.aa", "prefix_function", "unexpected_a", "?.", 1]
-// ["function aa(){}\n[]", "prefix_function", "unexpected_a", "[", 1]
 
             warn("unexpected_a");
         }

--- a/test.mjs
+++ b/test.mjs
@@ -879,7 +879,18 @@ jstestDescribe((
             ].map(function (directive) {
                 return [
                     "let [\n    aa, bb = 0\n] = 0;\naa();\nbb();",
-                    "let [...aa] = [...aa];\naa();",
+                    "let aa = 0;\nlet [...bb] = [...aa];\nbb();",
+
+// PR-459 - Allow destructuring-assignment after function-definition.
+
+                    (
+                        "let aa;\n"
+                        + "let bb;\n"
+                        + "function cc() {\n"
+                        + "    return;\n"
+                        + "}\n"
+                        + "[aa, bb] = cc();\n"
+                    ),
                     "let constructor = 0;\nconstructor();",
                     "let {\n    aa: bb\n} = 0;\nbb();",
                     "let {\n    aa: bb,\n    bb: cc\n} = 0;\nbb();\ncc();",


### PR DESCRIPTION
- jslint - Allow destructuring-assignment after function-definition.

This PR relaxes warning about `[]` operator appearing after a function definition, due to it now being legal-syntax for destructuring-assignment, e.g.

```
let aa;
let bb;
function foo() {
    return [1, 2];
}
[aa, bb] = foo();  // jslint previously would warn here
```

this PR will additionally:
- ci - Replace npm-package used to auto-build vscode-plugin, vsce to @vscode/vsce.
