### PR TITLE
# v2024.3.26

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -441,7 +441,7 @@ import moduleFs from "fs";
                     "type": "git",
                     "url": "https://github.com/jslint-org/jslint.git"
                 },
-                "version": "2024.3.1"
+                "version": "2024.3.26"
             }, undefined, 4)
         }
     ].map(async function ({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - jslint - add new warning requiring paren around plus-separated concatenations.
 - jslint - try to improve parser to be able to parse jquery.js without stopping.
 
-# v2024.3.1-beta
+# v2024.3.26
 - ci - Add shell-functions shGitPullrequestCleanup(), shGitPullrequest() to automatically cleanup or create-and-push github-pull-commit to origin/alpha.
 - jslint - Allow destructuring-assignment after function-definition.
 - ci - Replace npm-package used to auto-build vscode-plugin, vsce to @vscode/vsce.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Douglas Crockford <douglas@crockford.com>
 
 
 # Status
-| Branch | [master<br>(v2023.10.24)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
+| Branch | [master<br>(v2024.3.26)](https://github.com/jslint-org/jslint/tree/master) | [beta<br>(Web Demo)](https://github.com/jslint-org/jslint/tree/beta) | [alpha<br>(Development)](https://github.com/jslint-org/jslint/tree/alpha) |
 |--:|:--:|:--:|:--:|
 | CI | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jslint-org/jslint/actions?query=branch%3Amaster) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=beta)](https://github.com/jslint-org/jslint/actions?query=branch%3Abeta) | [![ci](https://github.com/jslint-org/jslint/actions/workflows/ci.yml/badge.svg?branch=alpha)](https://github.com/jslint-org/jslint/actions?query=branch%3Aalpha) |
 | Coverage | [![coverage](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-master/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-beta/.artifact/coverage/index.html) | [![coverage](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/coverage_badge.svg)](https://jslint-org.github.io/jslint/branch-alpha/.artifact/coverage/index.html) |
@@ -963,7 +963,7 @@ this PR will additionally:
 - $ `git push upstream alpha -f`
     - verify ci-success for upstream-branch-alpha
     - https://github.com/jslint-org/jslint/actions/workflows/ci.yml
-- goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-v2023.10.24
+- goto https://github.com/jslint-org/jslint/compare/beta...kaizhu256:jslint:branch-v2024.3.26
 - click `Create pull request`
 - input `Add a title` with: `# v20yy.mm.dd`
 - input `Add a description` with:

--- a/jslint.mjs
+++ b/jslint.mjs
@@ -163,7 +163,7 @@ let jslint_charset_ascii = (
     + "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_"
     + "`abcdefghijklmnopqrstuvwxyz{|}~\u007f"
 );
-let jslint_edition = "v2024.3.1-beta";
+let jslint_edition = "v2024.3.26";
 let jslint_export;                      // The jslint object to be exported.
 let jslint_fudge = 1;                   // Fudge starting line and starting
                                         // ... column to 1.

--- a/jslint_ci.sh
+++ b/jslint_ci.sh
@@ -421,6 +421,8 @@ shCiBase() {(set -e
 # # this function will run custom-code to lint files
 # )}
     export GITHUB_BRANCH0="$(git rev-parse --abbrev-ref HEAD)"
+    # Auto-correct common errors in package.json.
+    npm pkg fix
     # validate package.json.fileCount
     node --input-type=module --eval '
 import moduleFs from "fs";

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "shCiArtifactUpload": 1,
     "shCiPublishNpm": 1,
     "type": "module",
-    "version": "2024.3.1-beta"
+    "version": "2024.3.26"
 }


### PR DESCRIPTION
- ci - Add shell-functions shGitPullrequestCleanup(), shGitPullrequest() to automatically cleanup or create-and-push github-pull-commit to origin/alpha.
- jslint - Allow destructuring-assignment after function-definition.
- ci - Replace npm-package used to auto-build vscode-plugin, vsce to @vscode/vsce.
- test - Update test-function jstestDescribe() to wait awhile for imports to initialize before running tests.
- ci - Fix tmpdir in shell-function shBrowserScreenshot().
- vim - Allow installing vim-plugin to any directory, instead of hardcoded to ~/.vim/.
- ci - Update github-ci for actions/cache, actions/setup-python from nodejs v16 to nodejs v20.
- ci - Update shell-function shRollupFetch() to fix blank date-committed.
- ci - bugfix - Fix google-chrome unable to create screenshot because user-data-dir is /dev/null.